### PR TITLE
Revert storing multiple download objects for user/sound pair

### DIFF
--- a/sounds/views.py
+++ b/sounds/views.py
@@ -292,7 +292,7 @@ def sound_download(request, username, sound_id):
     sound = get_object_or_404(Sound, id=sound_id, moderation_state="OK", processing_state="OK")
     if sound.user.username.lower() != username.lower():
         raise Http404
-    if not Download.objects.filter(user=request.user, sound=sound).count():
+    if not Download.objects.filter(user=request.user, sound=sound).exists():
         Download.objects.create(user=request.user, sound=sound, license=sound.license)
     return sendfile(sound.locations("path"), sound.friendly_filename(), sound.locations("sendfile_url"))
 
@@ -304,7 +304,7 @@ def pack_download(request, username, pack_id):
     pack = get_object_or_404(Pack, id=pack_id)
     if pack.user.username.lower() != username.lower():
         raise Http404
-    if not Download.objects.filter(user=request.user, pack=pack).count():
+    if not Download.objects.filter(user=request.user, pack=pack).exists():
         Download.objects.create(user=request.user, pack=pack)
     licenses_url = (reverse('pack-licenses', args=[username, pack_id]))
     return download_sounds(licenses_url, pack)

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -292,7 +292,8 @@ def sound_download(request, username, sound_id):
     sound = get_object_or_404(Sound, id=sound_id, moderation_state="OK", processing_state="OK")
     if sound.user.username.lower() != username.lower():
         raise Http404
-    Download.objects.create(user=request.user, sound=sound, license=sound.license)
+    if not Download.objects.filter(user=request.user, sound=sound).count():
+        Download.objects.create(user=request.user, sound=sound, license=sound.license)
     return sendfile(sound.locations("path"), sound.friendly_filename(), sound.locations("sendfile_url"))
 
 
@@ -303,8 +304,8 @@ def pack_download(request, username, pack_id):
     pack = get_object_or_404(Pack, id=pack_id)
     if pack.user.username.lower() != username.lower():
         raise Http404
-
-    Download.objects.create(user=request.user, pack=pack)
+    if not Download.objects.filter(user=request.user, pack=pack).count():
+        Download.objects.create(user=request.user, pack=pack)
     licenses_url = (reverse('pack-licenses', args=[username, pack_id]))
     return download_sounds(licenses_url, pack)
 


### PR DESCRIPTION
Due to problems we experienced after introducing the changes in https://github.com/MTG/freesound/pull/964, we decided to rollback previous behaviour in which we only store one download object for user/sound pair. We experienced many new Download objects being created, which might be due to the use of download managers and HTTP range requests. We disable multiple download objects while we further investigate the issue.