### PR TITLE
Allow users to flag explicit content

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -547,6 +547,7 @@ def describe_sounds(request):
             sound = Sound()
             sound.user = request.user
             sound.original_filename = forms[i]['description'].cleaned_data['name']
+            sound.is_explicit = forms[i]['description'].cleaned_data['is_explicit']
             sound.original_path = forms[i]['sound'].full_path
             try:
                 sound.filesize = os.path.getsize(sound.original_path)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -527,7 +527,7 @@ def describe_sounds(request):
             prefix = str(i)
             forms.append({})
             forms[i]['sound'] = sounds_to_describe[i]
-            forms[i]['description'] = SoundDescriptionForm(request.POST, prefix=prefix)
+            forms[i]['description'] = SoundDescriptionForm(request.POST, prefix=prefix, explicit_disable=False)
             forms[i]['geotag'] = GeotaggingForm(request.POST, prefix=prefix)
             forms[i]['pack'] = PackForm(Pack.objects.filter(user=request.user).exclude(is_deleted=True),
                                         request.POST,

--- a/sounds/forms.py
+++ b/sounds/forms.py
@@ -60,10 +60,17 @@ class GeotaggingForm(forms.Form):
 class SoundDescriptionForm(forms.Form):
     name = forms.CharField(max_length=512, min_length=5,
                            widget=forms.TextInput(attrs={'size': 65, 'class':'inputText'}))
+    is_explicit = forms.BooleanField(required=False)
     tags = TagField(widget=forms.Textarea(attrs={'cols': 80, 'rows': 3}),
                     help_text="<br>Add at least 3 tags, separating them with spaces. Join multi-word tags with dashes. "
                               "For example: field-recording is a popular tag.")
     description = HtmlCleaningCharField(widget=forms.Textarea(attrs={'cols': 80, 'rows': 10}))
+
+    def __init__(self, explicit_disable=False, *args, **kwargs):
+        super(SoundDescriptionForm, self).__init__(*args, **kwargs)
+        # Disable is_explcit field if is already marked
+        self.initial['is_explicit'] = explicit_disable
+        self.fields['is_explicit'].disabled = explicit_disable
 
 
 class RemixForm(forms.Form):

--- a/sounds/forms.py
+++ b/sounds/forms.py
@@ -66,7 +66,12 @@ class SoundDescriptionForm(forms.Form):
                               "For example: field-recording is a popular tag.")
     description = HtmlCleaningCharField(widget=forms.Textarea(attrs={'cols': 80, 'rows': 10}))
 
-    def __init__(self, explicit_disable=False, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
+        explicit_disable = False
+        if 'explicit_disable' in kwargs:
+            explicit_disable = kwargs.get('explicit_disable')
+            del kwargs['explicit_disable']
+
         super(SoundDescriptionForm, self).__init__(*args, **kwargs)
         # Disable is_explcit field if is already marked
         self.initial['is_explicit'] = explicit_disable

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -345,7 +345,11 @@ def sound_edit(request, username, sound_id):
                                             ticket.MODERATOR_ONLY)
 
     if is_selected("description"):
-        description_form = SoundDescriptionForm(sound.is_explicit, request.POST, prefix="description")
+        description_form = SoundDescriptionForm(
+                request.POST,
+                prefix="description",
+                explicit_disable=sound.is_explicit)
+
         if description_form.is_valid():
             data = description_form.cleaned_data
             sound.is_explicit = data["is_explicit"]

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -345,9 +345,10 @@ def sound_edit(request, username, sound_id):
                                             ticket.MODERATOR_ONLY)
 
     if is_selected("description"):
-        description_form = SoundDescriptionForm(request.POST, prefix="description")
+        description_form = SoundDescriptionForm(sound.is_explicit, request.POST, prefix="description")
         if description_form.is_valid():
             data = description_form.cleaned_data
+            sound.is_explicit = data["is_explicit"]
             sound.set_tags(data["tags"])
             sound.description = remove_control_chars(data["description"])
             sound.original_filename = data["name"]
@@ -358,6 +359,7 @@ def sound_edit(request, username, sound_id):
     else:
         tags = " ".join([tagged_item.tag.name for tagged_item in sound.tags.all().order_by('tag__name')])
         description_form = SoundDescriptionForm(prefix="description",
+                                                explicit_disable=sound.is_explicit,
                                                 initial=dict(tags=tags,
                                                              description=sound.description,
                                                              name=sound.original_filename))

--- a/templates/accounts/describe_sounds.html
+++ b/templates/accounts/describe_sounds.html
@@ -258,6 +258,10 @@
                 Description:<br>
                 {{form.description.description }}
             </p>
+            <p>
+                Explicit content:
+                {{form.description.is_explicit }}
+            </p>
 
             <h3>Geotag</h3>
             <p id="gmap-header-{{forloop.counter}}">

--- a/templates/sounds/sound_edit.html
+++ b/templates/sounds/sound_edit.html
@@ -204,6 +204,10 @@
         Description:<br>
         {{description_form.description }}
     </p>
+    <p>
+        Explicit content:
+        {{description_form.is_explicit }}{% if sound.is_explicit %}(If the sound is not explicit contact the administrators){% endif %}
+    </p>
 
     <input type="submit" name="submit" value="submit" />
 </form>

--- a/templates/sounds/sound_edit.html
+++ b/templates/sounds/sound_edit.html
@@ -205,8 +205,8 @@
         {{description_form.description }}
     </p>
     <p>
-        Explicit content:
-        {{description_form.is_explicit }}{% if sound.is_explicit %}(If the sound is not explicit contact the administrators){% endif %}
+        The sound contains explicit content:
+        {{description_form.is_explicit }} {% if sound.is_explicit %}(to remove this flag, please send a <a href="{% url 'contact' %}">support request</a>){% endif %}
     </p>
 
     <input type="submit" name="submit" value="submit" />

--- a/templates/tickets/moderation_assigned.html
+++ b/templates/tickets/moderation_assigned.html
@@ -241,7 +241,7 @@
                     <form action="." method="post">{% csrf_token %}
 
                            <div id="moderation-decision-form">
-                               {{ mod_sound_form.as_table }}
+                               {{ mod_sound_form.as_p }}
                            </div>
                             <div style="clear:both;">
                            {% include 'tickets/moderation_options.html' %}

--- a/tickets/forms.py
+++ b/tickets/forms.py
@@ -80,6 +80,7 @@ class SoundModerationForm(forms.Form):
 
     ticket = forms.CharField(widget=forms.widgets.HiddenInput,
                              error_messages={'required': 'No sound selected...'})
+    is_explicit = forms.BooleanField(required=False, label='Mark as explcit content')
 
 class ModerationMessageForm(forms.Form):
     message = HtmlCleaningCharField(widget=forms.Textarea,

--- a/tickets/forms.py
+++ b/tickets/forms.py
@@ -80,7 +80,8 @@ class SoundModerationForm(forms.Form):
 
     ticket = forms.CharField(widget=forms.widgets.HiddenInput,
                              error_messages={'required': 'No sound selected...'})
-    is_explicit = forms.BooleanField(required=False, label='Mark as explcit content')
+    is_explicit = forms.BooleanField(required=False, label='Sound(s) contain explicit content')
+
 
 class ModerationMessageForm(forms.Form):
     message = HtmlCleaningCharField(widget=forms.Textarea,

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -381,10 +381,12 @@ def moderation_assigned(request, user_id):
 
             if action == "Approve":
                 tickets.update(status=TICKET_STATUS_CLOSED)
+                explicit = mod_sound_form.cleaned_data.get("is_explicit")
                 Sound.objects.filter(ticket__in=tickets).update(
                         is_index_dirty=True,
                         moderation_state='OK',
-                        moderation_date=datetime.datetime.now())
+                        moderation_date=datetime.datetime.now(),
+                        is_explicit=explicit)
                 if msg:
                     notification = Ticket.NOTIFICATION_APPROVED_BUT
                 else:


### PR DESCRIPTION
When a user uploads a sound now he/she can flag it as explicit content,
also he can modify the already uploaded sounds to flag them but it will
not be possible to unflag the sound.
Also moderators have the option to flag the content when moderating
sounds.

issue #861