### PR TITLE
Force paypal to display english interface

### DIFF
--- a/donations/views.py
+++ b/donations/views.py
@@ -102,7 +102,8 @@ def donate(request):
                         "business": settings.PAYPAL_EMAIL,
                         "item_name": "Freesound donation",
                         "custom": returned_data_str,
-                        "notify_url": return_url
+                        "notify_url": return_url,
+                        "lc": 'en_US'
                         }
                     }
 
@@ -120,6 +121,7 @@ def donate(request):
                 data['params']['no_shipping'] = 1
                 data['params']['item_name'] = 'Freesound monthly donation'
             else:
+                data['params']['no_shipping'] = 1
                 data['params']['amount'] = amount
         else:
             data = {'errors': form.errors}

--- a/donations/views.py
+++ b/donations/views.py
@@ -103,7 +103,8 @@ def donate(request):
                         "item_name": "Freesound donation",
                         "custom": returned_data_str,
                         "notify_url": return_url,
-                        "lc": 'en_US'
+                        "no_shipping": 1,
+                        "lc": "en_US"
                         }
                     }
 
@@ -118,10 +119,8 @@ def donate(request):
                 data['params']['t3'] = 'M'
                 # sra - Number of times to reattempt on failure
                 data['params']['sra'] = 1
-                data['params']['no_shipping'] = 1
                 data['params']['item_name'] = 'Freesound monthly donation'
             else:
-                data['params']['no_shipping'] = 1
                 data['params']['amount'] = amount
         else:
             data = {'errors': form.errors}


### PR DESCRIPTION
We got some messages of users telling that the form on paypal was in
spanish, this is because of the country on the seller's account.