### PR TITLE
Email validate

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -138,8 +138,8 @@ class RegistrationForm(forms.Form):
     first_name = forms.CharField(help_text=_("Optional."), max_length=30, required=False)
     last_name = forms.CharField(help_text=_("Optional."), max_length=30, required=False)
     email1 = forms.EmailField(label=_("Email"), help_text=_("We will send you a confirmation/activation email, so make "
-                                                            "sure this is correct!."))
-    email2 = forms.EmailField(label=_("Email confirmation"))
+                                                            "sure this is correct!."), max_length=254)
+    email2 = forms.EmailField(label=_("Email confirmation"), max_length=254)
     password1 = forms.CharField(label=_("Password"), widget=forms.PasswordInput)
     password2 = forms.CharField(label=_("Password confirmation"), widget=forms.PasswordInput)
     accepted_tos = forms.BooleanField(
@@ -210,7 +210,7 @@ class RegistrationForm(forms.Form):
 
 
 class ReactivationForm(forms.Form):
-    user = forms.CharField(label="The username or email you signed up with")
+    user = forms.CharField(label="The username or email you signed up with", max_length=254)
 
 
 class FsAuthenticationForm(AuthenticationForm):
@@ -229,7 +229,7 @@ class FsAuthenticationForm(AuthenticationForm):
 
 
 class UsernameReminderForm(forms.Form):
-    user = forms.EmailField(label="The email address you signed up with")
+    user = forms.EmailField(label="The email address you signed up with", max_length=254)
 
 
 class ProfileForm(forms.ModelForm):
@@ -291,7 +291,7 @@ class ProfileForm(forms.ModelForm):
 
 
 class EmailResetForm(forms.Form):
-    email = forms.EmailField(label=_("New e-mail address"), max_length=75)
+    email = forms.EmailField(label=_("New e-mail address"), max_length=254)
     password = forms.CharField(label=_("Your password"), widget=forms.PasswordInput)
 
     def __init__(self, *args, **kwargs):

--- a/donations/forms.py
+++ b/donations/forms.py
@@ -7,7 +7,7 @@ class DonateForm(forms.Form):
     RADIO_CHOICES = []
 
     donation_type = forms.ChoiceField(widget=forms.RadioSelect(), choices=RADIO_CHOICES)
-    name_option = forms.CharField(required=False)
+    name_option = forms.CharField(required=False, max_length=255)
     amount = forms.FloatField(initial=10.0, min_value=0.5)
     recurring = forms.BooleanField(required=False, initial=False,
             label='I want this to be a recurring monthly donation',)

--- a/donations/tests.py
+++ b/donations/tests.py
@@ -184,6 +184,14 @@ class DonationTest(TestCase):
         response =  ret.json()
         self.assertFalse('errors' in response)
 
+        long_mail = ('1'*256) + '@freesound.org'
+        data['name_option'] = long_mail
+        data['donation_type'] = '2'
+        ret = self.client.post("/donations/donate/", data)
+        response =  ret.json()
+        self.assertTrue('errors' in response)
+
+
     def test_donation_response(self):
         # 200 response on donate page
         resp = self.client.get(reverse('donate'))

--- a/forum/forms.py
+++ b/forum/forms.py
@@ -42,7 +42,7 @@ class PostReplyForm(forms.Form):
         return body
 
 class NewThreadForm(forms.Form):
-    title = forms.CharField()
+    title = forms.CharField(max_length=250)
     body = HtmlCleaningCharField(widget=forms.Textarea(attrs=dict(cols=100, rows=30)))
     subscribe = forms.BooleanField(help_text="Send me an email notification when new posts are added in this thread.", required=False, initial=True)
 

--- a/forum/tests.py
+++ b/forum/tests.py
@@ -87,6 +87,18 @@ class ForumPageResponses(TestCase):
         post = Post.objects.get(body=u'New thread body (first post)')
         self.assertRedirects(resp, post.get_absolute_url(), target_status_code=302)
 
+    @override_settings(LAST_FORUM_POST_MINIMUM_TIME=0)
+    def test_new_thread_title_length(self):
+        forum = Forum.objects.first()
+
+        # Assert logged in user fails creating thread
+        long_title = 255 * '1'
+        self.client.login(username=self.user.username, password='12345')
+        resp = self.client.post(reverse('forums-new-thread', args=[forum.name_slug]), data={
+            u'body': [u'New thread body (first post)'], u'subscribe': [u'on'], u'title': [long_title]
+        })
+        self.assertNotEqual(resp.context['form'].errors, None)
+
     def test_thread_response_ok(self):
         forum = Forum.objects.first()
         thread = forum.thread_set.first()


### PR DESCRIPTION
issue #1016 

I think the best way of handling validation of length in char fields is to pass max_length in the definition of forms fields, in this way the length of the field is validated by javascript and also in the backend automatically.

The only way to make sure that we always use the max_length when the model is restricted is to use a Model Form, but sometimes this makes the code unnecessarly complex for simple cases.

For this reasons I manually checked all the length restrictions in the models and checked that the corresponding forms had the max_length parameter.