### PR TITLE
Show correct text if an admin views other user's pending sounds

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1063,6 +1063,7 @@ def pending(request):
         'user': user,
         'show_pagination': show_pagination,
         'moderators_version': moderators_version,
+        'own_page': True,
     }
     tvars.update(paginate(request, pendings, settings.SOUNDS_PENDING_MODERATION_PER_PAGE))
     return render(request, 'accounts/pending.html', tvars)

--- a/templates/accounts/pending.html
+++ b/templates/accounts/pending.html
@@ -72,7 +72,13 @@
         {% endcomment %}
 
     {% empty %}
-        <p>Currently, you don't have any uploaded sounds awaiting moderation.</p>
+        <p>Currently,
+        {% if own_page %}
+        you don't
+        {% else %}
+        {{user.username}} doesn't
+        {% endif %}
+        have any uploaded sounds awaiting moderation.</p>
     {% endfor %}
 
     {% if show_pagination %}

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -449,7 +449,7 @@ def moderation_assign_single_ticket(request, user_id, ticket_id):
     ticket.modified = datetime.datetime.now()
     ticket.save()
     invalidate_all_moderators_header_cache()
-    
+
     msg = 'You have been assigned ticket "%s".' % ticket.title
     messages.add_message(request, messages.INFO, msg)
 
@@ -469,7 +469,7 @@ def moderation_assign_single_ticket(request, user_id, ticket_id):
 
 @permission_required('tickets.can_moderate')
 def moderation_assigned(request, user_id):
-    
+
     can_view_moderator_only_messages = _can_view_mod_msg(request)
     clear_forms = True
     if request.method == 'POST':
@@ -652,11 +652,13 @@ def pending_tickets_per_user(request, username):
                              processed.""" % (n_unprocessed_sounds, user.username))
 
     moderators_version = True
+    own_page = user == request.user
 
     paginated = paginate(request, pendings, settings.SOUNDS_PENDING_MODERATION_PER_PAGE)
     tvars = {"show_pagination": show_pagination,
              "moderators_version": moderators_version,
-             "user": user}
+             "user": user,
+             "own_page": own_page}
     tvars.update(paginated)
 
     return render(request, 'accounts/pending.html', tvars)


### PR DESCRIPTION
If the user has no pending sounds and you are a moderator it now shows their username instead of "you". Fixes #727