### PR TITLE
Remove locals() from geotags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 - pip install django-nose
 - pip install -r requirements.txt
 script:
-- python manage.py test --noinput --settings=freesound.test_settings accounts apiv2 bookmarks donations follow forum ratings search sounds support tags tickets utils wiki
+- python manage.py test --noinput --settings=freesound.test_settings accounts apiv2 bookmarks donations follow forum geotags ratings search sounds support tags tickets utils wiki
 notifications:
   hipchat:
     rooms:

--- a/freesound/context_processor.py
+++ b/freesound/context_processor.py
@@ -41,7 +41,6 @@ def context_extra(request):
         'use_js_dev_server': settings.USE_JS_DEVELOPMENT_SERVER,
         'media_url': settings.MEDIA_URL,
         'request': request,
-        'GOOGLE_API_KEY': settings.GOOGLE_API_KEY,
         'last_restart_date': settings.LAST_RESTART_DATE,
         'new_tickets_count': new_tickets_count,
         'num_pending_sounds': num_pending_sounds,

--- a/general/templatetags/google_maps.py
+++ b/general/templatetags/google_maps.py
@@ -1,0 +1,29 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+@register.simple_tag()
+def google_maps_js():
+    return "//maps.googleapis.com/maps/api/js?v=3&key=%s&sensor=false" % settings.GOOGLE_API_KEY

--- a/geotags/admin.py
+++ b/geotags/admin.py
@@ -21,11 +21,14 @@
 #
 
 from django.contrib import admin
+
 from geotags.models import GeoTag
+
 
 class GeoTagAdmin(admin.ModelAdmin):
     search_fields = ('=user__username',)
     raw_id_fields = ('user',) 
     list_display = ('user', 'lat', 'lon', 'created')
+
 
 admin.site.register(GeoTag, GeoTagAdmin)

--- a/geotags/models.py
+++ b/geotags/models.py
@@ -22,8 +22,9 @@
 
 from django.contrib.auth.models import User
 from django.db import models
-from django.utils.encoding import smart_unicode
 from django.urls import reverse
+from django.utils.encoding import smart_unicode
+
 
 class GeoTag(models.Model):
     user = models.ForeignKey(User)

--- a/geotags/templatetags/display_geotags.py
+++ b/geotags/templatetags/display_geotags.py
@@ -24,19 +24,19 @@ register = template.Library()
 
 
 @register.inclusion_tag('geotags/display_geotags.html', takes_context=True)
-def display_geotags(context, url="/geotags/geotags_box_barray/", width=900, height=600, clusters="on", center_lat=None, center_lon=None, zoom=None, username=None):
+def display_geotags(context, url='/geotags/geotags_box_barray/', width=900, height=600, clusters='on', center_lat=None, center_lon=None, zoom=None, username=None):
     if center_lat and center_lon and zoom:
-        borders = "defined"
+        borders = 'defined'
     else:
-        borders = "automatic"
+        borders = 'automatic'
 
-    return {"url": url,
-            "media_url": context['media_url'],
-            "m_width": width,
-            "m_height": height,
-            "clusters": clusters,
-            "center_lat": center_lat,
-            "center_lon": center_lon,
-            "zoom": zoom,
-            "borders": borders,
-            "username": username}
+    return {'url': url,
+            'media_url': context['media_url'],
+            'm_width': width,
+            'm_height': height,
+            'clusters': clusters,
+            'center_lat': center_lat,
+            'center_lon': center_lon,
+            'zoom': zoom,
+            'borders': borders,
+            'username': username}

--- a/geotags/tests.py
+++ b/geotags/tests.py
@@ -1,0 +1,68 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from geotags.models import GeoTag
+from sounds.models import Sound
+
+
+class GeoTagsTests(TestCase):
+
+    fixtures = ['sounds']
+
+    def check_context(self, context, values):
+        for k, v in values.items():
+            self.assertIn(k, context)
+            self.assertEquals(context[k], v)
+
+    def test_browse_geotags(self):
+        resp = self.client.get(reverse('geotags', kwargs={'tag': 'soundscape'}))
+        check_values = {'tag': 'soundscape', 'for_user': None}
+        self.check_context(resp.context, check_values)
+
+    def test_browse_geotags_box(self):
+        resp = self.client.get(reverse('geotags-box'))
+        check_values = {'m_width': 900, 'm_height': 600, 'clusters': 'on', 'center_lat': None, 'center_lon': None,
+                        'zoom': None, 'username': None}
+        self.check_context(resp.context, check_values)
+
+    def test_geotags_box_iframe(self):
+        resp = self.client.get(reverse('embed-geotags-box-iframe'))
+        check_values = {'m_width': 900, 'm_height': 600, 'clusters': 'on', 'center_lat': None, 'center_lon': None,
+                        'zoom': None, 'username': None}
+        self.check_context(resp.context, check_values)
+
+    def test_browse_geotags_for_user(self):
+        user = User.objects.get(username='Anton')
+        resp = self.client.get(reverse('geotags-for-user', kwargs={'username': 'Anton'}))
+        check_values = {'tag': None, 'for_user': user}
+        self.check_context(resp.context, check_values)
+
+    def test_geotags_infowindow(self):
+        sound = Sound.objects.first()
+        gt = GeoTag.objects.create(user=sound.user, lat=45.8498, lon=-62.6879, zoom=9)
+        sound.geotag = gt
+        sound.save()
+        resp = self.client.get(reverse('geotags-infowindow', kwargs={'sound_id': sound.id}))
+        self.check_context(resp.context, {'sound': sound})
+        self.assertInHTML('<a class="title" target="_blank" href="/people/Anton/sounds/16/">Glass A mf.wav</a>', resp.content)

--- a/geotags/views.py
+++ b/geotags/views.py
@@ -88,7 +88,6 @@ def geotags_for_pack_barray(request, pack_id):
 
 
 def geotags(request, tag=None):
-    google_api_key = settings.GOOGLE_API_KEY
     for_user = None
     return render(request, 'geotags/geotags.html', locals())
 
@@ -102,7 +101,6 @@ def geotags_box(request):
     zoom = request.GET.get("z", None)
     username = request.GET.get("username", None)
 
-    google_api_key = settings.GOOGLE_API_KEY
     return render(request, 'geotags/geotags_box.html', locals())
 
 
@@ -111,7 +109,6 @@ def for_user(request, username):
         for_user = User.objects.get(username__iexact=username)
     except User.DoesNotExist:
         raise Http404
-    google_api_key = settings.GOOGLE_API_KEY
     tag = None
     return render(request, 'geotags/geotags.html', locals())
 
@@ -134,5 +131,4 @@ def embed_iframe(request):
     zoom = request.GET.get("z", None)
     username = request.GET.get("username", None)
 
-    google_api_key = settings.GOOGLE_API_KEY
     return render(request, 'geotags/geotags_box_iframe.html', locals())

--- a/geotags/views.py
+++ b/geotags/views.py
@@ -22,7 +22,6 @@ import cStringIO
 import math
 import struct
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.http import Http404, HttpResponse
 from django.shortcuts import render
@@ -88,29 +87,41 @@ def geotags_for_pack_barray(request, pack_id):
 
 
 def geotags(request, tag=None):
-    for_user = None
-    return render(request, 'geotags/geotags.html', locals())
+    tvars = {'tag': tag,
+             'for_user': None}
+    return render(request, 'geotags/geotags.html', tvars)
+
+
+def _get_geotags_box_params(request):
+    return {
+        'm_width': request.GET.get('w', 900),
+        'm_height': request.GET.get('h', 600),
+        'clusters': request.GET.get('c', 'on'),
+        'center_lat': request.GET.get('c_lat', None),
+        'center_lon': request.GET.get('c_lon', None),
+        'zoom': request.GET.get('z', None),
+        'username': request.GET.get('username', None)
+    }
 
 
 def geotags_box(request):
-    m_width = request.GET.get("w", 900)
-    m_height = request.GET.get("h", 600)
-    clusters = request.GET.get("c", "on")
-    center_lat = request.GET.get("c_lat", None)
-    center_lon = request.GET.get("c_lon", None)
-    zoom = request.GET.get("z", None)
-    username = request.GET.get("username", None)
+    tvars = _get_geotags_box_params(request)
+    return render(request, 'geotags/geotags_box.html', tvars)
 
-    return render(request, 'geotags/geotags_box.html', locals())
+
+def embed_iframe(request):
+    tvars = _get_geotags_box_params(request)
+    return render(request, 'geotags/geotags_box_iframe.html', tvars)
 
 
 def for_user(request, username):
     try:
-        for_user = User.objects.get(username__iexact=username)
+        user = User.objects.get(username__iexact=username)
     except User.DoesNotExist:
         raise Http404
-    tag = None
-    return render(request, 'geotags/geotags.html', locals())
+    tvars = {'tag': None,
+             'for_user': user}
+    return render(request, 'geotags/geotags.html', tvars)
 
 
 def infowindow(request, sound_id):
@@ -119,16 +130,5 @@ def infowindow(request, sound_id):
     except Sound.DoesNotExist:
         raise Http404
 
-    return render(request, 'geotags/infowindow.html', locals())
-
-
-def embed_iframe(request):
-    m_width = request.GET.get("w", 900)
-    m_height = request.GET.get("h", 600)
-    clusters = request.GET.get("c", "on")
-    center_lat = request.GET.get("c_lat", None)
-    center_lon = request.GET.get("c_lon", None)
-    zoom = request.GET.get("z", None)
-    username = request.GET.get("username", None)
-
-    return render(request, 'geotags/geotags_box_iframe.html', locals())
+    tvars = {'sound': sound}
+    return render(request, 'geotags/infowindow.html', tvars)

--- a/geotags/views.py
+++ b/geotags/views.py
@@ -19,16 +19,16 @@
 #
 
 import cStringIO
+import math
 import struct
+
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.http import Http404, HttpResponse
 from django.shortcuts import render
-from django.template import RequestContext
-from sounds.models import Sound
 from django.views.decorators.cache import cache_page
-from django.contrib.auth.models import User
-import json
-import math
+
+from sounds.models import Sound
 
 
 def generate_bytearray(sound_queryset):
@@ -52,18 +52,19 @@ def geotags_barray(request, tag=None):
 
 
 def geotags_box_barray(request):
-    box = request.GET.get("box","-180,-90,180,90")
+    box = request.GET.get("box", "-180,-90,180,90")
     try:
         min_lat, min_lon, max_lat, max_lon = box.split(",")
         qs = Sound.objects.select_related("geotag").exclude(geotag=None).filter(moderation_state="OK", processing_state="OK")
+        sounds = []
         if min_lat <= max_lat and min_lon <= max_lon:
-            sounds = qs.filter(geotag__lat__range=(min_lat,max_lat)).filter(geotag__lon__range=(min_lon,max_lon))
+            sounds = qs.filter(geotag__lat__range=(min_lat, max_lat)).filter(geotag__lon__range=(min_lon, max_lon))
         elif min_lat > max_lat and min_lon <= max_lon:
-            sounds = qs.exclude(geotag__lat__range=(max_lat,min_lat)).filter(geotag__lon__range=(min_lon,max_lon))
+            sounds = qs.exclude(geotag__lat__range=(max_lat, min_lat)).filter(geotag__lon__range=(min_lon, max_lon))
         elif min_lat <= max_lat and min_lon > max_lon:
-            sounds =qs.filter(geotag__lat__range=(min_lat,max_lat)).exclude(geotag__lon__range=(max_lon,min_lon))
+            sounds = qs.filter(geotag__lat__range=(min_lat, max_lat)).exclude(geotag__lon__range=(max_lon, min_lon))
         elif min_lat > max_lat and min_lon > max_lon:
-            sounds = qs.exclude(geotag__lat__range=(max_lat,min_lat)).exclude(geotag__lon__range=(max_lon,min_lon))
+            sounds = qs.exclude(geotag__lat__range=(max_lat, min_lat)).exclude(geotag__lon__range=(max_lon, min_lon))
 
         return generate_bytearray(sounds)
     except ValueError:
@@ -76,13 +77,11 @@ def geotags_for_user_barray(request, username):
     return generate_bytearray(sounds)
 
 
-#@cache_page(60 * 15)
 def geotags_for_user_latest_barray(request, username):
     sounds = Sound.public.filter(user__username__iexact=username).exclude(geotag=None)[0:10]
     return generate_bytearray(sounds)
 
 
-#@cache_page(60 * 15)
 def geotags_for_pack_barray(request, pack_id):
     sounds = Sound.public.select_related('geotag').filter(pack__id=pack_id).exclude(geotag=None)
     return generate_bytearray(sounds)
@@ -95,13 +94,13 @@ def geotags(request, tag=None):
 
 
 def geotags_box(request):
-    m_width = request.GET.get("w",900)
-    m_height = request.GET.get("h",600)
-    clusters = request.GET.get("c","on")
-    center_lat = request.GET.get("c_lat",None)
-    center_lon = request.GET.get("c_lon",None)
-    zoom = request.GET.get("z",None)
-    username = request.GET.get("username",None)
+    m_width = request.GET.get("w", 900)
+    m_height = request.GET.get("h", 600)
+    clusters = request.GET.get("c", "on")
+    center_lat = request.GET.get("c_lat", None)
+    center_lon = request.GET.get("c_lon", None)
+    zoom = request.GET.get("z", None)
+    username = request.GET.get("username", None)
 
     google_api_key = settings.GOOGLE_API_KEY
     return render(request, 'geotags/geotags_box.html', locals())
@@ -110,7 +109,7 @@ def geotags_box(request):
 def for_user(request, username):
     try:
         for_user = User.objects.get(username__iexact=username)
-    except User.DoesNotExist: #@UndefinedVariable
+    except User.DoesNotExist:
         raise Http404
     google_api_key = settings.GOOGLE_API_KEY
     tag = None
@@ -120,20 +119,20 @@ def for_user(request, username):
 def infowindow(request, sound_id):
     try:
         sound = Sound.objects.select_related('user', 'geotag').get(id=sound_id)
-    except Sound.DoesNotExist: #@UndefinedVariable
+    except Sound.DoesNotExist:
         raise Http404
 
     return render(request, 'geotags/infowindow.html', locals())
 
 
 def embed_iframe(request):
-    m_width = request.GET.get("w",900)
-    m_height = request.GET.get("h",600)
-    clusters = request.GET.get("c","on")
-    center_lat = request.GET.get("c_lat",None)
-    center_lon = request.GET.get("c_lon",None)
-    zoom = request.GET.get("z",None)
-    username = request.GET.get("username",None)
+    m_width = request.GET.get("w", 900)
+    m_height = request.GET.get("h", 600)
+    clusters = request.GET.get("c", "on")
+    center_lat = request.GET.get("c_lat", None)
+    center_lon = request.GET.get("c_lon", None)
+    zoom = request.GET.get("z", None)
+    username = request.GET.get("username", None)
 
     google_api_key = settings.GOOGLE_API_KEY
     return render(request, 'geotags/geotags_box_iframe.html', locals())

--- a/media/js/maps.js
+++ b/media/js/maps.js
@@ -1,22 +1,3 @@
-// ----------GOOGLE MAPS FUNCTION -------------
-function zoomToBounds(map, bounds)
-{
-    var center = bounds.getCenter();
-    var newZoom = map.getBoundsZoomLevel(bounds) - 1;
-
-    if (newZoom < 0)
-        newZoom = 0;
-
-    if (map.getZoom() != newZoom)
-    {
-        map.setCenter(center, newZoom);
-    }
-    else
-    {
-        map.panTo(center);
-    }
-}
-
 function setMaxZoomCenter(map, lat, lng, zoom)
 {
     var latlng = new GLatLng(lat, lng);

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -593,7 +593,6 @@ def geotag(request, username, sound_id):
     sound = get_object_or_404(Sound, id=sound_id, moderation_state="OK", processing_state="OK")
     if sound.user.username.lower() != username.lower():
         raise Http404
-    google_api_key = settings.GOOGLE_API_KEY
     return render(request, 'sounds/geotag.html', locals())
 
 

--- a/templates/accounts/account.html
+++ b/templates/accounts/account.html
@@ -3,12 +3,13 @@
 {% load display_sound %}
 {% load tags %}
 {% load filter_img %}
+{% load google_maps %}
 
 {% block title %}{% if home %}home{% else %}{{user.username}}{% endif %}{% endblock %}
 
 {% block head %}
     {{ block.super }}
-    <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3&key={{ GOOGLE_API_KEY }}&sensor=false"></script>
+    <script type="text/javascript" src="{% google_maps_js %}"></script>
     <script src="{{media_url}}js/sounds_location.js?v={{ last_restart_date }}" type="text/javascript"></script>
 {% endblock head %}
 
@@ -324,12 +325,12 @@
             google.maps.event.addListener(infowindow, 'closeclick', function() {
                 stopAll();
             });
-           
+
             getSoundsLocations('{% url "geotags-for-user-latest-barray" user.username %}', function(data){
                 var bounds = new google.maps.LatLngBounds();
                 var nSounds = data.length;
                 var lastPoint;
-                
+
                 $.each(data, function(index, item) {
                     var id = item[0];
                     var lat = item[1];

--- a/templates/accounts/describe_sounds.html
+++ b/templates/accounts/describe_sounds.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% load display_license_form %}
+{% load google_maps %}
 
 {% block head %}
     {{ block.super }}
-    <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3&key={{google_api_key}}&sensor=false"></script>
+    <script type="text/javascript" src="{% google_maps_js %}"></script>
     <script>
         // Maps variables
         var maps = {};

--- a/templates/geotags/geotags.html
+++ b/templates/geotags/geotags.html
@@ -131,7 +131,6 @@
             markers.push(marker);
         });
 
-        //if (!bounds.isEmpty()) zoomToBounds(map, bounds);
         if (!bounds.isEmpty()) map.fitBounds(bounds);
         var mcOptions = { gridSize: 50, maxZoom: 12, imagePath:'/media/images/js-marker-clusterer/m' };
         var markerCluster = new MarkerClusterer(map, markers, mcOptions);

--- a/templates/geotags/geotags.html
+++ b/templates/geotags/geotags.html
@@ -1,12 +1,13 @@
 {% extends "sounds/_section.html" %}
 
 {% load absurl %}
+{% load google_maps %}
 
 {% block title %}geotags{% endblock title %}
 
 {% block head %}
 {{ block.super }}
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3&key={{google_api_key}}&sensor=false"></script>
+<script type="text/javascript" src="{% google_maps_js %}"></script>
 <script src="{{media_url}}js/markerclustererV3.js" type="text/javascript"></script>
 <script src="{{media_url}}js/maps.js?v={{ last_restart_date }}" type="text/javascript"></script>
 <script src="{{media_url}}js/sounds_location.js?v={{ last_restart_date }}" type="text/javascript"></script>

--- a/templates/geotags/geotags_box.html
+++ b/templates/geotags/geotags_box.html
@@ -1,10 +1,11 @@
 {% extends "sounds/_section.html" %}
 {% load display_geotags %}
+{% load google_maps %}
 {% block title %}geotags{% endblock title %}
 
 {% block head %}
 {{ block.super }}
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3&key={{google_api_key}}&sensor=false"></script>
+<script type="text/javascript" src="{% google_maps_js %}"></script>
 <script src="{{media_url}}js/markerclustererV3.js" type="text/javascript"></script>
 <script src="{{media_url}}js/sounds_location.js?v={{ last_restart_date }}" type="text/javascript"></script>
 {% endblock head %}

--- a/templates/geotags/geotags_box_iframe.html
+++ b/templates/geotags/geotags_box_iframe.html
@@ -1,9 +1,10 @@
 {% load display_geotags %}
+{% load google_maps %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">  
     <head>
         <script src="{{media_url}}js/jquery-1.5.2.min.js" type="text/javascript"></script>
-        <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3&key={{google_api_key}}&sensor=false"></script>
+        <script type="text/javascript" src="{% google_maps_js %}"></script>
         <script src="{{media_url}}js/sounds_location.js?v={{ last_restart_date }}" type="text/javascript"></script>
         <script src="{{media_url}}js/markerclustererV3.js" type="text/javascript"></script>
 

--- a/templates/sounds/geotag.html
+++ b/templates/sounds/geotag.html
@@ -1,11 +1,11 @@
 {% extends "sounds/_section.html" %}
-
+{% load google_maps %}
 
 {% block title %}&quot;{{sound.original_filename}}&quot; by {{sound.user.username}} - geotag{% endblock title %}
 
 {% block head %}
 {{ block.super }}
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3&key={{google_api_key}}&sensor=false"></script>
+<script type="text/javascript" src="{% google_maps_js %}"></script>
 {% endblock head %}
 
 {% block section_content %}

--- a/templates/sounds/pack.html
+++ b/templates/sounds/pack.html
@@ -3,12 +3,13 @@
 {% load display_sound %}
 {% load paginator %}
 {% load filter_img %}
+{% load google_maps %}
 
 {% block title %}pack: {{pack.name}} by {{pack.user.username}}{% endblock title %}
 
 {% block head %}
     {{ block.super }}
-    <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3&key={{ GOOGLE_API_KEY }}&sensor=false"></script>
+    <script type="text/javascript" src="{% google_maps_js %}"></script>
     <script src="{{media_url}}js/sounds_location.js?v={{ last_restart_date }}" type="text/javascript"></script>
 {% endblock head %}
 
@@ -43,7 +44,7 @@
 		    	<div id="download_text"><a href="{% url pack-downloaders pack.user.username pack.id %}">Downloaded<br /><b>{{pack.num_downloads}}</b> times</a></div>
 		    {% endif %}
 		</div>
-		
+
 		</div>
 	{% endif %}
 {% endif %}
@@ -86,15 +87,15 @@
 <p>
     See <a href="{% url 'packs-for-user' pack.user.username %}">more packs</a> by <a href="{% url 'account' pack.user.username %}">{{pack.user.username}}</a>
 </p>
-    
-    
+
+
 {% if pack.num_sounds > 0 %}
 	{% show_paginator paginator page current_page request "sound" %}
-	
+
 	{% for sound in pack_sounds %}
     	{% display_raw_sound sound %}
 	{% endfor %}
-	
+
 	{% show_paginator paginator page current_page request "sound" %}
 
 {% else %}
@@ -130,7 +131,7 @@
                     var id = item[0];
                     var lat = item[1];
                     var lon = item[2];
-                        
+
                     var point = new google.maps.LatLng(lat, lon);
                     lastPoint = point;
                     bounds.extend(point);
@@ -166,7 +167,7 @@
             });
         </script>
     </div><!-- #pack_geotags -->
-    
+
     {% if not pack.is_dirty %}
 	{% if num_sounds_ok > 0 %}
 		<!--<div id="single_pack_sidebar">-->
@@ -183,7 +184,7 @@
 		    	<div id="download_text"><a href="{% url 'pack-downloaders' pack.user.username pack.id %}">Downloaded<br /><b>{{pack.num_downloads}}</b> times</a></div>
 		    {% endif %}
 		</div>
-		
+
 		<!--</div>-->
 	{% endif %}
     {% endif %}

--- a/templates/sounds/sound_edit.html
+++ b/templates/sounds/sound_edit.html
@@ -1,12 +1,13 @@
 {% extends "sounds/_section.html" %}
 {% load display_license_form %}
+{% load google_maps %}
 
 {% block title %}&quot;editing {{sound.original_filename}}{% endblock title %}
 
 {% block head %}
 {{ block.super }}
 
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?v=3&key={{ GOOGLE_API_KEY }}&sensor=false"></script>
+<script type="text/javascript" src="{% google_maps_js %}"></script>
 <script type="text/javascript">
 
     var doLog = true;


### PR DESCRIPTION
Perform style cleanups on geotags code (formatting, pep8, etc).

I'm adding this PR now to get feedback on my changes made in 5fb6c568dda34f2cb09e6608820931330524923c. I like the idea of moving the `GOOGLE_API_KEY` setting out of the context processor, but I'm not sure of the best way of providing the template tag. One way is as I've commited, where `{% google_maps_js %}` will include a full
`<script type="....." src="//..........js"></script>` string. However, it's a bit opaque as to exactly what is being inserted with this tag. An alternative would be to have the tag only return the URL, so that we would use it as
```js
<script type="text/javascript" src="{% google_maps_js %}"></script>
```
which immediately makes it clear that this tag inserts a URL of some js that we have to load.

Thoughts?