### PR TITLE
small fix on monitor stats

### DIFF
--- a/media/js/stats.js
+++ b/media/js/stats.js
@@ -33,8 +33,8 @@ $( document ).ready(function() {
     var tags = [];
     var max = 0;
     d.downloads_tags.forEach(function(t) {
-      max = Math.max(t[2], max);
-      tags.push([t[1], t[2]]);
+      max = Math.max(t[0], max);
+      tags.push([t[1], t[0]]);
     });
     WordCloud($('#down-tags-cloud')[0], { list: tags, weightFactor: 100/max});
   });

--- a/monitor/management/commands/generate_stats.py
+++ b/monitor/management/commands/generate_stats.py
@@ -153,7 +153,7 @@ class Command(NoArgsCommand):
                     tags_taggeditem ti, tags_tag t, sounds_download d
                     WHERE d.sound_id = ti.object_id AND t.id = ti.tag_id
                     AND d.created > current_date - interval '14 days'
-                    GROUP BY ti.tag_id, t.name ORDER BY num_c limit 300""")
+                    GROUP BY ti.tag_id, t.name ORDER BY num_c DESC limit 300""")
 
             downloads_tags = cursor.fetchall()
 


### PR DESCRIPTION
We are showing the least downloaded tags in the word cloud instead of the most downloaded tags in the last two weeks