### PR TITLE
Update RadioSelect render of choices value to dj11

### DIFF
--- a/donations/forms.py
+++ b/donations/forms.py
@@ -8,7 +8,7 @@ class DonateForm(forms.Form):
 
     donation_type = forms.ChoiceField(widget=forms.RadioSelect(), choices=RADIO_CHOICES)
     name_option = forms.CharField(required=False)
-    amount = forms.CharField(required=True, initial="5")
+    amount = forms.CharField(initial="5")
     recurring = forms.BooleanField(required=False, initial=False,
             label='I want this to be a recurring monthly donation',)
     show_amount = forms.BooleanField(
@@ -32,13 +32,13 @@ class DonateForm(forms.Form):
         else:
             self.initial['donation_type'] = '1'
 
-        self.fields['donation_type'] = forms.ChoiceField(
-                    widget=forms.RadioSelect(), choices=choices)
+        self.fields['donation_type'].choices = choices
 
     def clean(self):
+        cleaned_data = super(DonateForm, self).clean()
+        amount = cleaned_data.get('amount')
         try:
-            if (not 'amount' in self.cleaned_data)\
-                    or float(self.cleaned_data['amount']) < 1:
+            if not amount or float(amount) < 1:
                 raise forms.ValidationError('The amount must be more than 1')
         except ValueError:
             raise forms.ValidationError('The amount must be a valid number, use \'.\' for decimals')
@@ -46,10 +46,10 @@ class DonateForm(forms.Form):
         campaign = DonationCampaign.objects.order_by('date_start').last()
         returned_data = {
                 "campaign_id": campaign.id,
-                "display_amount": self.cleaned_data['show_amount']
+                "display_amount": cleaned_data.get('show_amount')
                 }
 
-        annon = self.cleaned_data['donation_type']
+        annon = cleaned_data.get('donation_type')
 
         # We store the user even if the donation is annonymous
         if self.user_id :
@@ -58,9 +58,11 @@ class DonateForm(forms.Form):
         if annon == '1':
             returned_data['name'] = "Anonymous"
         elif annon == '2':
-            returned_data['name'] = self.cleaned_data.get('name_option', '')
+            returned_data['name'] = cleaned_data.get('name_option', '')
             if returned_data['name'] == '':
                 raise forms.ValidationError('You have to enter a name to display')
 
+
         # Paypal gives only one field to add extra data so we send it as b64
         self.encoded_data = base64.b64encode(json.dumps(returned_data))
+        return cleaned_data

--- a/templates/donations/donate.html
+++ b/templates/donations/donate.html
@@ -26,13 +26,13 @@
           <li>
               <input type="radio"
                      name="{{ form.donation_type.name }}"
-                     value="{{ choice.choice_value }}"
+                     value="{{ choice.data.value }}"
                      id="id_{{ form.donation_type.name }}_{{ forloop.counter0 }}"
-                     {% if form.donation_type.value == choice.choice_value %}
+                     {% if form.donation_type.value == choice.data.value %}
                          checked='checked'
                      {% endif %}/>
               {{ choice.choice_label }}
-              {% if choice.choice_value == "2" %} {{form.name_option}} {% endif %}
+              {% if choice.data.value == '2' %} {{form.name_option}} {% endif %}
           </li> 
           {% endfor %}
           </ul>


### PR DESCRIPTION

On django 1.11 they changed how to access the widget from templates: https://groups.google.com/forum/#!topic/django-users/z1V_qwSsiPs This brokes how we set the initial value of the donation_type field (which is a radio choice).

I also changed how we access to cleaned_data on the form clean method