### PR TITLE
Make absolute urls always https (#714)

### DIFF
--- a/general/templatetags/absurl.py
+++ b/general/templatetags/absurl.py
@@ -28,7 +28,7 @@ register = Library()
 class AbsoluteURLNode(URLNode):
     def render(self, context):
         path = super(AbsoluteURLNode, self).render(context)
-        domain = "http://%s" % Site.objects.get_current().domain
+        domain = "https://%s" % Site.objects.get_current().domain
         return urlparse.urljoin(domain, path)
 
 def absurl(parser, token, node_cls=AbsoluteURLNode):

--- a/templates/accounts/upload.html
+++ b/templates/accounts/upload.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load absurl %}
 
 
 {% block title %}upload files{% endblock %}

--- a/templates/sounds/deleted_sound.html
+++ b/templates/sounds/deleted_sound.html
@@ -4,7 +4,6 @@
 {% load util %}
 {% load ratings %}
 {% load cache %}
-{% load absurl %}
 
 {% block title %}Deleted Sound{% endblock title %}
 

--- a/templates/tickets/email_notification_whitelisted.txt
+++ b/templates/tickets/email_notification_whitelisted.txt
@@ -1,7 +1,5 @@
 {% extends "email_base.txt" %}
 
-{% load absurl %}
-
 {% block salutation %}{% if user_to %}{{user_to.username}}{% else %}X{% endif %}{% endblock %}
 
 {% block body %}


### PR DESCRIPTION
This makes all absolute urls start with `https://`. This mostly happens in emails that we send to people. It's also in social links, iframes, and the attribution page.
This shouldn't have much of an effect on any of our users - all of the pages will continue to work, and we haven't had any problems with https.