### PR TITLE
Pack download using temporary license file

### DIFF
--- a/sounds/models.py
+++ b/sounds/models.py
@@ -792,36 +792,12 @@ class Pack(SocialModel):
         username_slug =  slugify(self.user.username)
         return "%d__%s__%s.zip" % (self.id, username_slug, name_slug)
 
-    @locations_decorator()
-    def locations(self):
-        return dict(sendfile_url=settings.PACKS_SENDFILE_URL + "%d.zip" % self.id,
-                    license_url=settings.PACKS_SENDFILE_URL + "%d_license.txt" % self.id,
-                    license_path=os.path.join(settings.PACKS_PATH, "%d_license.txt" % self.id),
-                    path=os.path.join(settings.PACKS_PATH, "%d.txt" % self.id))
-
     def process(self):
         sounds = self.sound_set.filter(processing_state="OK", moderation_state="OK").order_by("-created")
         self.num_sounds = sounds.count()
         if self.num_sounds:
             self.last_updated = sounds[0].created
-        self.create_license_file(pack_sounds=sounds)
         self.save()
-
-    def create_license_file(self, pack_sounds):
-        """ Create a license file containing the licenses of all sounds in the
-            pack, and update the pack license_crc field, but DO NOT save the pack
-        """
-        from django.template.loader import render_to_string
-        if len(pack_sounds)>0:
-            licenses = License.objects.all()
-            license_path = self.locations("license_path")
-            attribution = render_to_string("sounds/pack_attribution.txt", dict(pack=self, licenses=licenses,
-                                                                               sound_list=pack_sounds))
-            f = open(license_path, 'w')
-            f.write(attribution.encode("UTF-8"))
-            f.close()
-            p = subprocess.Popen(["crc32", license_path], stdout=subprocess.PIPE)
-            self.license_crc = p.communicate()[0].split(" ")[0][:-1]
 
     def get_random_sound_from_pack(self):
         pack_sounds = Sound.objects.filter(pack=self.id, processing_state="OK", moderation_state="OK").order_by('?')[0:1]

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -286,7 +286,8 @@ def pack_download(request, username, pack_id):
         raise Http404
 
     Download.objects.get_or_create(user=request.user, pack=pack)
-    pack_sounds = pack.sound_set.filter(processing_state="OK", moderation_state="OK")
+    pack_sounds = pack.sound_set.filter(processing_state="OK",
+            moderation_state="OK").select_related('user', 'license')
     return download_sounds(pack_sounds, reverse('pack', args=[username, pack.id]))
 
 

--- a/templates/sounds/pack.html
+++ b/templates/sounds/pack.html
@@ -170,7 +170,7 @@
     </div><!-- #pack_geotags -->
     
     {% if not pack.is_dirty %}
-	{% if num_sounds_ok > 0  and file_exists %}
+	{% if num_sounds_ok > 0 %}
 		<!--<div id="single_pack_sidebar">-->
 		{% if pack_geotags %}
 		    <div id="download" style="margin-top:-40px">

--- a/templates/sounds/pack_attribution.txt
+++ b/templates/sounds/pack_attribution.txt
@@ -1,7 +1,7 @@
 {% load absurl %}Sound pack downloaded from Freesound.org
 ----------------------------------------
 
-This pack of sounds contains sounds by the following user{% if users|length > 1 %}s{% endif %}:
+This pack of sounds contains sounds by the following user{{ users|pluralize }}:
 {% for user in users %} - {{user.username}} ( {% absurl 'account' user.username %} ){% endfor %}
 
 {% if sounds_url %}You can find this pack online at: {{ sounds_url}}{% endif %}

--- a/templates/sounds/pack_attribution.txt
+++ b/templates/sounds/pack_attribution.txt
@@ -1,9 +1,10 @@
 {% load absurl %}Sound pack downloaded from Freesound.org
 ----------------------------------------
 
-This pack of sounds contains sounds by {{pack.user.username}} ( {% absurl 'account' pack.user.username %}  )
-You can find this pack online at: {% absurl 'pack' pack.user.username pack.id %}
+This pack of sounds contains sounds by the following user{% if users|length > 1 %}s{% endif %}:
+{% for user in users %} - {{user.username}} ( {% absurl 'account' user.username %} ){% endfor %}
 
+{% if sounds_url %}You can find this pack online at: {{ sounds_url}}{% endif %}
 
 License details
 ---------------

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -19,6 +19,7 @@
 #
 
 import os
+import stat
 import zlib
 import tempfile
 import subprocess
@@ -48,12 +49,14 @@ def download_sounds(sounds_list, sounds_url=None):
     tmpf = tempfile.NamedTemporaryFile(dir=settings.PACKS_PATH, delete=False)
     tmpf.write(attribution.encode("UTF-8"))
     tmpf.close()
+    secret_name = tmpf.name.replace(settings.PACKS_PATH, settings.PACKS_SENDFILE_URL)
 
+    os.chmod(tmpf.name, stat.S_IWUSR | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
     license_crc = zlib.crc32(attribution.encode('UTF-8')) & 0xffffffff
 
     filelist = "%02x %i %s %s\r\n" % (license_crc,
                                     os.stat(tmpf.name).st_size,
-                                    tmpf.name, "_readme_and_license.txt")
+                                    secret_name, "_readme_and_license.txt")
 
     for sound in sounds_list:
         url = sound.locations("sendfile_url")

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -1,0 +1,61 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+import os
+import tempfile
+import subprocess
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+from django.contrib.auth.models import User
+from sounds.models import License
+
+
+def download_sounds(sounds_list, sounds_url=None):
+    users = User.objects.filter(sounds__in=sounds_list).distinct()
+    # Generate text file with license info
+    licenses = License.objects.all()
+    attribution = render_to_string("sounds/pack_attribution.txt",
+        dict(users=users,
+            sounds_url=sounds_url,
+            licenses=licenses,
+            sound_list=sounds_list))
+
+    tmpf = tempfile.NamedTemporaryFile(dir=settings.PACKS_PATH, delete=False)
+    tmpf.write(attribution.encode("UTF-8"))
+    tmpf.close()
+
+    p = subprocess.Popen(["crc32", tmpf.name], stdout=subprocess.PIPE)
+    license_crc = p.communicate()[0].split(" ")[0][:-1]
+    filelist = "%s %i %s %s\r\n" % (license_crc,
+                                    os.stat(tmpf.name).st_size,
+                                    tmpf.name, "_readme_and_license.txt")
+
+    for sound in sounds_list:
+        url = sound.locations("sendfile_url")
+        name = sound.friendly_filename()
+        if sound.crc == '':
+            continue
+        filelist += "%s %i %s %s\r\n" % (sound.crc, sound.filesize, url, name)
+
+    response = HttpResponse(filelist, content_type="text/plain")
+    response['X-Archive-Files'] = 'zip'
+    return response


### PR DESCRIPTION
According to #751, when the user downloads a pack of sounds we create a temporary file with the license information so we can remove the process method in Pack. 
