### PR TITLE
Forum search cleanups

### DIFF
--- a/search/views.py
+++ b/search/views.py
@@ -309,11 +309,16 @@ def search_forum(request):
     date_from = request.GET.get("dt_from", "")
     date_to = request.GET.get("dt_to", "")
 
-    # TEMPORAL WORKAROUND!!! to prevent using watermark as the query for forum search...
-    # It only happens in some situations.
+    invalid = False
     if "search in " in search_query:
-        invalid = 1
+        invalid = True
 
+    error = False
+    error_text = ""
+    paginator = None
+    num_results = None
+    page = None
+    results = []
     if search_query.strip() != "" or filter_query:
         # add current forum
         if current_forum_name_slug.strip() != "":
@@ -362,18 +367,35 @@ def search_forum(request):
             num_results = paginator.count
             page = paginator.page(current_page)
             error = False
-        except SolrException, e:
+        except SolrException as e:
             logger.warning("search error: query: %s error %s" % (query, e))
             error = True
             error_text = 'There was an error while searching, is your query correct?'
-        except Exception, e:
+        except Exception as e:
             logger.error("Could probably not connect to Solr - %s" % e)
             error = True
             error_text = 'The search server could not be reached, please try again later.'
-    else:
-        results = []
 
-    return render(request, 'search/search_forum.html', locals())
+    tvars = {
+        'advanced_search': advanced_search,
+        'current_forum_name': current_forum_name,
+        'current_forum_name_slug': current_forum_name_slug,
+        'current_page': current_page,
+        'date_from': date_from,
+        'date_to': date_to,
+        'error': error,
+        'error_text': error_text,
+        'filter_query': filter_query,
+        'invalid': invalid,
+        'num_results': num_results,
+        'page': page,
+        'paginator': paginator,
+        'search_query': search_query,
+        'sort': sort,
+        'results': results,
+    }
+
+    return render(request, 'search/search_forum.html', tvars)
 
 
 def get_pack_tags(pack_obj):

--- a/search/views.py
+++ b/search/views.py
@@ -314,9 +314,8 @@ def search_forum(request):
     date_from = request.GET.get("dt_from", "")
     date_to = request.GET.get("dt_to", "")
 
-    invalid = False
-    if "search in " in search_query:
-        invalid = True
+    if search_query.startswith("search in"):
+        search_query = ""
 
     error = False
     error_text = ""
@@ -390,7 +389,6 @@ def search_forum(request):
         'error': error,
         'error_text': error_text,
         'filter_query': filter_query,
-        'invalid': invalid,
         'num_results': num_results,
         'page': page,
         'paginator': paginator,

--- a/search/views.py
+++ b/search/views.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+import datetime
 import json
 import logging
 
@@ -312,7 +313,19 @@ def search_forum(request):
     # Parse advanced search options
     advanced_search = request.GET.get("advanced_search", "")
     date_from = request.GET.get("dt_from", "")
+    try:
+        df_parsed = datetime.datetime.strptime(date_from, "%Y-%m-%d")
+        date_from_display = df_parsed.strftime("%d-%m-%Y")
+    except ValueError:
+        date_from = ""
+        date_from_display = "Choose a Date"
     date_to = request.GET.get("dt_to", "")
+    try:
+        dt_parsed = datetime.datetime.strptime(date_to, "%Y-%m-%d")
+        date_to_display = dt_parsed.strftime("%d-%m-%Y")
+    except ValueError:
+        date_to = ""
+        date_to_display = "Choose a Date"
 
     if search_query.startswith("search in"):
         search_query = ""
@@ -380,12 +393,15 @@ def search_forum(request):
             error = True
             error_text = 'The search server could not be reached, please try again later.'
 
+
     tvars = {
         'advanced_search': advanced_search,
         'current_forum': current_forum,
         'current_page': current_page,
         'date_from': date_from,
+        'date_from_display': date_from_display,
         'date_to': date_to,
+        'date_to_display': date_to_display,
         'error': error,
         'error_text': error_text,
         'filter_query': filter_query,

--- a/templates/forum/_section.html
+++ b/templates/forum/_section.html
@@ -45,21 +45,6 @@
                                                       altFormat: "yy-mm-dd"
                                                       });
 
-        		// Set the date in datepicker objects (if it exists in the parameters)
-        		from_date = gup('dt_from');
-        		if (from_date !== "") {
-        			dateParts = from_date.match(/(\d+)/g);
-            		realDate = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
-            		$('#date_from_forum_search').datepicker('setDate', realDate);
-        		}
-
-        		to_date = gup('dt_to');
-        		if (to_date !== ""){
-        			dateParts = to_date.match(/(\d+)/g);
-            		realDate = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
-            		$('#date_to_forum_search').datepicker('setDate', realDate);
-        		}
-
                 $("#forum_search input[name=q]").Watermark("search in {% if current_forum %}forum '{{current_forum.name}}'{% else %}{% if forum %}forum '{{forum.name|escapejs}}'{%else%}all forums{% endif %}{% endif %}");
 
             });
@@ -86,20 +71,6 @@
         			$("#dt_to").val("");
         		}
         	}
-
-            // Util to parse url parameters
-            function gup( name )
-        	{
-        	  name = name.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
-        	  var regexS = "[\\?&]"+name+"=([^&#]*)";
-        	  var regex = new RegExp( regexS );
-        	  var results = regex.exec( window.location.href );
-        	  if( results == null )
-        	    return "";
-        	  else
-        	    return results[1];
-        	}
-
         </script>
 {% endblock head %}
 
@@ -143,13 +114,13 @@
 
 
                 <label for="date_from_forum_search">From Date:</label>
-                <input class="input_date_field" type="text" value="Choose a Date" id="date_from_forum_search" />
-                <input type="hidden" value="" name="dt_from" id="dt_from" />
+                <input class="input_date_field" type="text" value="{{ date_from_display }}" id="date_from_forum_search" />
+                <input type="hidden" value="{{ date_from }}" name="dt_from" id="dt_from" />
 				<a onclick='clearDate(0);' style="cursor:pointer">clear</a>
 
                 <label for="date_to_forum_search">To Date:</label>
-                <input class="input_date_field"  type="text" value="Choose a Date" id="date_to_forum_search" />
-                <input type="hidden" value="" name="dt_to" id="dt_to" />
+                <input class="input_date_field" type="text" value="{{ date_to_display }}" id="date_to_forum_search" />
+                <input type="hidden" value="{{ date_to }}" name="dt_to" id="dt_to" />
 				<a onclick='clearDate(1);' style="cursor:pointer">clear</a>
                 <br>
                 <span class="advanced_search_options_button"><a id="hide_advanced_search" href="">hide advanced search options</a></span>

--- a/templates/forum/_section.html
+++ b/templates/forum/_section.html
@@ -113,8 +113,7 @@
 {% block forum_search %}
 <div {% if forum or forums or hide_search %}style="display:none"{% endif %} id="forum_search" class="advanced_forum_search_options">
     <form method="get" action="{% url "forums-search" %}" onsubmit="checkEmptyDates()">
-    <input type="hidden" name="current_forum_name_slug" value="{% if forum %}{{forum.name_slug}}{% else %}{{current_forum_name_slug}}{% endif %}"/>
-    <input type="hidden" name="current_forum_name" value="{% if forum %}{{forum.name}}{% else %}{{current_forum_name}}{% endif %}"/>
+    <input type="hidden" name="forum" value="{% if forum %}{{forum.name_slug}}{% else %}{{current_forum.name_slug}}{% endif %}"/>
 
         <input type="hidden"
                name="advanced_search"

--- a/templates/forum/_section.html
+++ b/templates/forum/_section.html
@@ -8,11 +8,20 @@
                 if ($("#forum_search").length) {
                     $("#show_search").show();
                 }
+                $("#show_search").click(function(event) {
+                    event.preventDefault();
+                    $("#forum_search").toggle("medium");
+                });
+                $("#show_advanced_search").click(function(event) {
+                    event.preventDefault();
+                    showAdvancedForumSearch();
+                });
+                $("#hide_advanced_search").click(function(event) {
+                    event.preventDefault();
+                    hideAdvancedForumSearch();
+                });
             });
 
-            function showSearch() {
-                $("#forum_search").toggle("medium");
-            }
             function showAdvancedForumSearch() {
                 $("#advanced_search").val(1);
                 $("#enableShowButton").hide();
@@ -34,19 +43,19 @@
                                                       dateFormat: 'dd-mm-yy',
                                                       altField: "#dt_to",
                                                       altFormat: "yy-mm-dd"
-                                                      })
+                                                      });
 
         		// Set the date in datepicker objects (if it exists in the parameters)
-        		from_date = gup('dt_from')
-        		if ( from_date != "" ){
-        			dateParts = from_date.match(/(\d+)/g)
+        		from_date = gup('dt_from');
+        		if (from_date !== "") {
+        			dateParts = from_date.match(/(\d+)/g);
             		realDate = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
             		$('#date_from_forum_search').datepicker('setDate', realDate);
         		}
 
-        		to_date = gup('dt_to')
-        		if ( to_date != "" ){
-        			dateParts = to_date.match(/(\d+)/g)
+        		to_date = gup('dt_to');
+        		if (to_date !== ""){
+        			dateParts = to_date.match(/(\d+)/g);
             		realDate = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
             		$('#date_to_forum_search').datepicker('setDate', realDate);
         		}
@@ -58,23 +67,23 @@
             function checkEmptyDates()
         	{
         		if ( $("#date_from_forum_search").val() == "" ){
-        			$("#dt_from").val("")
+        			$("#dt_from").val("");
         		}
 
         		if ( $("#date_to_forum_search").val() == "" ){
-        			$("#dt_to").val("")
+        			$("#dt_to").val("");
         		}
         	}
 
         	function clearDate(date)
         	{
-        		if (date == 0){
-        			$("#date_from_forum_search").val("Choose a Date")
-        			$("#dt_from").val("")
+        		if (date === 0){
+        			$("#date_from_forum_search").val("Choose a Date");
+        			$("#dt_from").val("");
         		}
-        		else if (date==1){
-        			$("#date_to_forum_search").val("Choose a Date")
-        			$("#dt_to").val("")
+        		else if (date === 1){
+        			$("#date_to_forum_search").val("Choose a Date");
+        			$("#dt_to").val("");
         		}
         	}
 
@@ -105,7 +114,7 @@
     <div id="breadcrumb_inner">
         <a href="{% url "forums-forums" %}">Freesound Forums</a> {% block breadcrumb %}{% endblock %}
     </div>
-    <a id="show_search" style="display:none;" onclick="showSearch()" ><span class="forum_search_button">search in the forum</span></a>
+    <a id="show_search" style="display:none;"><span class="forum_search_button">search in the forum</span></a>
     <br style="clear: both;" />
 
 </div>
@@ -136,14 +145,14 @@
                 <label for="date_from_forum_search">From Date:</label>
                 <input class="input_date_field" type="text" value="Choose a Date" id="date_from_forum_search" />
                 <input type="hidden" value="" name="dt_from" id="dt_from" />
-				<a onclick='clearDate(0);'>clear</a>
+				<a onclick='clearDate(0);' style="cursor:pointer">clear</a>
 
                 <label for="date_to_forum_search">To Date:</label>
                 <input class="input_date_field"  type="text" value="Choose a Date" id="date_to_forum_search" />
                 <input type="hidden" value="" name="dt_to" id="dt_to" />
-				<a onclick='clearDate(1);'>clear</a>
+				<a onclick='clearDate(1);' style="cursor:pointer">clear</a>
                 <br>
-                <span class="advanced_search_options_button"><a onclick='hideAdvancedForumSearch();'>hide advanced search options</a></span>
+                <span class="advanced_search_options_button"><a id="hide_advanced_search" href="">hide advanced search options</a></span>
             </div>
 
 
@@ -152,7 +161,7 @@
                   {% if advanced_search == "1" %}style="display:none"{% endif%}>
 
                 <div style="margin-top:4px;"></div>
-                <a onclick='showAdvancedForumSearch();'>show advanced search options</a>
+                <a id="show_advanced_search" href="">show advanced search options</a>
             </span>
 
         </fieldset>

--- a/templates/forum/_section.html
+++ b/templates/forum/_section.html
@@ -51,7 +51,7 @@
             		$('#date_to_forum_search').datepicker('setDate', realDate);
         		}
 
-                $("#forum_search input[name=q]").Watermark("search in {% if current_forum_name %}forum '{{current_forum_name}}'{% else %}{% if forum %}'forum {{forum.name|escapejs}}'{%else%}all forums{% endif %} {% endif %}");
+                $("#forum_search input[name=q]").Watermark("search in {% if current_forum %}forum '{{current_forum.name}}'{% else %}{% if forum %}forum '{{forum.name|escapejs}}'{%else%}all forums{% endif %}{% endif %}");
 
             });
 
@@ -125,7 +125,7 @@
             <input type="text"
             	   id="forum_search_box"
                    name="q"
-                   value="{% if not invalid %}{% if request.GET.q %}{{request.GET.q}}{% endif %}{% endif %}"
+                   value="{{search_query}}"
                    size="60" />
 
             <input type="submit" value="search!" id="search_submit" />

--- a/templates/search/search_forum.html
+++ b/templates/search/search_forum.html
@@ -8,11 +8,9 @@
 {% block title %}Forum Search{% endblock title %}
 
 {% block breadcrumb %}
-    {% if current_forum_name_slug and current_forum_name_slug.strip %}
-        {% url "forums-forum" current_forum_name_slug as forum_url %}
-        {% if forum_url %}
-            &#187; <a href="{{forum_url}}">{{current_forum_name}}</a>
-        {% endif %}
+    {% if current_forum %}
+        {% url "forums-forum" current_forum.name_slug as forum_url %}
+        &#187; <a href="{{forum_url}}">{{current_forum.name}}</a>
     {% endif %}
 {%  endblock %}
 


### PR DESCRIPTION
The root of these changes fixes #712

The core issue is that none of the parameters given to this view were validated before they were used. Now, instead of sending two parameters for the forum slug and forum name, we send a single parameter which is used to look up the forum in the database, returning 404 if this forum doesn't exist.

I also added validation to the date parameters, which wasn't done previously.

Additionally, some small cleanups to javascript and layout of the views. There was more JS stuff that I wanted to look at, but I pragmatically skipped this because of major changes that we'll be making in the future :)