### PR TITLE
Geotags speedups

### DIFF
--- a/geotags/views.py
+++ b/geotags/views.py
@@ -52,7 +52,7 @@ def generate_json(sound_queryset):
 
     sounds_data = [[s.id, s.lat, s.lon] for s in sound_queryset]
 
-    return HttpResponse(json.dumps(sounds_data))
+    return HttpResponse(json.dumps(sounds_data), mimetype="application/json")
 
 @cache_page(60 * 15)
 def geotags_json(request, tag=None):


### PR DESCRIPTION
Fixes #584. Because Django insisted on using an OUTER JOIN, we now
do the queries manually. Only one fast query is needed for geo
queries. Some additional changes to make sure every query only looks
at sounds with processing and moderation states are OK

Also a quick fix to serve json as json, not text
