### PR TITLE
privacy setting for sound/pack downloads

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -245,7 +245,12 @@ class ProfileForm(forms.ModelForm):
         label = "",
         required=False
     )
-    
+    hide_downloads = forms.BooleanField(
+        help_text="Hide sounds/packs downloaded on your Profile page",
+        label = "",
+        required=False
+    )
+
     def __init__(self, request, *args, **kwargs):
         self.request = request
         super(ProfileForm, self).__init__(*args, **kwargs)

--- a/templates/accounts/account.html
+++ b/templates/accounts/account.html
@@ -127,8 +127,10 @@
                 {% if user.profile.num_posts %}
                 <li>Number of forum posts: {{user.profile.num_posts}}</li>
                 {% endif %}
+                {% if not user.profile.hide_downloads %}
                 <li><a href="{% url user-downloaded-sounds user.username %}">Sounds downloaded</a> by {{user.username}}</li>
                 <li><a href="{% url user-downloaded-packs user.username %}">Packs downloaded</a> by {{user.username}}</li>
+                {% endif %}
                 {% if user.profile.num_sounds %}
                 <li><a href="{% url comments-for-user user.username %}">All comments</a> on {{user.username}}'s sounds</li>
                 {% endif %}

--- a/templates/accounts/downloaded_packs.html
+++ b/templates/accounts/downloaded_packs.html
@@ -9,7 +9,7 @@
 
 <h1>Packs downloaded by <a href="{% url account username %}">{{ username }}</a></h1>
 
-{% if paginator.count > 0 %}
+{% if paginator.count > 0 and not user.profile.hide_downloads %}
     <div class="search_paginator">
         {% show_paginator paginator page current_page request "pack" %}
     </div>
@@ -22,7 +22,7 @@
         {% show_paginator paginator page current_page request "pack" %}
     </div>
 {% else %}
-    <p>{{ username }} hasn't downloaded any packs yet...</p>
+    <p>{{ username }} has hidden their downloads or hasn't downloaded any packs yet...</p>
 {% endif %}
 
 {% endblock %}

--- a/templates/accounts/downloaded_sounds.html
+++ b/templates/accounts/downloaded_sounds.html
@@ -9,8 +9,7 @@
 
 <h1>Sounds downloaded by <a href="{% url account username %}">{{ username }}</a></h1>
 
-{% if paginator.count > 0 %}
-
+{% if paginator.count > 0 and not user.profile.hide_downloads %}
     <div class="search_paginator">
         {% show_paginator paginator page current_page request "sound" %}
     </div>
@@ -24,7 +23,7 @@
     </div>
 
 {% else %}
-    <p>{{ username }} hasn't downloaded any sounds yet...</p>
+    <p>{{ username }} has hidden their downloads or hasn't downloaded any sounds yet...</p>
 {% endif %}
 
 {% endblock %}

--- a/templates/accounts/edit.html
+++ b/templates/accounts/edit.html
@@ -39,7 +39,7 @@
     {% endif %}
 
     <div id="reset_password_and_email" class="content_box">
-        <h3>Password and email addres</h3>
+        <h3>Password and email address</h3>
         <ul>
             <li><a href="{% url accounts-email-reset %}">Change your email address</a></li>
             <li><a href="{% url accounts-password-reset %}">Reset your password</a></li>


### PR DESCRIPTION
Not tested as I don't see an obvious script to run a dev environment and don't have the time at the moment to figure it out. Should be a fairly simple change, though - the one thing I'm uncertain of is if the `hide_downloads` field needs to be populated elsewhere (e.g. some user data structure), and perhaps given a default ("false" is fine by me, but I just figure it's nice to give users the option).

Let me know your thoughts, thanks!