### PR TITLE
Add sound id/pack id as extra_data in sentry instead of in title

### DIFF
--- a/sounds/views.py
+++ b/sounds/views.py
@@ -316,8 +316,9 @@ def sound_download(request, username, sound_id):
     if sound.user.username.lower() != username.lower():
         raise Http404
 
-    sentry_logger.info('Download sound %s' % (sound_id),exc_info=True, extra={
+    sentry_logger.info('Download sound', exc_info=True, extra={
         'request': request,
+        'sound_id': sound_id,
     })
 
     if not Download.objects.filter(user=request.user, sound=sound).exists():
@@ -333,8 +334,9 @@ def pack_download(request, username, pack_id):
     if pack.user.username.lower() != username.lower():
         raise Http404
 
-    sentry_logger.info('Download pack %s' % (pack_id), exc_info=True, extra={
+    sentry_logger.info('Download pack', exc_info=True, extra={
         'request': request,
+        'pack_id': pack_id,
     })
 
     if not Download.objects.filter(user=request.user, pack=pack).exists():


### PR DESCRIPTION
Otherwise we get a sentry notification for every download. This way
sentry will suppress notification emails for all downloads