### PR TITLE
Make user admin not search first/last name. Fixes #656

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -29,21 +29,20 @@ from sounds.models import Sound,DeletedSound
 from accounts.models import User
 from django.conf import settings
 
-
 from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin
 
 def delete_active_user(modeladmin, request, queryset):
-    deleted_user = User.objects.get(id=settings.DELETED_USER_ID)     
+    deleted_user = User.objects.get(id=settings.DELETED_USER_ID)
     for user in queryset:
         for post in Post.objects.filter(author=user):
             post.author = deleted_user
             post.save()
-                
+
         for thread in Thread.objects.filter(author=user):
             thread.author = deleted_user
             thread.save()
-                    
+
         for comment in Comment.objects.filter(user=user):
             comment.user = deleted_user
             comment.save()
@@ -52,15 +51,11 @@ def delete_active_user(modeladmin, request, queryset):
             sound.user = deleted_user
             sound.save()
         user.delete()
-        
-delete_active_user.description="Delete user(s), not posts etc"  
 
-UserAdmin.actions.append(delete_active_user)
-admin.site.unregister(User)
-admin.site.register(User, UserAdmin)
+delete_active_user.description="Delete user(s), not posts etc"
 
 class ProfileAdmin(admin.ModelAdmin):
-    raw_id_fields = ('user', 'geotag') 
+    raw_id_fields = ('user', 'geotag')
     list_display = ('user', 'home_page', 'signature', 'is_whitelisted')
     ordering = ('id', )
     list_filter = ('is_whitelisted', 'wants_newsletter', )
@@ -73,3 +68,12 @@ class UserFlagAdmin(admin.ModelAdmin):
     raw_id_fields = ('user', 'reporting_user', 'content_type')
     list_display = ('user', 'reporting_user', 'content_type')
 admin.site.register(UserFlag, UserFlagAdmin)
+
+
+class FreesoundUserAdmin(UserAdmin):
+    search_fields = ('username', 'email')
+    actions = (delete_active_user, )
+
+admin.site.unregister(User)
+admin.site.register(User, FreesoundUserAdmin)
+


### PR DESCRIPTION
By default the `User` section of the django admin page does wildcard searching of username, email, first name, last name. Since we rarely use first/last names, disable them so that we only search usernames and email addresses.

In addition, by adding some new indexes to the table we can make search much faster:

```
create extension pg_trgm;
CREATE INDEX auth_user_email_gist_trgm_idx ON auth_user USING gist (upper(email) gist_trgm_ops);
CREATE INDEX auth_user_username_gist_trgm_idx ON auth_user USING gist (upper(username) gist_trgm_ops);
```
(I've created them already)