### PR TITLE
Catch exception on profile description edit and show message

### DIFF
--- a/utils/forms.py
+++ b/utils/forms.py
@@ -39,7 +39,7 @@ class HtmlCleaningCharField(forms.CharField):
             raise forms.ValidationError('Please moderate the amount of upper case characters in your post...')
         try:
             return clean_html(value)
-        except HTMLParseError:
+        except HTMLParseError, UnicodeEncodeError:
             raise forms.ValidationError('The text you submitted is badly formed HTML, please fix it')
 
 


### PR DESCRIPTION
Sometimes we get some errors when a user changes the profile description
and BeautifulSoup can't load the text because of a problem with the
encoding. We see that this happen just 4 times this year and they all
seem like spam content.

issue #807 