### PR TITLE
Not index deleted packs

### DIFF
--- a/sounds/models.py
+++ b/sounds/models.py
@@ -169,7 +169,7 @@ class SoundManager(models.Manager):
         FROM
           sounds_sound sound
           LEFT JOIN auth_user ON auth_user.id = sound.user_id
-          LEFT JOIN sounds_pack ON sound.pack_id = sounds_pack.id
+          LEFT JOIN sounds_pack ON (sound.pack_id = sounds_pack.id AND sounds_pack.is_deleted = False)
           LEFT JOIN sounds_license ON sound.license_id = sounds_license.id
           LEFT JOIN geotags_geotag ON sound.geotag_id = geotags_geotag.id
         WHERE

--- a/utils/search/search_general.py
+++ b/utils/search/search_general.py
@@ -46,7 +46,7 @@ def convert_to_solr_document(sound):
     document["tag"] = getattr(sound, "tag_array")
     document["license"] = getattr(sound, "license_name")
 
-    if getattr(sound, "pack_id"):
+    if getattr(sound, "pack_name"):
         document["pack"] = remove_control_chars(getattr(sound, "pack_name"))
         document["grouping_pack"] = str(getattr(sound, "pack_id")) + "_" + remove_control_chars(getattr(sound, "pack_name"))
     else:


### PR DESCRIPTION
I noticed that we indexed deleted packs, it's possible (but not completely sure) that the issue #779 is because of this problem.

After this change it took more time to do the full index, @alastair maybe we need a index in the DB for the field is_deleted of the Pack table?