### PR TITLE
Create generic async tasks using the same queue

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -79,12 +79,12 @@ class SimpleUserTest(TestCase):
         # 200 response on user geotags access
         resp = self.client.get(reverse('geotags-for-user', kwargs={'username': self.user.username}))
         self.assertEqual(resp.status_code, 200)
- 
+
     def test_user_packs_response_ok(self):
         # 200 response on user packs access
         resp = self.client.get(reverse('packs-for-user', kwargs={'username': self.user.username}))
         self.assertEqual(resp.status_code, 200)
- 
+
     def test_user_downloaded_response_ok(self):
         # 200 response on user downloaded sounds and packs access
         resp = self.client.get(reverse('user-downloaded-sounds', kwargs={'username': self.user.username}))
@@ -96,7 +96,7 @@ class SimpleUserTest(TestCase):
         # 200 response on user bookmarks sounds and packs access
         resp = self.client.get(reverse('bookmarks-for-user', kwargs={'username': self.user.username}))
         self.assertEqual(resp.status_code, 200)
- 
+
     def test_user_follow_response_ok(self):
         # 200 response on user user bookmarks sounds and packs access
         resp = self.client.get(reverse('user-following-users', kwargs={'username': self.user.username}))
@@ -105,8 +105,9 @@ class SimpleUserTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         resp = self.client.get(reverse('user-following-tags', kwargs={'username': self.user.username}))
         self.assertEqual(resp.status_code, 200)
-  
-    def test_sounds_response_ok(self):
+
+    @mock.patch('gearman.GearmanClient.submit_job')
+    def test_sounds_response_ok(self, submit_job):
         # 200 response on sounds page access
         resp = self.client.get(reverse('sounds'))
         self.assertEqual(resp.status_code, 200)

--- a/general/management/commands/gm_worker_async_tasks.py
+++ b/general/management/commands/gm_worker_async_tasks.py
@@ -19,10 +19,13 @@
 #
 
 import gearman, sys, traceback, json, time, os
+from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from tickets.models import Ticket
+from sounds.models import Sound
 from optparse import make_option
+from utils.mail import send_mail_template
 from tickets import TICKET_STATUS_CLOSED
 import logging
 
@@ -30,12 +33,6 @@ logger = logging.getLogger("gearman_worker_async_tasks")
 
 class Command(BaseCommand):
     help = 'Run the async tasks worker'
-
-    option_list = BaseCommand.option_list + (
-        make_option('--queue', action='store', dest='queue',
-            default='whitelist_user',
-            help='Register this function (default: whilelist_user)'),
-    )
 
     def write_stdout(self, msg):
         logger.info("[%d] %s" % (os.getpid(),msg))
@@ -46,17 +43,19 @@ class Command(BaseCommand):
         # N.B. don't take out the print statements as they're
         # very very very very very very very very very very
         # helpful in debugging supervisor+worker+gearman
-        self.write_stdout('Starting worker\n')
-        task_name = 'task_%s' % options['queue']
-        self.write_stdout('Task: %s\n' % task_name)
-        if task_name not in dir(self):
-            self.write_stdout("Wow.. That's crazy! Maybe try an existing queue?\n")
-            sys.exit(1)
-        task_func = lambda x, y: getattr(Command, task_name)(self, x, y)
         self.write_stdout('Initializing gm_worker\n')
         gm_worker = gearman.GearmanWorker(settings.GEARMAN_JOB_SERVERS)
-        self.write_stdout('Registering task %s, function %s\n' % (task_name, task_func))
-        gm_worker.register_task(options['queue'], task_func)
+
+        # Read all methods of the class and if it starts with 'task_' then
+        # register as a task on gearman
+        for task_name in dir(self):
+            if task_name.startswith('task_'):
+                task_name = str(task_name)
+                t_name = task_name.replace('task_', '');
+                self.write_stdout('Task: %s\n' % t_name)
+                task_func = lambda i:(lambda x, y: getattr(Command, i)(self, x, y))
+                gm_worker.register_task(t_name, task_func(task_name))
+
         self.write_stdout('Starting work\n')
         gm_worker.work()
         self.write_stdout('Ended work\n')
@@ -90,3 +89,50 @@ class Command(BaseCommand):
                 count_done = count_done + 1
             self.write_stdout("Finished processing one ticket, %d remaining" % (len(tickets)-count_done))
         return 'true' if len(tickets) == count_done else 'false'
+
+    def task_email_random_sound(self, gearman_worker, gearman_job):
+        self.write_stdout("Notifying user of random sound of the day")
+        random_sound_id = gearman_job.data
+        random_sound = Sound.objects.get(id=random_sound_id)
+
+        send_mail_template(\
+                u'One of your sounds has been chosen as random sound of the day!',
+                'sounds/email_random_sound.txt',
+                {'sound': random_sound, 'user': random_sound.user},
+                None, random_sound.user.email)
+
+        self.write_stdout("Finished sending mail to user %s of random sound of the day %s" %
+                (random_sound.user, random_sound.id))
+        return 'true'
+
+    def task_delete_user(self, gearman_worker, gearman_job):
+        self.write_stdout("Started delete_user task ")
+        self.write_stdout("Data received: %s" % gearman_job.data)
+        data = json.loads(gearman_job.data)
+        user = User.objects.get(id=data['user_id'])
+
+        if data['action'] == 'full_db_delete':
+            # This will fully delete the user and the sounds from the database.
+            # WARNING: Once the sounds are deleted NO DeletedSound object will
+            # be created.
+
+            user.delete()
+            self.write_stdout("Fully deleted user %d" % data['user_id'])
+            return 'true'
+        elif data['action'] == 'delete_user_keep_sounds':
+            # This will anonymize the user and will keep the sounds publicly
+            # availabe
+
+            user.profile.delete_user()
+            self.write_stdout("Deleted user %d" % data['user_id'])
+            return 'true'
+        elif data['action'] == 'delete_user_delete_sounds':
+            # This will anonymize the user and remove the sounds, a
+            # DeletedSound object will be created for each sound but kill not
+            # be publicly available
+
+            user.profile.delete_user(True)
+            self.write_stdout("Deleted user %d and her sounds" % data['user_id'])
+            return 'true'
+
+        return 'false'

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -53,6 +53,7 @@ from utils.similarity_utilities import get_similar_sounds
 from utils.text import remove_control_chars
 from follow import follow_utils
 from operator import itemgetter
+import gearman
 import datetime
 import time
 import logging
@@ -73,6 +74,9 @@ def get_random_sound():
     if not random_sound:
         random_sound = Sound.objects.random()
         cache.set(cache_key, random_sound, 60*60*24)
+        gm_client = gearman.GearmanClient(settings.GEARMAN_JOB_SERVERS)
+        gm_client.submit_job("email_random_sound", str(random_sound),
+                wait_until_complete=False, background=True)
     return random_sound
 
 

--- a/templates/sounds/email_random_sound.txt
+++ b/templates/sounds/email_random_sound.txt
@@ -1,0 +1,13 @@
+{% extends "email_base.txt" %}
+
+{% load absurl %}
+
+{% block salutation %}{{sound.user.username}}{% endblock %}
+
+{% block body %}
+Good news! your sound {{sound.original_filename}} has been selected as the random sound of the day!
+
+To see the random sound of the day, please visit:
+<https://freesound.org>
+
+{% endblock %}


### PR DESCRIPTION
For the tasks in gm_worker_async_tasks is not needed to run the django command again, now all this tasks are registered in the same worker. This doesn't change how they are used from the app.

issues #754, #713

If this changes are fine, we have to delete the branch: 
async-delete-user 946f52e1745231a974ae35a87f8391a8f4ffcf19
notify-random-sound 29080a6605af92eda93ae88f50ab9f12e7d6d830

Also close the PR: #769 