### PR TITLE
Round bit rate to int and set bit depth to 0 if None

### DIFF
--- a/utils/audioprocessing/processing.py
+++ b/utils/audioprocessing/processing.py
@@ -546,8 +546,12 @@ def stereofy_and_find_info(stereofy_executble_path, input_filename, output_filen
     m = re.match(r".*#bitdepth (?P<bitdepth>\d+).*", stdout)
     if m != None:
         bitdepth = float(m.group("bitdepth"))
+    else:
+        # If there is no information of bitdepth we set it to 0
+        bitdepth = 0
 
     bitrate = (os.path.getsize(input_filename) * 8.0) / 1024.0 / duration if duration > 0 else 0
+    bitrate = int(round(bitrate))
 
     return dict(duration=duration, channels=channels, samplerate=samplerate, bitrate=bitrate, bitdepth=bitdepth)
 


### PR DESCRIPTION
As explained in issue #722 now we round the bitrate and always set bit depth to 0.

Stereofy doesn't (completely) support Adpcm but Libsndfile does support it so it could be possible to set the right bit depth if we want, but as @ffont mentioned there are just a few of this files.