### PR TITLE
Verify that we can create a URL before using it

### DIFF
--- a/templates/search/search_forum.html
+++ b/templates/search/search_forum.html
@@ -9,7 +9,10 @@
 
 {% block breadcrumb %}
     {% if current_forum_name_slug and current_forum_name_slug.strip %}
-        &#187; <a href="{% url "forums-forum" current_forum_name_slug %}">{{current_forum_name}}</a>
+        {% url "forums-forum" current_forum_name_slug as forum_url %}
+        {% if forum_url %}
+            &#187; <a href="{{forum_url}}">{{current_forum_name}}</a>
+        {% endif %}
     {% endif %}
 {%  endblock %}
 


### PR DESCRIPTION
Fixes #824
We pass the `current_forum_name_slug` parameter from the view into
the template, which means that a user could change this value into
something not accepted by the URL string. Store the URL to a temp
value and check that it exists before using it. This may be a problem
in other views too.