### PR TITLE
Asking for information to ease moderation, easy link to learn about licenses

### DIFF
--- a/sounds/forms.py
+++ b/sounds/forms.py
@@ -54,7 +54,8 @@ class SoundDescriptionForm(forms.Form):
                            widget=forms.TextInput(attrs={'size': 65, 'class':'inputText'}))
     tags = TagField(widget=forms.Textarea(attrs={'cols': 80, 'rows': 2, 'style':'resize: none;'}),
                     help_text="<br>Separate tags with spaces. Join multi-word tags with dashes. For example: field-recording is a popular tag.")
-    description = HtmlCleaningCharField(widget=forms.Textarea(attrs={'cols': 80, 'rows': 10, 'style':'resize: none;'}))
+    description = HtmlCleaningCharField(widget=forms.Textarea(attrs={'cols': 80, 'rows': 10, 'style':'resize: none;'}),
+                    help_text="<br />Describe what hardware/software was used and credit sounds by other people with links.")
 
 
 class RemixForm(forms.Form):
@@ -170,7 +171,8 @@ class LicenseForm(forms.Form):
 
 class NewLicenseForm(forms.Form):
     license = forms.ModelChoiceField(queryset=License.objects.filter(Q(name__startswith='Attribution') | Q(name__startswith='Creative')),
-                                     required=True)
+                                     required=True,
+                                     help_text="<br />Not sure what this means? Learn about the available licenses in our <a target=\"_blank\" href=\"/help/faq/#licenses-0\">FAQ</a>.")
 
 class FlagForm(RecaptchaForm):
     email = forms.EmailField(label="Your email", required=True, 


### PR DESCRIPTION
One of the major problems with moderating sounds is that users easily can add information about what device/software they used to create the sound - an information that also rather clearly confirms that they are the creators and copyright authors - but it doesn't come to their attention that such information might be useful or required.

Not knowing the effects of the licenses used (especially since their full names are not being used consistently in the description form and faq) is another issue, plus not being sure where to find information.

Simply adding a request text and a link can help battle both issues.

Description form now asks about software/hardware and credits and license form gives a helping links, useful for people not knowing the licenses.

Note: this is my first pull request ever. Please triple-check and inform me whether there are any mistakes and sorry for any possible mess.
