### PR TITLE
Move generation links of paginated pages outside templates

### DIFF
--- a/general/templatetags/paginator.py
+++ b/general/templatetags/paginator.py
@@ -48,13 +48,22 @@ def show_paginator(context, paginator, page, current_page, request, anchor="", n
 
     # although paginator objects are 0-based, we use 1-based paging
     page_numbers = [n for n in range(min_page_num, max_page_num) if n > 0 and n <= paginator.num_pages]
-    
+
     params = urllib.urlencode([(key, value.encode('utf-8')) for (key, value) in request.GET.items() if key.lower() != u"page"])
-    
+
     if params == "":
         url = request.path + u"?page="
     else:
         url = request.path + u"?" + params + u"&page="
+
+    url_prev_page = None
+    if page.has_previous():
+        url_prev_page = url + str(page.previous_page_number())
+    url_next_page = None
+    if page.has_next():
+        url_next_page = url + str(page.next_page_number())
+    url_first_page = url + "1"
+    url_last_page = url + str(paginator.num_pages)
 
     return {
         "page": page,
@@ -64,6 +73,10 @@ def show_paginator(context, paginator, page, current_page, request, anchor="", n
         "show_first": 1 not in page_numbers,
         "show_last": paginator.num_pages not in page_numbers,
         "url" : url,
+        "url_prev_page": url_prev_page,
+        "url_next_page": url_next_page,
+        "url_first_page": url_first_page,
+        "url_last_page": url_last_page,
         "media_url": context['media_url'],
         "anchor": anchor,
         "non_grouped_number_of_results": non_grouped_number_of_results

--- a/general/templatetags/paginator.py
+++ b/general/templatetags/paginator.py
@@ -56,9 +56,8 @@ def show_paginator(context, paginator, page, current_page, request, anchor="", n
     else:
         url = request.path + u"?" + params + u"&page="
 
-    url_last_page = None
-
-    # Page could be a dict or an object
+    # The pagination could be over a queryset or over the result of a query to solr, so 'page' could be an object
+    # if it's the case a query to the DB or a dict if it's the case of a query to solr
     if isinstance(page, dict):
         url_prev_page = url + str(page['previous_page_number'])
         url_next_page =  url + str(page['next_page_number'])
@@ -71,7 +70,7 @@ def show_paginator(context, paginator, page, current_page, request, anchor="", n
         if page.has_next():
              url_next_page = url + str(page.next_page_number())
         url_first_page = url + '1'
-        url_last_page = url + str(paginator.num_pages)
+    url_last_page = url + str(paginator.num_pages)
 
     return {
         "page": page,

--- a/general/templatetags/paginator.py
+++ b/general/templatetags/paginator.py
@@ -56,14 +56,22 @@ def show_paginator(context, paginator, page, current_page, request, anchor="", n
     else:
         url = request.path + u"?" + params + u"&page="
 
-    url_prev_page = None
-    if page.has_previous():
-        url_prev_page = url + str(page.previous_page_number())
-    url_next_page = None
-    if page.has_next():
-        url_next_page = url + str(page.next_page_number())
-    url_first_page = url + "1"
-    url_last_page = url + str(paginator.num_pages)
+    url_last_page = None
+
+    # Page could be a dict or an object
+    if isinstance(page, dict):
+        url_prev_page = url + str(page['previous_page_number'])
+        url_next_page =  url + str(page['next_page_number'])
+        url_first_page = url + '1'
+    else:
+        url_prev_page = None
+        if page.has_previous():
+             url_prev_page = url + str(page.previous_page_number())
+        url_next_page = None
+        if page.has_next():
+             url_next_page = url + str(page.next_page_number())
+        url_first_page = url + '1'
+        url_last_page = url + str(paginator.num_pages)
 
     return {
         "page": page,

--- a/templates/templatetags/paginator.html
+++ b/templates/templatetags/paginator.html
@@ -4,20 +4,20 @@
 	{% if page.has_other_pages %}
 	
 		{% if page.has_previous %}
-			<li class="previous-page"><a href="{{ url }}{{ page.previous_page_number }}{% if anchor %}#{{anchor}}{% endif %}" title="Previous Page">previous</a></li>
+			<li class="previous-page"><a href="{{ url_prev_page }}{% if anchor %}#{{anchor}}{% endif %}" title="Previous Page">previous</a></li>
 		{% else %}
 			<li class="disabled-previous-next">previous</li>
 		{% endif %}
 		
 		{% if page.has_next %}
-			<li class="next-page"><a href="{{ url }}{{ page.next_page_number }}{% if anchor %}#{{anchor}}{% endif %}" title="Next Page">next</a></li>
+			<li class="next-page"><a href="{{ url_next_page }}{% if anchor %}#{{anchor}}{% endif %}" title="Next Page">next</a></li>
 		{% else %}
 			<li class="disabled-previous-next"><span style="color:#888">next</span></li>
 		{% endif %}
 		
 		
 		{% if show_first %}
-			<li class="first-page"><a href="{{ url }}1{% if anchor %}#{{anchor}}{% endif %}" title="First Page">1</a></li>
+			<li class="first-page"><a href="{{ url_first_page }}{% if anchor %}#{{anchor}}{% endif %}" title="First Page">1</a></li>
 			<li class="dots">...</li>
 		{% endif %}
 		
@@ -31,7 +31,7 @@
 		
 		{% if show_last %}
 			<li class="dots">...</li>
-			<li class="last-page"><a href="{{ url }}{{ paginator.num_pages }}{% if anchor %}#{{anchor}}{% endif %}" title="Last Page">{{paginator.num_pages}}</a></li>
+			<li class="last-page"><a href="{{ url_last_page }}{% if anchor %}#{{anchor}}{% endif %}" title="Last Page">{{paginator.num_pages}}</a></li>
 		{% endif %}
 
 


### PR DESCRIPTION
issue #710

Now the links to the first/last/next/last page are generated from python
code and passed to the templates using the context.