### PR TITLE
Make solr random sounds more random

### DIFF
--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -184,7 +184,7 @@
         <br style="clear: both;">
     </div>
 
-    {% cache 3600 sound_footer_top sound.id %}
+    {% cache 3600 sound_footer_top sound.id display_random_link %}
 
 	<div id="sound_license">
         <img src="{{media_url}}images/creative_commons.png" with="95" height="23" alt="Creative Commons" />

--- a/utils/search/search_general.py
+++ b/utils/search/search_general.py
@@ -154,7 +154,7 @@ def get_random_sound_from_solr():
         docs = response.docs
         if docs:
             return docs[0]
-    except socket.error:
+    except (SolrException, socket.error):
         pass
     return {}
 

--- a/utils/search/search_general.py
+++ b/utils/search/search_general.py
@@ -20,8 +20,8 @@
 
 import logging
 import math
+import random
 import socket
-import time
 
 from django.conf import settings
 
@@ -144,7 +144,8 @@ def get_random_sound_from_solr():
     """
     solr = Solr(settings.SOLR_URL)
     query = SolrQuery()
-    sort = ['random_%d asc' % (time.time())]
+    rand_key = random.randint(1, 10000000)
+    sort = ['random_%d asc' % rand_key]
     filter_query = 'is_explicit:0'
     query.set_query("*:*")
     query.set_query_options(start=0, rows=1, field_list=["*"], filter_query=filter_query, sort=sort)


### PR DESCRIPTION
`time.time()` was giving sound ids which increased at the same rate as time, and so weren't very random. Replace with randint between 1 and 10 million.

Also fix a caching problem with the random browsing mode.