### PR TITLE
Use modern exception handling syntax

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -204,9 +204,9 @@ class Profile(SocialModel):
 
             try:
                 results = SolrResponseInterpreter(solr.select(unicode(query)))
-            except SolrException, e:
+            except SolrException as e:
                 return False
-            except Exception, e:
+            except Exception as e:
                 return False
 
             return [{'name': tag, 'count': count} for tag, count in results.facets['tag']]

--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -187,7 +187,7 @@ def api_search(search_form, target_file=None, extra_parameters=False, merging_st
 
             gaia_count = count
             return gaia_ids, gaia_count, distance_to_target_data, None, note, None, None
-        except SimilarityException, e:
+        except SimilarityException as e:
             if e.status_code == 500:
                 raise ServerErrorException(msg=e.message, resource=resource)
             elif e.status_code == 400:
@@ -196,7 +196,7 @@ def api_search(search_form, target_file=None, extra_parameters=False, merging_st
                 raise NotFoundException(msg=e.message, resource=resource)
             else:
                 raise ServerErrorException(msg='Similarity server error: %s' % e.message, resource=resource)
-        except Exception, e:
+        except Exception as e:
             raise ServerErrorException(msg='The similarity server could not be reached or some unexpected error occurred.', resource=resource)
 
 
@@ -223,11 +223,11 @@ def api_search(search_form, target_file=None, extra_parameters=False, merging_st
 
             return solr_ids, solr_count, None, more_from_pack_data, None, None, None
 
-        except SolrException, e:
+        except SolrException as e:
             if search_form.cleaned_data['filter'] != None:
                 raise BadRequestException(msg='Search server error: %s (please check that your filter syntax and field names are correct)' % e.message, resource=resource)
             raise BadRequestException(msg='Search server error: %s' % e.message, resource=resource)
-        except Exception, e:
+        except Exception as e:
             raise ServerErrorException(msg='The search server could not be reached or some unexpected error occurred.', resource=resource)
 
     else:
@@ -311,7 +311,7 @@ def prepend_base(rel, dynamic_resolve=True, use_https=False, request_is_secure=F
             url_name = resolve(rel.replace('<sound_id>', '1').replace('<username', 'name').replace('<pack_id>', '1').replace('<category_id>', '1')).url_name
             if url_name in settings.APIV2_RESOURCES_REQUIRING_HTTPS:
                 use_https = True
-        except Exception, e:
+        except Exception as e:
             pass
 
     if use_https:

--- a/apiv2/combined_search_strategies.py
+++ b/apiv2/combined_search_strategies.py
@@ -297,7 +297,7 @@ def get_gaia_results(search_form, target_file, page_size, max_pages, start_page=
             current_page += 1
             n_page_requests += 1
 
-    except SimilarityException, e:
+    except SimilarityException as e:
         if e.status_code == 500:
             raise ServerErrorException(msg=e.message)
         elif e.status_code == 400:
@@ -306,7 +306,7 @@ def get_gaia_results(search_form, target_file, page_size, max_pages, start_page=
             raise NotFoundException(msg=e.message)
         else:
             raise ServerErrorException(msg='Similarity server error: %s' % e.message)
-    except Exception, e:
+    except Exception as e:
         raise ServerErrorException(msg='The similarity server could not be reached or some unexpected error occurred.')
 
     return gaia_ids, gaia_count, distance_to_target_data, note
@@ -349,9 +349,9 @@ def get_solr_results(search_form, page_size, max_pages, start_page=1, valid_ids=
             current_page += 1
             n_page_requests += 1
 
-    except SolrException, e:
+    except SolrException as e:
         raise ServerErrorException(msg='Search server error: %s' % e.message)
-    except Exception, e:
+    except Exception as e:
         raise ServerErrorException(msg='The search server could not be reached or some unexpected error occurred.')
 
     return solr_ids, solr_count

--- a/apiv2/management/commands/basic_api_tests.py
+++ b/apiv2/management/commands/basic_api_tests.py
@@ -121,7 +121,7 @@ class Command(BaseCommand):
                                 else:
                                     print 'FAIL! (%i)' % r.status_code
                                     failed.append((prepended_url, r.status_code))
-                            except Exception, e:
+                            except Exception as e:
                                 print 'ERROR (%s)' % str(e)
                                 error.append(prepended_url)
 

--- a/apiv2/serializers.py
+++ b/apiv2/serializers.py
@@ -251,7 +251,7 @@ class SoundListSerializer(AbstractSoundSerializer):
         # Get descriptors from the view class (should have been requested before the serializer is invoked)
         try:
             return self.context['view'].sound_analysis_data[str(obj.id)]
-        except Exception, e:
+        except Exception as e:
             return None
 
 
@@ -274,7 +274,7 @@ class SoundSerializer(AbstractSoundSerializer):
                                               only_leaf_descriptors=True)[str(obj.id)]
             else:
                 return 'No descriptors specified. You should indicate which descriptors you want with the \'descriptors\' request parameter.'
-        except Exception, e:
+        except Exception as e:
             return None
 
 

--- a/apiv2/views.py
+++ b/apiv2/views.py
@@ -95,9 +95,9 @@ class TextSearch(GenericAPIView):
         # Get search results
         try:
             results, count, distance_to_target_data, more_from_pack_data, note, params_for_next_page, debug_note = api_search(search_form, resource=self)
-        except APIException, e:
+        except APIException as e:
             raise e
-        except Exception, e:
+        except Exception as e:
             raise ServerErrorException(msg='Unexpected error', resource=self)
 
         # Paginate results
@@ -169,9 +169,9 @@ class ContentSearch(GenericAPIView):
             analysis_file = self.analysis_file.read()
         try:
             results, count, distance_to_target_data, more_from_pack_data, note, params_for_next_page, debug_note = api_search(search_form, target_file=analysis_file, resource=self)
-        except APIException, e:
+        except APIException as e:
             raise e # TODO pass correct exception message
-        except Exception, e:
+        except Exception as e:
             #logger_error.error('<500 Server error unexpected> %s' % str(e))
             raise ServerErrorException(msg='Unexpected error', resource=self)
 
@@ -274,9 +274,9 @@ class CombinedSearch(GenericAPIView):
                              extra_parameters=extra_parameters,
                              merging_strategy=self.merging_strategy,
                              resource=self)
-        except APIException, e:
+        except APIException as e:
             raise e # TODO pass correct resource parameter
-        except Exception, e:
+        except Exception as e:
             #logger_error.error('<500 Server error unexpected> %s' % str(e))
             raise ServerErrorException(msg='Unexpected error', resource=self)
 
@@ -776,9 +776,9 @@ class UploadSound(WriteRequiredGenericAPIView):
                                 msg = "Server error."
                             raise ServerErrorException(msg=msg, resource=self)
 
-                    except APIException, e:
+                    except APIException as e:
                         raise e # TODO pass correct resource variable
-                    except Exception, e:
+                    except Exception as e:
                         raise ServerErrorException(msg='Unexpected error', resource=self)
 
                     return Response(data={'detail': 'Audio file successfully uploaded and described (now pending processing and moderation).', 'id': int(sound.id) }, status=status.HTTP_201_CREATED)
@@ -1097,7 +1097,7 @@ class AvailableAudioDescriptors(GenericAPIView):
                 descriptor_names[key] = [item[1:] for item in value] #  remove initial dot from descriptor names
 
             return Response({'fixed-length':{'one-dimensional':descriptor_names['fixed-length'], 'multi-dimensional':descriptor_names['multidimensional']}, 'variable-length':descriptor_names['variable-length']}, status=status.HTTP_200_OK)
-        except Exception, e:
+        except Exception as e:
             raise ServerErrorException(resource=self)
 
 

--- a/follow/management/commands/send_stream_emails.py
+++ b/follow/management/commands/send_stream_emails.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
             user = User.objects.get(username=username)
             try:
                 users_sounds, tags_sounds = follow_utils.get_stream_sounds(user, time_lapse)
-            except Exception, e:
+            except Exception as e:
                 # If error occur do not send the email
                 print "could not get new sounds data for", username.encode('utf-8')
                 profile.save()  # Save last_attempt_of_sending_stream_email
@@ -98,7 +98,7 @@ class Command(BaseCommand):
             try:
                 send_mail(subject_str, text_content, email_from=settings.DEFAULT_FROM_EMAIL, email_to=[email_to],
                           reply_to=None)
-            except Exception, e:
+            except Exception as e:
                 logger.info("An error occurred sending notification stream email to %s (%s)" % (str(email_to), str(e)))
                 # Do not send the email and do not update the last email sent field in the profile
                 profile.save()  # Save last_attempt_of_sending_stream_email

--- a/general/management/commands/similarity_update.py
+++ b/general/management/commands/similarity_update.py
@@ -111,7 +111,7 @@ class Command(BaseCommand):
                 #    else:
                 #        Similarity.save()
 
-            except Exception, e:
+            except Exception as e:
                 if not options['indexing_server']:
                     sound.set_similarity_state('FA')
                 print 'Sound could not be added (id: %i, %i of %i): \n\t%s' % (sound.id, count+1, N ,str(e))

--- a/search/views.py
+++ b/search/views.py
@@ -280,10 +280,10 @@ def search(request):
             'non_grouped_number_of_results': non_grouped_number_of_results,
         })
 
-    except SolrException, e:
+    except SolrException as e:
         logger.warning('Search error: query: %s error %s' % (query, e))
         tvars.update({'error_text': 'There was an error while searching, is your query correct?'})
-    except Exception, e:
+    except Exception as e:
         logger.error('Could probably not connect to Solr - %s' % e)
         tvars.update({'error_text': 'The search server could not be reached, please try again later.'})
 
@@ -362,11 +362,11 @@ def search_forum(request):
             num_results = paginator.count
             page = paginator.page(current_page)
             error = False
-        except SolrException, e:
+        except SolrException as e:
             logger.warning("search error: query: %s error %s" % (query, e))
             error = True
             error_text = 'There was an error while searching, is your query correct?'
-        except Exception, e:
+        except Exception as e:
             logger.error("Could probably not connect to Solr - %s" % e)
             error = True
             error_text = 'The search server could not be reached, please try again later.'

--- a/similarity/gaia_wrapper.py
+++ b/similarity/gaia_wrapper.py
@@ -200,7 +200,7 @@ class GaiaWrapper:
                     msg = 'Added point with name %s. Index has now %i points (pca index has %i points).' % (str(point_name), self.original_dataset.size(), self.pca_dataset.size())
                     logger.info(msg)
 
-            except Exception, e:
+            except Exception as e:
                 msg = 'Point with name %s could NOT be added (%s).' % (str(point_name), str(e))
                 logger.info(msg)
                 return {'error': True, 'result': msg, 'status_code': SERVER_ERROR_CODE}
@@ -483,7 +483,7 @@ class GaiaWrapper:
                         query = self.original_dataset.history().mapPoint(p)  # map point to original dataset
                     target_file_parsing_type = 'mapPoint'
 
-                except Exception, e:
+                except Exception as e:
                     logger.info('Unable to create gaia point from uploaded file (%s). Trying adding descriptors one by one.' % e)
 
                     # If does not work load descriptors one by one
@@ -524,7 +524,7 @@ class GaiaWrapper:
 
                         target_file_parsing_type = 'walkDict'
 
-                    except Exception, e:
+                    except Exception as e:
                         logger.info('Unable to create gaia point from uploaded file and adding descriptors one by one (%s)' % e)
                         return {'error': True, 'result': 'Unable to create gaia point from uploaded file. Probably the file does not have the required layout. Are you using the correct version of Essentia\'s Freesound extractor?', 'status_code': SERVER_ERROR_CODE}
         else:
@@ -577,7 +577,7 @@ class GaiaWrapper:
                     search = self.view.nnSearch(query, metric, str(filter))
             results = search.get(num_results, offset=offset)
             count = search.size()
-        except Exception, e:
+        except Exception as e:
             return {'error': True, 'result': 'Similarity server error', 'status_code': SERVER_ERROR_CODE}
 
         note = None

--- a/similarity/similarity_server.py
+++ b/similarity/similarity_server.py
@@ -160,7 +160,7 @@ class SimilarityServer(resource.Resource):
                             return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
                     if not target.items():
                         return json.dumps({'error': True, 'result': 'Invalid target.', 'status_code': BAD_REQUEST_CODE})
-                except Exception, e:
+                except Exception as e:
                     return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
             elif target_type == 'file':
                 data = request.content.getvalue().split('&')[0]  # If more than one file attached, just get the first one
@@ -181,7 +181,7 @@ class SimilarityServer(resource.Resource):
                         return json.dumps({'error': True, 'result': filter, 'status_code': BAD_REQUEST_CODE})
                     else:
                         return json.dumps({'error': True, 'result': 'Invalid filter.', 'status_code': BAD_REQUEST_CODE})
-            except Exception, e:
+            except Exception as e:
                 return json.dumps({'error': True, 'result': 'Invalid filter.', 'status_code': BAD_REQUEST_CODE})
 
         '''

--- a/sounds/forms.py
+++ b/sounds/forms.py
@@ -118,7 +118,7 @@ class RemixForm(forms.Form):
                 )
             except Sound.DoesNotExist:
                 pass
-            except Exception, e:
+            except Exception as e:
                 # Report any other type of exception and fail silently
                 print ("Problem removing source from remix or sending mail: %s" % e)
 
@@ -131,7 +131,7 @@ class RemixForm(forms.Form):
                     {'source': source, 'action': 'added', 'remix': self.sound},
                     None, source.user.email
                 )
-            except Exception, e:
+            except Exception as e:
                 # Report any exception but fail silently
                 print ("Problem sending mail about source added to remix: %s" % e)
 

--- a/sounds/management.py
+++ b/sounds/management.py
@@ -38,7 +38,7 @@ def create_locations(sender, **kwargs):
             try:
                 os.mkdir(folder)
                 print ("Successfullly created the folder: '%s'" % folder)
-            except Exception, e:
+            except Exception as e:
                 print ("Problem creating this folder: '%s', %s"
                     % (folder, e))
         else:

--- a/sounds/management/commands/csv_bulk_upload.py
+++ b/sounds/management/commands/csv_bulk_upload.py
@@ -147,7 +147,7 @@ class Command(BaseCommand):
                 # Process
                 try:
                     sound.process()
-                except Exception, e:
+                except Exception as e:
                     print 'Sound with id %s could not be scheduled. (%s)' % (sound.id, str(e))
 
                 if sound.pack:

--- a/sounds/management/commands/gm_worker_processing.py
+++ b/sounds/management/commands/gm_worker_processing.py
@@ -104,7 +104,7 @@ class Command(BaseCommand):
             self.write_stdout("Found pack with id %d\n" % pack.id)
             pack.create_zip()
             self.write_stdout("Finished creating zip")
-        except Exception, e:
+        except Exception as e:
             self.write_stdout("ERROR in zip creation: % \n"%str(e))
         return 'true'
     
@@ -146,7 +146,7 @@ class Command(BaseCommand):
             self.write_stdout("\t did not find sound with id: %s\n" % sound_id)
             success = False
             return 'false'
-        except Exception, e:
+        except Exception as e:
             self.write_stdout("\t something went terribly wrong: %s\n" % e)
             self.write_stdout("\t%s\n" % traceback.format_exc())
             success = False

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -243,7 +243,7 @@ def sound(request, username, sound_id):
                             send_mail_template(u'You have a new comment.', 'sounds/email_new_comment.txt',
                                                {'sound': sound, 'user': request.user, 'comment': comment_text},
                                                None, sound.user.email)
-                    except Exception, e:
+                    except Exception as e:
                         # If the email sending fails, ignore...
                         logger.error("Problem sending email to '%s' about new comment: %s" % (request.user.email, e))
 

--- a/tagrecommendation/recommendationDataProcessor/__init__.py
+++ b/tagrecommendation/recommendationDataProcessor/__init__.py
@@ -285,7 +285,7 @@ class RecommendationDataProcessor:
         instances_ids = resources_tags.keys()
         try:
             resource_class = loadFromJson(RECOMMENDATION_DATA_DIR + 'Classifier_classified_resources.json')
-        except Exception, e:
+        except Exception as e:
             resource_class = dict()
 
         for count, id in enumerate(instances_ids):

--- a/tagrecommendation/tagrecommendation_server.py
+++ b/tagrecommendation/tagrecommendation_server.py
@@ -68,7 +68,7 @@ class TagRecommendationServer(resource.Resource):
         try:
             self.index_stats = loadFromJson(RECOMMENDATION_DATA_DIR + 'Current_index_stats.json')
             logger.info("Matrices computed out of information from %i sounds" % self.index_stats['n_sounds_in_matrix'])
-        except Exception, e:
+        except Exception as e:
             print(e)
             self.index_stats = {
                 'n_sounds_in_matrix': 0,
@@ -78,7 +78,7 @@ class TagRecommendationServer(resource.Resource):
             self.index = loadFromJson(RECOMMENDATION_DATA_DIR + 'Index.json')
             self.index_stats['biggest_id_in_index'] = max([int(key) for key in self.index.keys()])
             self.index_stats['n_sounds_in_index'] = len(self.index.keys())
-        except Exception, e:
+        except Exception as e:
             logger.info("Index file not present. Listening for indexing data from appservers.")
             self.index_stats['biggest_id_in_index'] = 0
             self.index_stats['n_sounds_in_index'] = 0
@@ -104,7 +104,7 @@ class TagRecommendationServer(resource.Resource):
                                                                   max_number_of_tags=max_number_of_tags)
             result = {'error': False, 'result': {'tags': recommended_tags, 'community': com_name}}
 
-        except Exception, e:
+        except Exception as e:
             logger.debug('Errors occurred while recommending tags to %s' % input_tags)
             result = {'error': True, 'result': str(e)}
 

--- a/tags/views.py
+++ b/tags/views.py
@@ -87,7 +87,7 @@ def tags(request, multiple_tags=None):
         for d in docs:
             d["sound"] = allsounds[d["id"]]
 
-    except SolrException, e:
+    except SolrException as e:
         error = True
         search_logger.error("SOLR ERROR - %s" % e)
     except :
@@ -112,7 +112,7 @@ def old_tag_link_redirect(request):
         tags = fs1tag_id.split('_')
         try:
             fs1tags = FS1Tag.objects.filter(fs1_id__in=tags).values_list('tag', flat=True)
-        except ValueError, e:
+        except ValueError as e:
             raise Http404
 
         tags = Tag.objects.filter(id__in=fs1tags).values_list('name', flat=True)

--- a/utils/audioprocessing/convert_to_wav.py
+++ b/utils/audioprocessing/convert_to_wav.py
@@ -29,5 +29,5 @@ try:
     info = audio_info(sys.argv[2])
     if not ( info["bits"] == 16 and info["samplerate"] == 44100 and info["channels"] == 2 and info["duration"] > 0 ):
         print "warning, created file is not 44.1, stereo, 16bit!"
-except AudioProcessingException, e:
+except AudioProcessingException as e:
     print "warning, audio processing seems to have failed:", e

--- a/utils/audioprocessing/essentia_analysis.py
+++ b/utils/audioprocessing/essentia_analysis.py
@@ -67,8 +67,8 @@ def analyze(sound):
                 signal.alarm(FFMPEG_TIMEOUT)
                 p.wait()
                 signal.alarm(0)
-            except Exception, e:
-                failure("ffmpeg conversion failed ",e)
+            except Exception as e:
+                failure("ffmpeg conversion failed ", e)
                 return False
             input_path = tmp_wav_path
         tmp_ana_path = '/tmp/analysis_%s' % sound.id
@@ -83,8 +83,8 @@ def analyze(sound):
                 output_std, output_err = p.communicate()
                 failure( "Essentia extractor returned an error (%s) stdout:%s stderr: %s"%(p_result, output_std, output_err))
                 return False
-        except Exception, e:
-            failure("Essentia extractor failed ",e)
+        except Exception as e:
+            failure("Essentia extractor failed ", e)
             return False
 
         __create_dir(statistics_path)
@@ -94,8 +94,8 @@ def analyze(sound):
         #os.remove('%s.json' % tmp_ana_path)  # Current extractor does not produce the json file
         sound.set_analysis_state('OK')
         sound.set_similarity_state('PE')  # So sound gets reindexed in gaia
-    except Exception, e:
-        failure("Unexpected error in analysis ",e)
+    except Exception as e:
+        failure("Unexpected error in analysis ", e)
         return False
     finally:
         if tmp_conv:

--- a/utils/audioprocessing/extract_info.py
+++ b/utils/audioprocessing/extract_info.py
@@ -26,5 +26,5 @@ from processing import stereofy_and_find_info, AudioProcessingException
 try:
     for (k,v) in stereofy_and_find_info("/Users/bram/Development/nightingale/sandbox/legacy/stereofy/stereofy", sys.argv[1], '/dev/null').items():
         print k,"->", v
-except AudioProcessingException, e:
+except AudioProcessingException as e:
     print "warning, audio information extraction seems to have failed:", e

--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -101,16 +101,16 @@ def process(sound):
         else:
             to_cleanup.append(tmp_wavefile)
             success("converted to pcm: " + tmp_wavefile)
-    except AudioProcessingException, e:
+    except AudioProcessingException as e:
         failure("conversion to pcm has failed, trying ffmpeg", e)
         try:
             audioprocessing.convert_using_ffmpeg(sound.original_path, tmp_wavefile)
             to_cleanup.append(tmp_wavefile)
             success("converted to pcm: " + tmp_wavefile)
-        except AudioProcessingException, e:
+        except AudioProcessingException as e:
             failure("conversion to pcm with ffmpeg failed", e)
             return False
-    except Exception, e:
+    except Exception as e:
         failure("unhandled exception", e)
         cleanup(to_cleanup)
         return False
@@ -120,18 +120,18 @@ def process(sound):
     try:
         info = audioprocessing.stereofy_and_find_info(settings.STEREOFY_PATH, tmp_wavefile, tmp_wavefile2)
         to_cleanup.append(tmp_wavefile2)
-    except AudioProcessingException, e:
+    except AudioProcessingException as e:
         failure("stereofy has failed, trying ffmpeg first", e)
         try:
             audioprocessing.convert_using_ffmpeg(sound.original_path, tmp_wavefile)
             info = audioprocessing.stereofy_and_find_info(settings.STEREOFY_PATH, tmp_wavefile, tmp_wavefile2)
             #if tmp_wavefile not in to_cleanup: to_cleanup.append(tmp_wavefile)
             to_cleanup.append(tmp_wavefile2)
-        except AudioProcessingException, e:
+        except AudioProcessingException as e:
             failure("ffmpeg + stereofy failed", e)
             cleanup(to_cleanup)
             return False
-    except Exception, e:
+    except Exception as e:
         failure("unhandled exception", e)
         cleanup(to_cleanup)
         return False
@@ -142,7 +142,7 @@ def process(sound):
 
     try:
         sound.set_audio_info_fields(info)
-    except Exception, e:  # Could not catch a more specific exception
+    except Exception as e:  # Could not catch a more specific exception
         failure("failed writting audio info fields to db", e)
 
     for mp3_path, quality in [(sound.locations("preview.LQ.mp3.path"),70), (sound.locations("preview.HQ.mp3.path"), 192)]:
@@ -154,11 +154,11 @@ def process(sound):
 
         try:
             audioprocessing.convert_to_mp3(tmp_wavefile2, mp3_path, quality)
-        except AudioProcessingException, e:
+        except AudioProcessingException as e:
             cleanup(to_cleanup)
             failure("conversion to mp3 (preview) has failed", e)
             return False
-        except Exception, e:
+        except Exception as e:
             failure("unhandled exception", e)
             cleanup(to_cleanup)
             return False
@@ -173,11 +173,11 @@ def process(sound):
 
         try:
             audioprocessing.convert_to_ogg(tmp_wavefile2, ogg_path, quality)
-        except AudioProcessingException, e:
+        except AudioProcessingException as e:
             cleanup(to_cleanup)
             failure("conversion to ogg (preview) has failed", e)
             return False
-        except Exception, e:
+        except Exception as e:
             failure("unhandled exception", e)
             cleanup(to_cleanup)
             return False
@@ -194,11 +194,11 @@ def process(sound):
 
     try:
         audioprocessing.create_wave_images(tmp_wavefile2, waveform_path_m, spectral_path_m, 120, 71, 2048)
-    except AudioProcessingException, e:
+    except AudioProcessingException as e:
         cleanup(to_cleanup)
         failure("creation of images (M) has failed", e)
         return False
-    except Exception, e:
+    except Exception as e:
         failure("unhandled exception", e)
         cleanup(to_cleanup)
         return False
@@ -209,11 +209,11 @@ def process(sound):
     spectral_path_l = sound.locations("display.spectral.L.path")
     try:
         audioprocessing.create_wave_images(tmp_wavefile2, waveform_path_l, spectral_path_l, 900, 201, 2048)
-    except AudioProcessingException, e:
+    except AudioProcessingException as e:
         cleanup(to_cleanup)
         failure("creation of images (L) has failed", e)
         return False
-    except Exception, e:
+    except Exception as e:
         failure("unhandled exception", e)
         cleanup(to_cleanup)
         return False

--- a/utils/audioprocessing/wav2png.py
+++ b/utils/audioprocessing/wav2png.py
@@ -60,7 +60,7 @@ for input_file in args:
     if not options.profile:
         try:
             create_wave_images(*args)
-        except AudioProcessingException, e:
+        except AudioProcessingException as e:
             print "Error running wav2png: ", e
     else:
         from hotshot import stats

--- a/utils/forms.py
+++ b/utils/forms.py
@@ -39,7 +39,7 @@ class HtmlCleaningCharField(forms.CharField):
             raise forms.ValidationError('Please moderate the amount of upper case characters in your post...')
         try:
             return clean_html(value)
-        except HTMLParseError, UnicodeEncodeError:
+        except (HTMLParseError, UnicodeEncodeError):
             raise forms.ValidationError('The text you submitted is badly formed HTML, please fix it')
 
 
@@ -152,7 +152,7 @@ class RecaptchaForm(forms.Form):
                 check = captcha.submit(rcf, rrf, settings.RECAPTCHA_PRIVATE_KEY, ip_address)
                 if not check.is_valid:
                     raise forms.ValidationError('You have not entered the correct words')
-            except URLError, timeout:
+            except URLError as timeout:
                 # We often sometimes see error messages that recaptcha url is unreachable and
                 # this causes 500 errors. If recaptcha is unreachable, just skip captcha validation.
                 pass

--- a/utils/search/search_forum.py
+++ b/utils/search/search_forum.py
@@ -51,7 +51,7 @@ def add_post_to_solr(post):
     logger.info("adding single forum post to solr index")
     try:
         Solr(settings.SOLR_FORUM_URL).add([convert_to_solr_document(post)])
-    except SolrException, e:
+    except SolrException as e:
         logger.error("failed to add forum post %d to solr index, reason: %s" % (post.id, str(e)))
 
 
@@ -78,12 +78,12 @@ def add_all_posts_to_solr(post_queryset, slice_size=4000, mark_index_clean=False
         try:
             posts = post_queryset[i:i+slice_size]
             add_posts_to_solr(posts)
-        except SolrException, e:
+        except SolrException as e:
             logger.error("failed to add post batch to solr index, reason: %s" % str(e))
 
 def delete_post_from_solr(post):
     logger.info("deleting post with id %d" % post.id)
     try:
         Solr(settings.SOLR_FORUM_URL).delete_by_id(post.id)
-    except Exception, e:
+    except Exception as e:
         logger.error('could not delete post with id %s (%s).' % (post.id, e))

--- a/utils/search/solr.py
+++ b/utils/search/solr.py
@@ -439,7 +439,7 @@ class Solr(object):
         encoded_docs = self.encoder.encode(docs)
         try:
             self._request(message=encoded_docs)
-        except error, e:
+        except error as e:
             raise SolrException, e
         #if self.auto_commit:
         #    self.commit()

--- a/utils/similarity_utilities.py
+++ b/utils/similarity_utilities.py
@@ -54,7 +54,7 @@ def get_similar_sounds(sound, preset = DEFAULT_PRESET, num_results = settings.SO
             result = Similarity.search(sound.id, preset = preset, num_results = num_results, offset = offset)
             similar_sounds = [[int(x[0]), float(x[1])] for x in result['results']]
             count = result['count']
-        except Exception, e:
+        except Exception as e:
             logger.debug('Could not get a response from the similarity service (%s)\n\t%s' % \
                          (e, traceback.format_exc()))
             result = False
@@ -137,10 +137,10 @@ def get_sounds_descriptors(sound_ids, descriptor_names, normalization=True, only
             not_cached_sound_ids.remove(id)
     try:
         returned_data = Similarity.get_sounds_descriptors(not_cached_sound_ids, descriptor_names, normalization, only_leaf_descriptors)
-    except Exception, e:
+    except Exception as e:
         logger.info('Something wrong occurred with the "get sound descriptors" request (%s)\n\t%s' %\
                      (e, traceback.format_exc()))
-        raise Exception(e)
+        raise
 
     # save sound analysis information in cache
     for key, item in returned_data.items():
@@ -156,7 +156,7 @@ def delete_sound_from_gaia(sound):
     logger.info("Deleting sound from gaia with id %d" % sound.id)
     try:
         Similarity.delete(sound.id)
-    except Exception, e:
+    except Exception as e:
         logger.warn("Could not delete sound from gaia with id %d (%s)" % (sound.id, str(e)))
 
 

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -118,7 +118,7 @@ def create_sound(user, sound_fields, apiv2_client=None, process=True, remove_exi
             remove_uploaded_file_from_mirror_locations(sound.original_path)
             _remove_user_uploads_folder_if_empty(sound.user)
 
-        except IOError, e:
+        except IOError as e:
             raise CantMoveException("Failed to move file from %s to %s" % (sound.original_path, new_original_path))
         sound.original_path = new_original_path
         sound.save()


### PR DESCRIPTION
As part of a gradual move to Python 3, this patch migrates from the pre-2.6 style of exception handling to the modern way. There should be no functional changes to this code - we still catch `Exception` in a lot of places which should be tackled at some other time too.
Tests pass and FS still runs.