### PR TITLE
Twitter stream for mobile client

### DIFF
--- a/sounds/models.py
+++ b/sounds/models.py
@@ -371,6 +371,9 @@ class Sound(SocialModel):
             )
         )
 
+    def get_preview_abs_url(self):
+        return 'https://%s%s' % (Site.objects.get_current().domain, self.locations()['preview']['LQ']['mp3']['url'])
+
     def get_thumbnail_abs_url(self, size='M'):
         return 'https://%s%s' % (Site.objects.get_current().domain, self.locations()['display']['wave'][size]['url'])
 

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -241,6 +241,7 @@ def sound(request, username, sound_id):
     is_explicit = sound.is_explicit and (not request.user.is_authenticated \
                         or not request.user.profile.is_adult)
 
+
     tvars = {
         'sound': sound,
         'username': username,
@@ -249,7 +250,6 @@ def sound(request, username, sound_id):
         'is_following': is_following,
         'is_explicit': is_explicit,
         'sizes': settings.IFRAME_PLAYER_SIZE,
-        'stream_uri': request.build_absolute_uri(sound.locations()['preview']['LQ']['mp3']['url']),
     }
     tvars.update(paginate(request, qs, settings.SOUND_COMMENTS_PER_PAGE))
     return render(request, 'sounds/sound.html', tvars)
@@ -789,7 +789,6 @@ def oembed(request):
         sizes = settings.IFRAME_PLAYER_SIZE['medium']
     if player_size == 'small':
         sizes = settings.IFRAME_PLAYER_SIZE['small']
-    from django.contrib.sites.models import Site
     tvars = {
         'sound': sound,
         'sizes': sizes,

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -249,6 +249,7 @@ def sound(request, username, sound_id):
         'is_following': is_following,
         'is_explicit': is_explicit,
         'sizes': settings.IFRAME_PLAYER_SIZE,
+        'stream_uri': request.build_absolute_uri(sound.locations()['preview']['LQ']['mp3']['url']),
     }
     tvars.update(paginate(request, qs, settings.SOUND_COMMENTS_PER_PAGE))
     return render(request, 'sounds/sound.html', tvars)

--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -33,6 +33,8 @@
     <meta name="twitter:player" content="{% absurl 'embed-simple-sound-iframe' sound.id "full_size" %}" />
     <meta name="twitter:player:width" content="{{ sizes.twitter_card.0 }}" />
     <meta name="twitter:player:height" content="{{ sizes.twitter_card.1 }}" />
+    <meta name="twitter:player:stream" content="{{ stream_uri }}" />
+    <meta name="twitter:player:stream:content_type" content="audio/mp4" />
 {% endblock head %}
 
 {% block section_content %}

--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -33,7 +33,7 @@
     <meta name="twitter:player" content="{% absurl 'embed-simple-sound-iframe' sound.id "full_size" %}" />
     <meta name="twitter:player:width" content="{{ sizes.twitter_card.0 }}" />
     <meta name="twitter:player:height" content="{{ sizes.twitter_card.1 }}" />
-    <meta name="twitter:player:stream" content="{{ stream_uri }}" />
+    <meta name="twitter:player:stream" content="{{ sound.get_preview_abs_url }}" />
     <meta name="twitter:player:stream:content_type" content="audio/mp4" />
 {% endblock head %}
 


### PR DESCRIPTION
Now when you access twitter from a mobile device and you click on the player it opens a browser to play the sound, with this change it doesn't open the browser and it plays the sound directly from twitter app.