### PR TITLE
Replace faad2 for ffmpeg for processing m4a files

### DIFF
--- a/utils/audioprocessing/processing.py
+++ b/utils/audioprocessing/processing.py
@@ -494,7 +494,7 @@ def convert_to_pcm(input_filename, output_filename):
     elif sound_type == "flac":
         cmd = ["flac", "-f", "-d", "-s", "-o", output_filename, input_filename]
     elif sound_type == "m4a":
-        cmd = ["faad", "-o", output_filename, input_filename]
+        cmd = ["ffmpeg", "-i", input_filename, output_filename]
     else:
         return False
 


### PR DESCRIPTION
issue #1004

Tested in test.freesound.org and it works fine for the same m4a file:

http://test.freesound.org/people/test/sounds/274383/