### PR TITLE
Moderators wiki page

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -271,10 +271,6 @@ class SimpleUserTest(TestCase):
         resp = self.client.get(reverse('wiki'))
         self.assertEqual(resp.status_code, 302)
 
-        # 200 response on wiki developers page
-        resp = self.client.get(reverse('wiki_developers'))
-        self.assertEqual(resp.status_code, 302)
-
         # 200 response on forums moderation page
         resp = self.client.get(reverse('forums-moderate'))
         self.assertEqual(resp.status_code, 200)

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -201,6 +201,8 @@ DONATION_MODAL_DISPLAY_TIMES_DAY = 10  # max number of times we display the popu
 # COOKIE_LAW_EXPIRATION_TIME change in freesound.js (now is 360 days)
 # $.cookie("cookieConsent", "yes", { expires: 360, path: '/' });
 
+WIKI_MODERATORS_PAGE_CODENAME = 'moderators'
+
 DELETED_USER_ID = 1
 
 DISPLAY_DEBUG_TOOLBAR = False # change this in the local_settings

--- a/templates/tickets/guide.html
+++ b/templates/tickets/guide.html
@@ -12,10 +12,13 @@
     descriptions and tags, the sounds that are uploaded to Freesound have to be
     approved by the moderator team before they show up on the website. If you 
     are part of the moderator team or the staff you can help to moderate the 
-    sounds.
+    sounds.</p>
 
-    <p>This short guide will teach you how the moderation pages work and
-    what to take into account when you are moderating.
+    <p>This guide will teach you how the moderation pages work. Please
+    read the <a href="{% url 'wiki_moderators' %}">moderation tips wiki page</a>
+    to get lots of useful advice and tips for moderating sounds. It is a wiki
+    page, so feel free to update it and make it even more useful for other
+    moderators :)</p>
 
     <h3>Moderation pages</h3>
 
@@ -181,79 +184,7 @@
     the user that moderators are waiting for some response, and in case there is no response
     at all the sound can be deleted. This is to avoid having lots of deferred sounds lost forever
     in the moderation stage.</p>
-    
-    
-    <h3>Moderation tips</h3>
 
-    <p>Here is some advice to help you make decisions when moderating files.
-    Please feel free to add your own advice here.</p>
-
-    <p><b>Spotting illegal content</b></p>
-
-    <p>Identifying content which may infringe on someone's copyrights is
-    probably the hardest part of the job. If you can clearly recognize the
-    sample as being taken from a popular song or movie, you should of course
-    delete the sound, click 'Illegal' and be done with it. However, it is not
-    often so clear-cut, although there are certain signs you should look for.
-
-    <p>If you suspect a sample is illegal, check the format, bitrate, and sample
-    rate of the file. Low bitrates (usually 8 bit) or with varying bitrates
-    (VBR) indicate that the file was downloaded from the web. Users uploading
-    samples with widely different bitrates between individual files are also
-    suspicious. You may want to note common web formats like mp3 and wav, though
-    keep in mind that many legitimate uploaders make use of these formats.</p>
-
-    <p>It may also be helpful to do a web search for terms the uploader entered
-    in the file description or tags.</p>
-
-    <p>If you have doubts about the legality of a sound, defer the sound and
-    contact the user. Most users will tell you if they made sounds themselves or
-    if they "found it on a website".</p>
-
-    <p>Sounds that come from websites that say that the sounds are "free" most
-    of the time are NOT compatible with the creative commons licenses.</p>
-
-    <p><b>Good description standards</b></p>
-
-    <p>Deciding what constitutes a good description is largely a matter of your
-    own judgement, but here are a few guidelines.
-
-    <p>For synthesized sounds, a brief description may be sufficient, i.e.
-    "jazzy glissando, synthesized." If the uploader states the program or
-    language they used to create the sound, even better.</p>
-
-    <p>For field recordings, a more detailed description is expected. Where it
-    was recorded, what kind of mic/recorder setup was used, etc. make for a good
-    description. The bare minimum would be something like "nightingales recorded
-    in my backyard in Slough, UK." Something even less descriptive, such as
-    "birds in the yard" may constitute a description poor enough to be marked as
-    "Approved", but with an added message of "insufficient tags/description".
-
-    <p><b>No waveform in player</b></p>
-
-    <p>If the picture of a sound doesn't appear this means the sound has not been
-    processed correctly. Usually this means the file is not an audio file, that
-    it is an unsupported format, or that it is broken. You should delete the
-    sound, but inform the user that the file could not be read by Freesound and
-    ask him to upload it in a supported format.</p>
-
-    <p><b>Some final words from Bram</b></p>
-
-    <p>If it's a good sound, always scale your opinion upwards. I very
-    frequently just choose "ok, bad description" ;)</p>
-
-    <h3>Some final notes</h3>
-
-    <p>In the future the moderation task will include not just the moderation of
-    sounds, but also giving support to the community.</p>
-
-	{% comment %}
-    <p>Only sounds that have passed through the processing system will show up
-    in the moderation system. It's possible that some sounds fail to process
-    correctly. These sounds will still show up in the moderation system, but
-    the sound player will be left white and a small text will indicate the
-    processing has failed.</p>
-    {% endcomment %}
 </div>
 
 {% endblock section_content %}

--- a/templates/tickets/guide.html
+++ b/templates/tickets/guide.html
@@ -15,7 +15,7 @@
     sounds.</p>
 
     <p>This guide will teach you how the moderation pages work. Please
-    read the <a href="{% url 'wiki_moderators' %}">moderation tips wiki page</a>
+    read the <a href="{% url 'wiki' %}moderators/">moderation tips wiki page</a>
     to get lots of useful advice and tips for moderating sounds. It is a wiki
     page, so feel free to update it and make it even more useful for other
     moderators :)</p>

--- a/wiki/tests.py
+++ b/wiki/tests.py
@@ -1,0 +1,148 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+from django.test import TestCase
+from django.urls import reverse
+from wiki.models import Page, Content
+from django.conf import settings
+from django.contrib.auth.models import User, Permission
+
+
+class WikiPermissions(TestCase):
+
+    def setUp(self):
+        # Create wiki pages, one normal page and one for moderators
+        self.normal_page = Page.objects.create(name="normal_page")
+        self.normal_page_content = Content.objects.create(page=self.normal_page)
+        self.moderators_page = Page.objects.create(name=settings.WIKI_MODERATORS_PAGE_CODENAME)
+        self.moderators_page_content = Content.objects.create(page=self.moderators_page)
+
+        # Create users
+        self.normal_user = User.objects.create_user(username="normal_user", password="testpass")
+        self.wiki_user = User.objects.create_user(username="wiki_user", password="testpass")
+        self.wiki_user.user_permissions.add(Permission.objects.get(codename='add_page'))
+        self.moderator_user = User.objects.create_user(username="moderator_user", password="testpass")
+        self.moderator_user.user_permissions.add(Permission.objects.get(codename='can_moderate'))
+
+    def test_view_wiki_page(self):
+
+        # Non authenticated users can't visit moderation wiki pages, but can visit the others
+        resp = self.client.get(reverse('wiki-page', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 404)
+
+        resp = self.client.get(reverse('wiki-page', args=['normal_page']))
+        self.assertEqual(resp.status_code, 200)
+
+        # Logged in users can only visit moderation page if they are moderators or wiki editors
+        self.client.login(username=self.normal_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 404)
+
+        self.client.login(username=self.moderator_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 200)
+
+        self.client.login(username=self.wiki_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 200)
+
+        # Wiki pages other than moderators page can be visited by all logged in users
+        self.client.login(username=self.normal_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page', args=['normal_page']))
+        self.assertEqual(resp.status_code, 200)
+
+        self.client.login(username=self.moderator_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page', args=['normal_page']))
+        self.assertEqual(resp.status_code, 200)
+
+        self.client.login(username=self.wiki_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page', args=['normal_page']))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_edit_wiki_page(self):
+
+        # Non authenticated users can't edit wiki pages
+        resp = self.client.get(reverse('wiki-page-edit', args=['normal_page']))
+        self.assertEqual(resp.status_code, 404)
+
+        resp = self.client.get(reverse('wiki-page-edit', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 404)
+
+        # Normal wiki pages can only be edited by users with wiki edit perms
+        self.client.login(username=self.normal_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-edit', args=['normal_page']))
+        self.assertEqual(resp.status_code, 404)
+
+        self.client.login(username=self.moderator_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-edit', args=['normal_page']))
+        self.assertEqual(resp.status_code, 404)
+
+        self.client.login(username=self.wiki_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-edit', args=['normal_page']))
+        self.assertEqual(resp.status_code, 200)
+
+        # Moderator page can be edited by users with wiki edit perms and moderators
+        self.client.login(username=self.normal_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-edit', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 404)
+
+        self.client.login(username=self.moderator_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-edit', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 200)
+
+        self.client.login(username=self.wiki_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-edit', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_history_wiki_page(self):
+        # NOTE: History can be accessed by same users who can edit pages, therefore similar
+        # tests as above apply:
+
+        # Non authenticated users can't view history pages
+        resp = self.client.get(reverse('wiki-page-history', args=['normal_page']))
+        self.assertEqual(resp.status_code, 404)
+
+        resp = self.client.get(reverse('wiki-page-history', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 404)
+
+        # Normal wiki history pages can only be viewed by users with wiki edit perms
+        self.client.login(username=self.normal_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-history', args=['normal_page']))
+        self.assertEqual(resp.status_code, 404)
+
+        self.client.login(username=self.moderator_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-history', args=['normal_page']))
+        self.assertEqual(resp.status_code, 404)
+
+        self.client.login(username=self.wiki_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-history', args=['normal_page']))
+        self.assertEqual(resp.status_code, 200)
+
+        # Moderator page history can be viewed by users with wiki edit perms and moderators
+        self.client.login(username=self.normal_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-history', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 404)
+
+        self.client.login(username=self.moderator_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-history', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 200)
+
+        self.client.login(username=self.wiki_user.username, password='testpass')
+        resp = self.client.get(reverse('wiki-page-history', args=[settings.WIKI_MODERATORS_PAGE_CODENAME]))
+        self.assertEqual(resp.status_code, 200)

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -26,7 +26,6 @@ import wiki.views as wiki
 
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url="/help/main/"), name="wiki"),
-    url(r'^$', RedirectView.as_view(url="/help/developers/"), name="wiki_developers"),
     url(r'^(?P<name>[//\w_-]+)/history/$', wiki.history, name="wiki-page-history"),
     url(r'^(?P<name>[//\w_-]+)/edit/$', wiki.editpage, name="wiki-page-edit"),
     url(r'^(?P<name>[//\w_-]+)/$', wiki.page, name="wiki-page"),

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -27,7 +27,6 @@ import wiki.views as wiki
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url="/help/main/"), name="wiki"),
     url(r'^$', RedirectView.as_view(url="/help/developers/"), name="wiki_developers"),
-    url(r'^$', RedirectView.as_view(url="/help/moderators/"), name="wiki_moderators"),
     url(r'^(?P<name>[//\w_-]+)/history/$', wiki.history, name="wiki-page-history"),
     url(r'^(?P<name>[//\w_-]+)/edit/$', wiki.editpage, name="wiki-page-edit"),
     url(r'^(?P<name>[//\w_-]+)/$', wiki.page, name="wiki-page"),

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -26,7 +26,8 @@ import wiki.views as wiki
 
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url="/help/main/"), name="wiki"),
-    url(r'^$',RedirectView.as_view(url="/help/developers/"), name="wiki_developers"),
+    url(r'^$', RedirectView.as_view(url="/help/developers/"), name="wiki_developers"),
+    url(r'^$', RedirectView.as_view(url="/help/moderators/"), name="wiki_moderators"),
     url(r'^(?P<name>[//\w_-]+)/history/$', wiki.history, name="wiki-page-history"),
     url(r'^(?P<name>[//\w_-]+)/edit/$', wiki.editpage, name="wiki-page-edit"),
     url(r'^(?P<name>[//\w_-]+)/$', wiki.page, name="wiki-page"),

--- a/wiki/views.py
+++ b/wiki/views.py
@@ -22,13 +22,13 @@ from django import forms
 from django.urls import reverse
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render
-from django.template import RequestContext
 from wiki.models import Content, Page
+
 
 def page(request, name):
     try:
         version = int(request.GET.get("version", -1))
-    except:
+    except ValueError:
         version = -1
 
     try:
@@ -36,10 +36,11 @@ def page(request, name):
             content = Content.objects.filter(page__name__iexact=name).select_related().latest()
         else:
             content = Content.objects.select_related().get(page__name__iexact=name, id=version)
-    except Content.DoesNotExist: #@UndefinedVariable
+    except Content.DoesNotExist:
         content = Content.objects.filter(page__name__iexact="blank").select_related().latest()
 
     return render(request, 'wiki/page.html', locals())
+
 
 def editpage(request, name):
     if not (request.user.is_authenticated and request.user.has_perm('wiki.add_page')):
@@ -49,6 +50,7 @@ def editpage(request, name):
     class ContentForm(forms.ModelForm):
         title = forms.CharField(label='Page name',widget=forms.TextInput(attrs={'size': '100'}))
         body = forms.CharField(widget=forms.Textarea(attrs={'rows':'40', 'cols':'100'}))
+
         class Meta:
             model = Content
             exclude = ('author', 'page', "created")
@@ -67,10 +69,11 @@ def editpage(request, name):
             # if the page already exists, load up the previous content
             content = Content.objects.filter(page__name__iexact=name).select_related().latest()
             form = ContentForm(initial={"title": content.title, "body":content.body})
-        except Content.DoesNotExist: #@UndefinedVariable
+        except Content.DoesNotExist:
             form = ContentForm()
 
     return render(request, 'wiki/edit.html', locals())
+
 
 def history(request, name):
     if not (request.user.is_authenticated and request.user.has_perm('wiki.add_page')):
@@ -83,7 +86,7 @@ def history(request, name):
 
     try:
         versions = Content.objects.filter(page=page).select_related()
-    except Content.DoesNotExist: #@UndefinedVariable
+    except Content.DoesNotExist:
         raise Http404
 
     if request.GET and "version1" in request.GET and "version2" in request.GET:
@@ -91,8 +94,7 @@ def history(request, name):
         version1 = Content.objects.select_related().get(id=request.GET.get("version1"))
         version2 = Content.objects.select_related().get(id=request.GET.get("version2"))
 
-        diff = difflib.HtmlDiff(4, 55).make_table(version1.body.split("\n"), version2.body.split("\n"), "version %d" % version1.id, "version %d" % version2.id, True, 5)
-
+        diff = difflib.HtmlDiff(4, 55).make_table(version1.body.split("\n"), version2.body.split("\n"),
+                                                  "version %d" % version1.id, "version %d" % version2.id, True, 5)
 
     return render(request, 'wiki/history.html', locals())
-


### PR DESCRIPTION
I created a wiki page where moderators can add their tips and share it with others.
In Freesound, users with `add_page` are the ones who can edit and create wiki pages.
I wanted moderators to be able to edit their wiki page but not others so I had to implement new permission checks for the wiki pages. Also, I wanted moderators wiki page to not be visible by non-moderators.

In this PR I implement all these changes plus a number of other related ones like  updating the moderation guide with a link to the moderation wiki page.