### PR TITLE
Use an in-memory cache as the default cache

### DIFF
--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -93,7 +93,12 @@ USE_TZ = False
 # to load the internationalization machinery.
 USE_I18N = False
 
-#CACHE_BACKEND = 'memcached://127.0.0.1:11211/'
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    }
+}
+
 CACHE_MIDDLEWARE_SECONDS = 300
 CACHE_MIDDLEWARE_KEY_PREFIX = 'freesound'
 

--- a/sounds/tests.py
+++ b/sounds/tests.py
@@ -21,6 +21,7 @@
 from django.test import TestCase, Client
 from django.urls import reverse
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.core.management import call_command
 from django.core import mail
 from sounds.models import Sound, Pack, License, DeletedSound, SoundOfTheDay, Flag
@@ -492,6 +493,9 @@ class RandomSoundTestCase(TestCase):
 class SoundOfTheDayTestCase(TestCase):
 
     fixtures = ['sounds', 'email_preference_type']
+
+    def setUp(self):
+        cache.clear()
 
     def test_no_random_sound(self):
         # If we have no sound, return None


### PR DESCRIPTION
This is to make tests work with minimal configuration (especially on
CI/Travis). We override this setting in local_settings in the
freesound-deploy repository

Hopefully the CI tests for this PR will pass.