### PR TITLE
Override PasswordResetForm.get_users to reset "unusable" passwords

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -23,6 +23,7 @@ import time
 from django import forms
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import PasswordResetForm, AuthenticationForm
+from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext as _
 from django.utils.safestring import mark_safe
 from django.urls import reverse
@@ -237,7 +238,7 @@ class ProfileForm(forms.ModelForm):
         required=False
     )
     is_adult = forms.BooleanField(help_text="I'm an adult, I don't want to see inapropriate content warnings",
-            label="", required=False) 
+            label="", required=False)
     not_shown_in_online_users_list = forms.BooleanField(
         help_text="Hide from \"users currently online\" list in the People page",
         label = "",
@@ -321,3 +322,18 @@ class EmailSettingsForm(forms.Form):
     )
 
 
+class FsPasswordResetForm(PasswordResetForm):
+    def get_users(self, email):
+        """Given an email, return matching user(s) who should receive a reset.
+
+            This subclass will let all active users reset their password.
+            Django's PasswordReset form will only let a user reset their
+            password if the password is "valid" (i.e., it's using a
+            password hash that django understands)
+        """
+        UserModel = get_user_model()
+        active_users = UserModel._default_manager.filter(**{
+            '%s__iexact' % UserModel.get_email_field_name(): email,
+            'is_active': True,
+        })
+        return (u for u in active_users)

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -19,14 +19,18 @@
 #
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.utils import override_settings, skipIf
 from django.contrib.auth.models import User, Permission
+from django.contrib.auth.forms import PasswordResetForm
+from django.contrib.sites.models import Site
 from django.urls import reverse
 from django.core.files.uploadedfile import InMemoryUploadedFile, SimpleUploadedFile
+from django.core import mail
 from django.conf import settings
 from accounts.models import Profile, EmailPreferenceType
 from accounts.views import handle_uploaded_image
+from accounts.forms import FsPasswordResetForm
 from sounds.models import License, Sound, Pack, DeletedSound
 from tags.models import TaggedItem
 from utils.filesystem import File
@@ -668,4 +672,30 @@ class UserDelete(TestCase):
         self.assertEqual(Sound.objects.filter(user__id=user.id).exists(), False)
         self.assertEqual(DeletedSound.objects.filter(user__id=user.id).exists(), True)
 
+
+class PasswordReset(TestCase):
+    def test_reset_form_get_users(self):
+        """Check that a user with an unknown password hash can reset their password"""
+
+        user = User.objects.create_user("testuser", email="testuser@freesound.org")
+
+        # Using Django's password reset form, no user will be returned
+        form = PasswordResetForm()
+        dj_users = form.get_users("testuser@freesound.org")
+        self.assertEqual(len(list(dj_users)), 0)
+
+        # But using our form, a user will be returned
+        form = FsPasswordResetForm()
+        fs_users = form.get_users("testuser@freesound.org")
+        self.assertEqual(list(fs_users)[0].get_username(), user.get_username())
+
+    @override_settings(SITE_ID=2)
+    def test_reset_view(self):
+        """Check that the reset password view calls our form"""
+        Site.objects.create(id=2, domain="freesound.org", name="Freesound")
+        user = User.objects.create_user("testuser", email="testuser@freesound.org")
+        self.client.post(reverse("password_reset"), {"email": "testuser@freesound.org"})
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Password reset on Freesound")
 

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -21,17 +21,22 @@
 #
 
 from django.conf.urls import url, include
-from django.contrib.auth.views import LoginView
+from django.contrib.auth.views import LoginView, PasswordResetView
 import messages.views as messages
 import accounts.views as accounts
-from accounts.forms import FsAuthenticationForm
+from accounts.forms import FsAuthenticationForm, FsPasswordResetForm
 import bookmarks.views as bookmarks
 import follow.views as follow
 import apiv2.views as api
 
+# By putting some URLs at the top that are the same as the ones listed in
+# django.contrib.auth.urls, we can override some configuration:
+# https://docs.djangoproject.com/en/1.11/topics/http/urls/#how-django-processes-a-request
+# 3. Django runs through each URL pattern, in order, and stops at the first one that matches the requested URL.
 urlpatterns = [
     url(r'^login/$', LoginView.as_view(template_name='registration/login.html',
                                        authentication_form=FsAuthenticationForm), name="accounts-login"),
+    url(r'^password_reset/$', PasswordResetView.as_view(form_class=FsPasswordResetForm), name='password_reset'),
     url('^', include('django.contrib.auth.urls')),  # Include logout and reset email urls
     url(r'^register/$', accounts.registration, name="accounts-register"),
     url(r'^reactivate/$', accounts.resend_activation, name="accounts-resend-activation"),


### PR DESCRIPTION
The default django reset password form will not let a user reset their
email if the current password is "unusable", which is the case if
django no longer understands the password hash. This change lets
users with sha1 passwords reset them.