### PR TITLE
{% url %} templatetag quoting from future, accounts edition

### DIFF
--- a/templates/accounts/account.html
+++ b/templates/accounts/account.html
@@ -2,6 +2,7 @@
 
 {% load display_sound %}
 {% load tags %}
+{% load url from future %}
 
 {% block title %}{% if home %}home{% else %}{{user.username}}{% endif %}{% endblock %}
 

--- a/templates/accounts/account.html
+++ b/templates/accounts/account.html
@@ -69,22 +69,22 @@
 
         <div class="account_information_and_home_options">
         <ul>
-            <li><a href="{% url account user.username %}">View</a> your public profile</li>
-            <li><a href="{% url accounts-edit %}">Edit</a> your public profile</li>
-            <li><a href="{% url accounts-describe %}">Describe</a> your sounds</li>
-            <li><a href="{% url accounts-attribution %}">Attribution</a> - the sounds you downloaded</li>
+            <li><a href="{% url "account" user.username %}">View</a> your public profile</li>
+            <li><a href="{% url "accounts-edit" %}">Edit</a> your public profile</li>
+            <li><a href="{% url "accounts-describe" %}">Describe</a> your sounds</li>
+            <li><a href="{% url "accounts-attribution" %}">Attribution</a> - the sounds you downloaded</li>
             {% if perms.tickets.can_moderate %}
-                <li><a href="{% url tickets-home %}">Moderate sounds</a> - {{ new_tickets_count }} new sound{{ new_tickets_count|pluralize}} {% comment %}, {{ new_support }} support requests{% endcomment %}</li>
+                <li><a href="{% url "tickets-home" %}">Moderate sounds</a> - {{ new_tickets_count }} new sound{{ new_tickets_count|pluralize}} {% comment %}, {{ new_support }} support requests{% endcomment %}</li>
             {% endif %}
             {% if perms.forum.can_moderate_forum %}
-                <li><a href="{% url forums-moderate %}">Moderate posts</a> - {{ new_posts }} new post{{ new_posts|pluralize}} </li>
+                <li><a href="{% url "forums-moderate" %}">Moderate posts</a> - {{ new_posts }} new post{{ new_posts|pluralize}} </li>
             {% endif %}
             {% if user.profile.num_sounds %}
-                <li><a href="{% url comments-for-user user.username %}">All comments</a> on your sounds</li>
+                <li><a href="{% url "comments-for-user" user.username %}">All comments</a> on your sounds</li>
             {% endif %}
-            <li>Your <a href="{% url bookmarks-for-user user.username %}">bookmarks</a></li>
-            <li>Activity <a href="{% url stream %}">stream</a></li>
-            {% comment %}<li>Your sound uploads <a href="{% url accounts-pending %}">pending moderation</a></li>{% endcomment %}
+            <li>Your <a href="{% url "bookmarks-for-user" user.username %}">bookmarks</a></li>
+            <li>Activity <a href="{% url "stream" %}">stream</a></li>
+            {% comment %}<li>Your sound uploads <a href="{% url "accounts-pending" %}">pending moderation</a></li>{% endcomment %}
         </ul>
         </div>
         <br style="clear: both;" />
@@ -116,7 +116,7 @@
             </div>
             <div class="account_information_and_home_options">
             <ul>
-                <li><a href="{% url messages-new user.username %}">Send a private message to this user</a></li>
+                <li><a href="{% url "messages-new" user.username %}">Send a private message to this user</a></li>
                 {% if user.profile.home_page %}
                 <li>Home page: <a href="{{user.profile.home_page}}" rel="nofollow">{{user.profile.home_page}}</a></li>
                 {% endif %}
@@ -127,23 +127,23 @@
                 {% if user.profile.num_posts %}
                 <li>Number of forum posts: {{user.profile.num_posts}}</li>
                 {% endif %}
-                <li><a href="{% url user-downloaded-sounds user.username %}">Sounds downloaded</a> by {{user.username}}</li>
-                <li><a href="{% url user-downloaded-packs user.username %}">Packs downloaded</a> by {{user.username}}</li>
+                <li><a href="{% url "user-downloaded-sounds" user.username %}">Sounds downloaded</a> by {{user.username}}</li>
+                <li><a href="{% url "user-downloaded-packs" user.username %}">Packs downloaded</a> by {{user.username}}</li>
                 {% if user.profile.num_sounds %}
-                <li><a href="{% url comments-for-user user.username %}">All comments</a> on {{user.username}}'s sounds</li>
+                <li><a href="{% url "comments-for-user" user.username %}">All comments</a> on {{user.username}}'s sounds</li>
                 {% endif %}
                 {% if has_bookmarks %}
-                <li><a href="{% url bookmarks-for-user user.username %}">Bookmarks</a> by {{user.username}}</li>
+                <li><a href="{% url "bookmarks-for-user" user.username %}">Bookmarks</a> by {{user.username}}</li>
                 {% endif %}
                 {% if perms.can_moderate %}
                     <li class="separator">Moderators only links</li>
-                    <li>Uploaded sounds <a href="{% url tickets-user-pending_sounds user.username %}">pending moderation ({{ num_sounds_pending_count }})</a></li>
-                    <li><a href="{% url forums-search %}?f=post_author:%22{{ user.username }}%22">All forum posts</a> by {{ user.username }}</li>
-                    <li><a href="{% url comments-by-user user.username %}">All comments</a> by {{ user.username }}</li>
+                    <li>Uploaded sounds <a href="{% url "tickets-user-pending_sounds" user.username %}">pending moderation ({{ num_sounds_pending_count }})</a></li>
+                    <li><a href="{% url "forums-search" %}?f=post_author:%22{{ user.username }}%22">All forum posts</a> by {{ user.username }}</li>
+                    <li><a href="{% url "comments-by-user" user.username %}">All comments</a> by {{ user.username }}</li>
                 {% endif %}
                 {% if request.user.is_staff %}
                     <li class="separator">Admin only links</li>
-                    <li><a id="admin_link" class="icon" href="{% url admin:auth_user_change user.id %}">Edit user in the admin</a></li>
+                    <li><a id="admin_link" class="icon" href="{% url "admin:auth_user_change" user.id %}">Edit user in the admin</a></li>
                 {% endif %}
 
             </ul>
@@ -168,7 +168,7 @@
             {% for sound in latest_sounds %}
                     {% display_raw_sound sound %}
             {% endfor %}
-            <p><a href="{% url sounds-for-user user.username %}?page={% if home %}1{% else %}2{% endif %}">more...</a></p>
+            <p><a href="{% url "sounds-for-user" user.username %}?page={% if home %}1{% else %}2{% endif %}">more...</a></p>
         </div>
     {% else %}
         <div id="latest_sounds" class="content_box">
@@ -185,14 +185,14 @@
             <div id="unmoderated_sounds" class="content_box">
                 <h3>Uploaded sounds awaiting moderation ({{ unmoderated_sounds_count }})</h3>
                 {% for ticket, sound in unmoderated_sounds %}
-                    <li><span class="filename">{{sound.original_filename}}</span>, uploaded on <span class="date">{{sound.created}}</span> <span class="ticket_link"><a href="{% url tickets-ticket ticket.key %}">Go to ticket</a></span></li>
+                    <li><span class="filename">{{sound.original_filename}}</span>, uploaded on <span class="date">{{sound.created}}</span> <span class="ticket_link"><a href="{% url "tickets-ticket" ticket.key %}">Go to ticket</a></span></li>
                 {% endfor %}
                 {% if num_more_unmoderated_sounds > 0 %}
                     <li> And {{ num_more_unmoderated_sounds }} other uploaded sound{{ num_more_unmoderated_sounds|pluralize}}
                 {% endif %}
 
             </div><!-- #unmoderated_sounds -->
-            <p style='margin-left:20px'><a href="{% url accounts-pending %}">more...</a></p>
+            <p style='margin-left:20px'><a href="{% url "accounts-pending" %}">more...</a></p>
 
         {% endif %}
 
@@ -225,7 +225,7 @@
                         {% endif %}
                     {% endif %}
                 {% endif %}
-                <a href="{% url sound-delete sound.user.username sound.id %}" >x</a>
+                <a href="{% url "sound-delete" sound.user.username sound.id %}" >x</a>
                 </li>
             {% endfor %}
 
@@ -241,7 +241,7 @@
         <div id="user_most_used_tags" class="content_box">
             <h3>{% if home %}Your{% else %}{{ user.username }}'s{% endif %} most used tags</h3>
             <p class="user_tagcloud">
-            {% for tag in tags|add_sizes:"True:0.5:2.5" %}<span style="font-size:{{tag.size}}em"><a href="{% url tags tag.name %}">{{tag.name}}</a></span> {% endfor %}
+            {% for tag in tags|add_sizes:"True:0.5:2.5" %}<span style="font-size:{{tag.size}}em"><a href="{% url "tags" tag.name %}">{{tag.name}}</a></span> {% endfor %}
             </p>
         </div><!-- #user_most_used_tags -->
     {% endif %}
@@ -261,10 +261,10 @@
 
                 <ul>
                     {% for suser in following %}
-                        <a href="{% url account suser %}" title="{{suser}}"><img src="{{suser.profile.locations.avatar.M.url}}" alt="avatar" /></a>
+                        <a href="{% url "account" suser %}" title="{{suser}}"><img src="{{suser.profile.locations.avatar.M.url}}" alt="avatar" /></a>
                     {% endfor %}
                 </ul>
-                <p><a href="{% url user-following-users user %}">more...</a></p>
+                <p><a href="{% url "user-following-users" user %}">more...</a></p>
             {% endif %}
 
             {% if followers %}
@@ -276,10 +276,10 @@
 
                 <ul>
                     {% for suser in followers %}
-                        <a href="{% url account suser %}" title="{{suser}}"><img src="{{suser.profile.locations.avatar.M.url}}" alt="avatar" /></a>
+                        <a href="{% url "account" suser %}" title="{{suser}}"><img src="{{suser.profile.locations.avatar.M.url}}" alt="avatar" /></a>
                     {% endfor %}
                 </ul>
-                <p><a href="{% url user-followers user %}">more...</a></p>
+                <p><a href="{% url "user-followers" user %}">more...</a></p>
             {% endif %}
 
             {% if following_tags %}
@@ -291,17 +291,17 @@
                     {% endif %}
                     <ul>
                         {% for space_tags, slash_tags, split_tags in following_tags %}
-                            <span class="tag_group" onclick="location.href='{% url tags slash_tags %}'">
+                            <span class="tag_group" onclick="location.href='{% url "tags" slash_tags %}'">
                             <ul class="tags" id="following_tags">
                             {% for tag in split_tags %}
-                                {% comment %}<li><a href="{% url tags tag %}">{{ tag }}</a></li>{% endcomment %}
+                                {% comment %}<li><a href="{% url "tags"tag %}">{{ tag }}</a></li>{% endcomment %}
                                 <li><a>{{ tag }}</a></li>
                                 {% comment %}<li>{{ tag }}</li>{% endcomment %}
                             {% endfor %}
                             </ul></span>
                         {% endfor %}
                     </ul>
-                    <p><a href="{% url user-following-tags user %}">more...</a></p>
+                    <p><a href="{% url "user-following-tags" user %}">more...</a></p>
                 </div>
             {% endif %}
 
@@ -326,7 +326,7 @@
                 stopAll();
             });
 
-            ajaxLoad('{% url geotags-for-user-latest-json user.username %}', function(data, responseCode)
+            ajaxLoad('{% url "geotags-for-user-latest-json" user.username %}', function(data, responseCode)
             {
                 var bounds = new google.maps.LatLngBounds();
                 var nSounds = 0;
@@ -371,7 +371,7 @@
                 }
             });
         </script>
-        <p><a href="{% url geotags-for-user user.username %}">more...</a></p>
+        <p><a href="{% url "geotags-for-user" user.username %}">more...</a></p>
     </div><!-- #latest_geotags -->
 
 
@@ -380,10 +380,10 @@
         <h3>{% if home %}Your{% else %}{{ user.username }}'s{% endif %} latest packs</h3>
         <ul>
         {% for pack in latest_packs %}
-            <li><a href="{% url pack user.username pack.id %}">{{pack.name}}</a> (<span class="pack_count">{{pack.num_sounds}}</span>)</li>
+            <li><a href="{% url "pack" user.username pack.id %}">{{pack.name}}</a> (<span class="pack_count">{{pack.num_sounds}}</span>)</li>
         {% endfor %}
         </ul>
-        <p><a href="{% url packs-for-user user.username %}">more...</a></p>
+        <p><a href="{% url "packs-for-user" user.username %}">more...</a></p>
     </div><!-- #latest_packs -->
     {% endif %}
 
@@ -394,7 +394,7 @@
             <p>This list contains packs that are empty or packs whose sounds are unmoderated or unprocessed.</p>
             <ul>
             {% for pack in packs_without_sounds %}
-                <li><a href="{% url pack user.username pack.id %}">{{pack.name}}</a>, created on <span class="date">{{pack.created}}</span></li>
+                <li><a href="{% url "pack" user.username pack.id %}">{{pack.name}}</a>, created on <span class="date">{{pack.created}}</span></li>
             {% endfor %}
             <ul>
         </div><!-- #unmoderated_packs -->

--- a/templates/accounts/accounts.html
+++ b/templates/accounts/accounts.html
@@ -4,6 +4,7 @@
 {% load display_sound %}
 {% load tags %}
 {% load smileys %}
+{% load url from future %}
 {% block title %} people {% endblock %}
 
 {% block section_content %}

--- a/templates/accounts/accounts.html
+++ b/templates/accounts/accounts.html
@@ -17,7 +17,7 @@
         {% include "accounts/active_user_and_content.html" %}
      {% endfor %} <br class="clear" /><!-- clear #most_active_users -->
     </div><!-- #most_active_users -->
-    
+
     <div id="newest_active_users" class="content_box">
     <h3>Newest active users</h3>
      {% for user in new_users %}
@@ -27,25 +27,25 @@
 
 </div><!-- #content -->
 <div id="sidebar">
-    <div id="all_time_most_active_users" class="content_box">   
+    <div id="all_time_most_active_users" class="content_box">
     <h3>All time most active users</h3>
-    
+
      {% for user in all_time_most_active_users %}
         {% include "accounts/active_user.html" %}
      {% endfor %} <br class="clear" />
     </div><!-- #users_currently_online -->
 
-    <div id="users_currently_online" class="content_box">   
+    <div id="users_currently_online" class="content_box">
     <h3>Users currently online ({{logged_users|length}})</h3>
     <div id="users_currently_online_box">
-    {% for user in logged_users %}     
-        
+    {% for user in logged_users %}
+
         <div class="online_user">
-            <a href="{% url account user.username %}">
+            <a href="{% url "account" user.username %}">
                 <img src="{{user.profile.locations.avatar.M.url}}" alt="avatar" class="currently_online_avatar" title="{{user.username}}" />
             </a>
         </div>
-        
+
     {% endfor %}
     </div>
     </div><!-- #users_currently_online -->

--- a/templates/accounts/activate.html
+++ b/templates/accounts/activate.html
@@ -1,4 +1,5 @@
 {% extends "accounts/_section.html" %}
+{% load url from future %}
 
 {% block title %}user activation{% endblock %}
 

--- a/templates/accounts/activate.html
+++ b/templates/accounts/activate.html
@@ -5,13 +5,13 @@
 {% block section_content %}
 {% if all_ok %}
     <h1>Activation succeeded...</h1>
-    <p>You have been activated. Please <a href="{% url accounts-login %}">log in</a> to continue.
+    <p>You have been activated. Please <a href="{% url "accounts-login" %}">log in</a> to continue.
 {% else %}
     <h1>Activation failed...</h1>
     {% if user_does_not_exist %}
     <p>We're sorry but the user you are trying to activate does not exist anymore! Please sign up again...</p>
     {% endif %}
-    
+
     {% if decode_error %}
     <p>We're sorry but we can't find that activation key in the database. Try copy-pasting the link that we sent you instead of clicking it...</p>
     {% endif %}

--- a/templates/accounts/active_user.html
+++ b/templates/accounts/active_user.html
@@ -6,7 +6,7 @@
     <div class="active_user_info">
         <img src="{{user.0.profile.locations.avatar.M.url}}" alt="avatar" />
 
-        <div class="post_author"><a href="{% url account user.0.username %}">{{user.0.username}}</a></div><!-- .post_author -->
+        <div class="post_author"><a href="{% url "account" user.0.username %}">{{user.0.username}}</a></div><!-- .post_author -->
 
         <div class="people_user_info">
             {{user.0.profile.num_sounds}} sound{{user.0.profile.num_sounds|pluralize}},

--- a/templates/accounts/active_user.html
+++ b/templates/accounts/active_user.html
@@ -1,6 +1,7 @@
 {% load cache %}
 {% cache 3600 active_user_no_content user.0.id %}
 {% load active_user_content %}
+{% load url from future %}
 
 <div class="active_user">
     <div class="active_user_info">

--- a/templates/accounts/active_user_and_content.html
+++ b/templates/accounts/active_user_and_content.html
@@ -1,5 +1,6 @@
 {% load cache %}
 {% cache 3600 active_user_and_content user.0.id %}
+{% load url from future %}
 
 {% load active_user_content %}
 

--- a/templates/accounts/active_user_and_content.html
+++ b/templates/accounts/active_user_and_content.html
@@ -7,7 +7,7 @@
     <div class="active_user_info">
         <img src="{{user.0.profile.locations.avatar.M.url}}" alt="avatar" />
 
-        <div class="post_author"><a href="{% url account user.0.username %}">{{user.0.username}}</a></div><!-- .post_author -->
+        <div class="post_author"><a href="{% url "account" user.0.username %}">{{user.0.username}}</a></div><!-- .post_author -->
 
         <div class="people_user_info">
             {{user.0.profile.num_sounds}} sound{{user.0.profile.num_sounds|pluralize}} ,

--- a/templates/accounts/active_user_content.html
+++ b/templates/accounts/active_user_content.html
@@ -1,6 +1,7 @@
 {% load cache %}
 {% load util %}
 {% load smileys %}
+{% load url from future %}
 
 {% cache 3600 active_user_content user.id %}
 

--- a/templates/accounts/active_user_content.html
+++ b/templates/accounts/active_user_content.html
@@ -11,13 +11,13 @@
     {% endif %}
 
     {% if content_type == 'post' %}
-        <span class="people_user_info">post in <a href="{% url forums-thread content.thread.forum.name_slug content.thread.id %}"
+        <span class="people_user_info">post in <a href="{% url "forums-thread" content.thread.forum.name_slug content.thread.id %}"
             class="topic_subject">  {{content.thread.title|safe}}</a></span>
             {{content.body|smileys|safe|linebreaks|truncatewords:30}}
     {% endif %}
 
     {% if content_type == 'comment' %}
-        <span class="people_user_info">comment in <a class="title" href="{% url sound content.content_object.user.username content.content_object.id %}">{{content.content_object.original_filename|truncate_string:28}}</a></span>
+        <span class="people_user_info">comment in <a class="title" href="{% url "sound" content.content_object.user.username content.content_object.id %}">{{content.content_object.original_filename|truncate_string:28}}</a></span>
         {{content.comment.sound}}
         {{content.comment|smileys|safe|linebreaks}}
 

--- a/templates/accounts/attribution.html
+++ b/templates/accounts/attribution.html
@@ -2,6 +2,7 @@
 
 {% load paginator %}
 {% load absurl %}
+{% load url from future %}
 
 {% block title %}Attribution{% endblock %}
 

--- a/templates/accounts/attribution.html
+++ b/templates/accounts/attribution.html
@@ -9,7 +9,7 @@
 
 <h1>Attribution</h1>
 <p>
-	This is the list of files you have downloaded. When you use freesound samples (under the "attribution" or "attribution non-commercial license"), you have to <a href="{% url wiki-page "faq" %}#how-do-i-creditattribute">credit the original creator of the sound</a> in your work. This list makes it a little bit easier to do so. "S" means sound, "P" means pack.<br/>
+	This is the list of files you have downloaded. When you use freesound samples (under the "attribution" or "attribution non-commercial license"), you have to <a href="{% url "wiki-page" "faq" %}#how-do-i-creditattribute">credit the original creator of the sound</a> in your work. This list makes it a little bit easier to do so. "S" means sound, "P" means pack.<br/>
 	There are 3 flavors of this list: <a href="?format=regular">regular</a>, <a href="?format=html">html</a> or <a href="?format=plaintext">plain text</a>.
 </p>
 
@@ -26,11 +26,11 @@
 			{% for download_item in group.list %}
 				{% if download_item.sound %}
 					{% with download_item.sound as sound %}
-						<li>S: <a href="{% url sound sound.user.username sound.id %}">{{sound.original_filename}}</a> by <a href="{% url account sound.user.username %}">{{sound.user.username}}</a>  | <span style="color:gray">License:</span> {{ sound.license }}</li>
+						<li>S: <a href="{% url "sound" sound.user.username sound.id %}">{{sound.original_filename}}</a> by <a href="{% url "account" sound.user.username %}">{{sound.user.username}}</a>  | <span style="color:gray">License:</span> {{ sound.license }}</li>
 					{% endwith %}
 				{% else %}
 					{% with download_item.pack as pack %}
-						<li>P: <a href="{% url pack pack.user.username pack.id %}">{{pack.name}}</a> by <a href="{% url account pack.user.username %}">{{pack.user.username}}</a></li>
+						<li>P: <a href="{% url "pack" pack.user.username pack.id %}">{{pack.name}}</a> by <a href="{% url "account" pack.user.username %}">{{pack.user.username}}</a></li>
 					{% endwith %}
 				{% endif %}
 			{% endfor %}

--- a/templates/accounts/confirm_delete_undescribed_files.html
+++ b/templates/accounts/confirm_delete_undescribed_files.html
@@ -23,14 +23,14 @@
 
     <div id="confirm_deletion">
     <h4><a href="javascript:document.fileform.submit();">yes</a></h4>
-    <h4><a href="{% url accounts-describe %}">no</a></h4>
+    <h4><a href="{% url "accounts-describe" %}">no</a></h4>
     </div>
     <br style="clear: both;" />
-    
+
 </form>
 
 
 </div>
-    
+
 
 {% endblock %}

--- a/templates/accounts/confirm_delete_undescribed_files.html
+++ b/templates/accounts/confirm_delete_undescribed_files.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load filefunctions %}
+{% load url from future %}
 
 {% block title %}{{ block.super }}Delete undescribed files{% endblock %}
 

--- a/templates/accounts/delete.html
+++ b/templates/accounts/delete.html
@@ -1,6 +1,7 @@
 {% extends "sounds/_section.html" %}
 
 {% load paginator %}
+{% load url from future %}
 
 {% block title %}Delete yourself{% endblock title %}
 

--- a/templates/accounts/delete.html
+++ b/templates/accounts/delete.html
@@ -10,7 +10,7 @@
 {% if num_sounds > 0 %}
 <p>
     Because you have sounds on freesound, deleting your user is not a trivial task.
-    As such, we ask you to please contact the administrators via the <a href="{% url contact %}">Contact Form</a>.
+    As such, we ask you to please contact the administrators via the <a href="{% url "contact" %}">Contact Form</a>.
     They will help you with the deletion of your account.
 </p>
 {% else %}

--- a/templates/accounts/downloaded_packs.html
+++ b/templates/accounts/downloaded_packs.html
@@ -2,6 +2,7 @@
 
 {% load display_pack %}
 {% load paginator %}
+{% load url from future %}
 
 {% block title %}Packs downloaded by {{ username }}{% endblock %}
 

--- a/templates/accounts/downloaded_packs.html
+++ b/templates/accounts/downloaded_packs.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<h1>Packs downloaded by <a href="{% url account username %}">{{ username }}</a></h1>
+<h1>Packs downloaded by <a href="{% url "account" username %}">{{ username }}</a></h1>
 
 {% if paginator.count > 0 %}
     <div class="search_paginator">

--- a/templates/accounts/downloaded_sounds.html
+++ b/templates/accounts/downloaded_sounds.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<h1>Sounds downloaded by <a href="{% url account username %}">{{ username }}</a></h1>
+<h1>Sounds downloaded by <a href="{% url "account" username %}">{{ username }}</a></h1>
 
 {% if paginator.count > 0 %}
 

--- a/templates/accounts/downloaded_sounds.html
+++ b/templates/accounts/downloaded_sounds.html
@@ -2,6 +2,7 @@
 
 {% load display_sound %}
 {% load paginator %}
+{% load url from future %}
 
 {% block title %}Sounds downloaded by {{ username }}{% endblock %}
 

--- a/templates/accounts/edit.html
+++ b/templates/accounts/edit.html
@@ -1,4 +1,5 @@
 {% extends "accounts/_section.html" %}
+{% load url from future %}
 
 {% block title %}edit account{% endblock %}
 

--- a/templates/accounts/edit.html
+++ b/templates/accounts/edit.html
@@ -34,22 +34,22 @@
     {% if has_granted_permissions %}
         <div id="app_permissions" class="content_box">
             <h3>App permissions</h3>
-            <p>Manage your list of permissions granted to API applications <a href="{% url access-tokens %}">here</a>.</p>
+            <p>Manage your list of permissions granted to API applications <a href="{% url "access-tokens" %}">here</a>.</p>
         </div>
     {% endif %}
 
     <div id="reset_password_and_email" class="content_box">
         <h3>Password and email addres</h3>
         <ul>
-            <li><a href="{% url accounts-email-reset %}">Change your email address</a></li>
-            <li><a href="{% url accounts-password-reset %}">Reset your password</a></li>
+            <li><a href="{% url "accounts-email-reset" %}">Change your email address</a></li>
+            <li><a href="{% url "accounts-password-reset" %}">Reset your password</a></li>
         </ul>
     </div><!-- #reset_password_and_email -->
 
     <div id="delete_account" class="content_box">
         <h3>Delete account</h3>
         <p>
-            To delete your account, please go <a href="{% url accounts-delete %}">here</a>.
+            To delete your account, please go <a href="{% url "accounts-delete" %}">here</a>.
         </p>
     </div><!-- #delete_account -->
 </div><!-- #sidebar -->

--- a/templates/accounts/email_reset_email.html
+++ b/templates/accounts/email_reset_email.html
@@ -8,7 +8,7 @@ You're receiving this e-mail because you requested an e-mail reset for your user
 
 Please go to the following page to confirm your new e-mail address:
 
-<{{ protocol }}://{{ domain }}{% url accounts.views.email_reset_complete uidb36=uid, token=token %}>
+<{{ protocol }}://{{ domain }}{% url "accounts.views.email_reset_complete" uidb36=uid token=token %}>
 
 Your username, in case you've forgotten: {{ user.username }}
 {% endautoescape %}

--- a/templates/accounts/email_reset_email.html
+++ b/templates/accounts/email_reset_email.html
@@ -1,5 +1,5 @@
 {% extends "email_base.txt" %}
-
+{% load url from future %}
 {% block salutation %}{{user.username}}{% endblock %}
 
 {% block body %}

--- a/templates/accounts/flag_user.html
+++ b/templates/accounts/flag_user.html
@@ -54,7 +54,7 @@
     {% if flagged %}
         <span style="color:#808080;">{{ done_text }}</span>
     {% else %}
-        <a onclick="post_flag('{{content_obj_id}}{{flag_type}}','{{username}}','{{ flag_type }}',{{ content_obj_id }},'{% url flag-user username %}')" href="javascript:void(0)">{{ link_text }}</a>
+        <a onclick="post_flag('{{content_obj_id}}{{flag_type}}','{{username}}','{{ flag_type }}',{{ content_obj_id }},'{% url "flag-user" username %}')" href="javascript:void(0)">{{ link_text }}</a>
     {% endif %}
     </span>
 

--- a/templates/accounts/flag_user.html
+++ b/templates/accounts/flag_user.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 {% if no_show %}
     <!-- do noting -->
 {% else %}

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -15,7 +15,7 @@
 <input type="submit" value="login" />
 <input type="hidden" name="next" value="{{ next }}" />
 </form>
-<p>Don't have an account yet? Why not <a href="{% url accounts-register %}">register</a>?</p>
+<p>Don't have an account yet? Why not <a href="{% url "accounts-register" %}">register</a>?</p>
 
 {% include "accounts/reminders.html" %}
 

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -1,4 +1,5 @@
 {% extends "accounts/_section.html" %}
+{% load url from future %}
 
 {% block title %}login{% endblock %}
 

--- a/templates/accounts/password_reset_email.html
+++ b/templates/accounts/password_reset_email.html
@@ -8,7 +8,7 @@ You're receiving this e-mail because you requested a password reset for your use
 
 Please go to the following page and choose a new password:
 
-{{ protocol }}://{{ domain }}{% url django.contrib.auth.views.password_reset_confirm uidb36=uid, token=token %}
+{{ protocol }}://{{ domain }}{% url "django.contrib.auth.views.password_reset_confirm" uidb36=uid token=token %}
 
 Your username, in case you've forgotten: {{ user.username }}
 {% endautoescape %}

--- a/templates/accounts/password_reset_email.html
+++ b/templates/accounts/password_reset_email.html
@@ -1,5 +1,5 @@
 {% extends "email_base.txt" %}
-
+{% load url from future %}
 {% block salutation %}{{user.username}}{% endblock %}
 
 {% block body %}

--- a/templates/accounts/pending.html
+++ b/templates/accounts/pending.html
@@ -1,4 +1,5 @@
 {% extends "accounts/_section.html" %}
+{% load url from future %}
 
 {% load display_sound %}
 {% load paginator %}

--- a/templates/accounts/pending.html
+++ b/templates/accounts/pending.html
@@ -7,7 +7,7 @@
 {% block title %}Uploaded sounds awaiting moderation{% endblock title %}
 {% block section_content %}
 
-    <h2>Uploaded sounds awaiting moderation {% if moderators_version %} by  <a class="title" href="{% url account user.username %}">{{user.username}}</a>{% endif %}</h2>
+    <h2>Uploaded sounds awaiting moderation {% if moderators_version %} by  <a class="title" href="{% url "account" user.username %}">{{user.username}}</a>{% endif %}</h2>
 
     {% if show_pagination %}
         {% show_paginator paginator page current_page request "moderation ticket" %}
@@ -24,7 +24,7 @@
 
                     <div class="sound_title">
                         <div class="sound_filename">
-                            <a class="title" href="{% url sound sound.user.username sound.id %}" title="{{sound.original_filename}}">{{sound.original_filename|truncate_string:27}}</a>
+                            <a class="title" href="{% url "sound" sound.user.username sound.id %}" title="{{sound.original_filename}}">{{sound.original_filename|truncate_string:27}}</a>
                         </div><!-- .sound_filename -->
 
                         <div class="sound_description">
@@ -34,7 +34,7 @@
                         <div class="sound_tags">
                             <ul class="tags">
                                 {% for tag_link in sound.tags.all %}
-                                    <li><a href="{% url tags tag_link.tag.name %}">{{tag_link.tag.name}}</a></li>
+                                    <li><a href="{% url "tags" tag_link.tag.name %}">{{tag_link.tag.name}}</a></li>
                                 {% endfor %}
                             </ul>
                             <br style="clear: both;"/>
@@ -45,9 +45,9 @@
 
                     <span class="date">{{sound.created|date:"F jS, Y"}}</span><br />
                     {% if not moderators_version %}
-                        <a href="{% url sound-edit sound.user.username sound.id %}" class="icon" id="edit_link" title="edit sound">Edit sound information</a><br />
+                        <a href="{% url "sound-edit" sound.user.username sound.id %}" class="icon" id="edit_link" title="edit sound">Edit sound information</a><br />
                     {% endif %}
-                    See full <a href="{% url tickets-ticket ticket.key %}">moderation ticket</a><br />
+                    See full <a href="{% url "tickets-ticket" ticket.key %}">moderation ticket</a><br />
                     {% with comments|first as last_comment %}
                         {% ifnotequal last_comment.sender_id user.id %}
                             <br><img src="{{media_url}}images/info_red.png" width="12" height="12" valign="middle" />
@@ -60,10 +60,10 @@
 
         {% comment %}
         <div class='last-ticket-comments'>
-            <p>Last comment{{ comments|length|pluralize}} on <a href="{% url tickets-ticket ticket.key %}">moderation ticket</a>:
+            <p>Last comment{{ comments|length|pluralize}} on <a href="{% url "tickets-ticket" ticket.key %}">moderation ticket</a>:
                 <ul>
                     {% for comment in comments %}
-                        <li><a href="{% url account comment.sender %}">{{ comment.sender }}</a> <span id="time-since">({{ comment.created|timesince}} ago)</span>: <i>{{ comment.text }}</i></li>
+                        <li><a href="{% url "account" comment.sender %}">{{ comment.sender }}</a> <span id="time-since">({{ comment.created|timesince}} ago)</span>: <i>{{ comment.text }}</i></li>
                     {% endfor %}
                 </ul>
             </p>
@@ -81,7 +81,7 @@
     {% if moderators_version %}
         <script type="text/javascript">
             $(document).ready(function (){
-                var loadUrl = '{% url tickets-user-annotations 0 %}'.replace('0', ''+ {{ user.id }});
+                var loadUrl = '{% url "tickets-user-annotations" 0 %}'.replace('0', ''+ {{ user.id }});
                 $('#user-annotations-section').load(loadUrl);
             });
         </script>

--- a/templates/accounts/player.html
+++ b/templates/accounts/player.html
@@ -1,6 +1,6 @@
 {% load util %}
 
-<span class="people_user_info">New sound: <a href="{% url sound sound.user.username sound.id %}">{{sound.original_filename|truncate_string:35}}</a>
+<span class="people_user_info">New sound: <a href="{% url "sound" sound.user.username sound.id %}">{{sound.original_filename|truncate_string:35}}</a>
 </span>
 
 <div class="player_medium">

--- a/templates/accounts/player.html
+++ b/templates/accounts/player.html
@@ -1,4 +1,5 @@
 {% load util %}
+{% load url from future %}
 
 <span class="people_user_info">New sound: <a href="{% url "sound" sound.user.username sound.id %}">{{sound.original_filename|truncate_string:35}}</a>
 </span>

--- a/templates/accounts/reminders.html
+++ b/templates/accounts/reminders.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <h1>Already a member?</h1>
 <p>Here are some useful links for the forgetful...</p>
 <ul>

--- a/templates/accounts/reminders.html
+++ b/templates/accounts/reminders.html
@@ -1,7 +1,7 @@
 <h1>Already a member?</h1>
 <p>Here are some useful links for the forgetful...</p>
 <ul>
-    <li><a href="{% url accounts-password-reset %}">Reset your password</a></li>
-    <li><a href="{% url accounts-resend-activation %}">Resend activation code</a></li>
-    <li><a href="{% url accounts-username-reminder %}">Forgotten username?</a></li>
+    <li><a href="{% url "accounts-password-reset" %}">Reset your password</a></li>
+    <li><a href="{% url "accounts-resend-activation" %}">Resend activation code</a></li>
+    <li><a href="{% url "accounts-username-reminder" %}">Forgotten username?</a></li>
 </ul>

--- a/templates/accounts/upload.html
+++ b/templates/accounts/upload.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load absurl %}
+{% load url from future %}
 
 {% block title %}upload files{% endblock %}
 

--- a/templates/accounts/upload.html
+++ b/templates/accounts/upload.html
@@ -85,7 +85,7 @@
         margin-right:120px;
         width:320px;
         color:gray;
-    
+
     }
     #upload_button_block{
         display:block;
@@ -94,28 +94,28 @@
         margin-left:120px;
         width:320px;
         color:gray;
-    
+
     }
-    
+
     #buttons_container
     {
-    
+
         width: 100%;
         height: 130px;
     }
-    
+
     .html_upload_form{
     	margin-left: 0px;
 		padding: 0px;
 		border-left: none;
 		background: white;
-		margin-bottom: 0px;  
-		text-align:left;  	
+		margin-bottom: 0px;
+		text-align:left;
     }
     .centered{
     	text-align:center;
     }
-    
+
     </style>
 {% endblock %}
 
@@ -129,7 +129,7 @@
 <div>
     <div class="please_note content_box">
         <h3>Legality</h3>
-        <p>Only upload sounds created or recorded <strong>by you</strong>. <em><a href="{% url wiki-page "faq" %}#sounds-4">More details...</a></em>
+        <p>Only upload sounds created or recorded <strong>by you</strong>. <em><a href="{% url "wiki-page" "faq" %}#sounds-4">More details...</a></em>
     </div>
     <div class="please_note content_box">
         <h3>Sounds only</h3>
@@ -138,13 +138,13 @@
     </div>
     <div class="please_note content_box">
         <h3>Moderation</h3>
-        <p>All files are <strong>moderated</strong>. If you upload illegal files or files that don't follow the <a href="{% url wiki-page "faq" %}#sounds">guidelines</a> they will be removed.
+        <p>All files are <strong>moderated</strong>. If you upload illegal files or files that don't follow the <a href="{% url "wiki-page" "faq" %}#sounds">guidelines</a> they will be removed.
     </div>
     <div class="please_note content_box">
         <h3>Formats</h3>
         <p>We prefer <strong>wav, aif and flac</strong>, but we support ogg and mp3 too. For very large files please use some compressed format. Uploading more than 1GB at once will fail.
     </div>
-    
+
     <br style="clear: both;">
 </div>
 <br>
@@ -165,7 +165,7 @@
         if(queue.length==0){
             $("#describe_img").attr("src", "{{media_url}}images/describe_sounds.png");
             $("#describe_a").mouseover(function () {$(this).css('cursor', 'pointer')});
-            $("#describe_a").attr("href", "{% url accounts-describe %}");
+            $("#describe_a").attr("href", "{% url "accounts-describe" %}");
         }
     }
 
@@ -216,8 +216,8 @@
         removeFromQueue(fileId);
 
     }
-    
-    
+
+
 </script>
   {% if no_flash %}
         <form method="POST" enctype="multipart/form-data" action="/home/upload/html/" class="html_upload_form"
@@ -264,12 +264,12 @@
 <img src="{{media_url}}/images/fugue-icons/icons/exclamation.png"> <span style="color:black">Don't leave before upload finishes!</span><br/>
 Hint: you can upload multiple files at once</p>
 {% endif %}
-  
+
 </div>
 
 <div id="describe_button_block">
 
-<p><a id="describe_a" href="{% url accounts-describe %}"><img id="describe_img" src="{{media_url}}images/describe_sounds.png" width="160" height="31" alt="Describe Your Sounds Link" /></a></p>
+<p><a id="describe_a" href="{% url "accounts-describe" %}"><img id="describe_img" src="{{media_url}}images/describe_sounds.png" width="160" height="31" alt="Describe Your Sounds Link" /></a></p>
 <p>Before your sounds show up on the web site you'll have to describe them</p>
 </div>
 </div>
@@ -281,9 +281,9 @@ Hint: you can upload multiple files at once</p>
 
 <p class="centered">
 {% if no_flash %}
-<a href="{% url accounts-upload %}"> switch to flash version </a>
+<a href="{% url "accounts-upload" %}"> switch to flash version </a>
 {% else %}
-<a href="{% url accounts-upload-html %}"> switch to non-flash version </a>
+<a href="{% url "accounts-upload-html" %}"> switch to non-flash version </a>
 {% endif %}
 </p>
 </div><!-- #upload_page -->


### PR DESCRIPTION
This is one of the biggest changes we need to make for django 1.5, adding quotes to the url templatetags in django. I'll commit the templates for each app separately, so that someone can double-check them in smaller batches that I didn't miss, e.g. a missing quote, or change any words.

I'm not sure what the best way to deploy this is. One idea would be to update django at the same time, make all the template changes, and also every other change that has to be made.
An alternative is to use the future tag: `{% load url from future %}`. This is valid in django 1.4. We could add it to all templates, bit by bit, deploy with the current django, and then when we make the upgrade to 1.5, remove the future import.  Thoughts?