### PR TITLE
Replace sentry log of downloads for graylog

### DIFF
--- a/freesound/local_settings.example.py
+++ b/freesound/local_settings.example.py
@@ -95,8 +95,6 @@ APIV2_POST_THROTTLING_RATES_PER_LEVELS = {
     99: [],  # No limit of requests
 }
 
-LOG_DOWNLOADS = False
-
 # Sentry
 
 RAVEN_CONFIG = {

--- a/freesound/local_settings.example.py
+++ b/freesound/local_settings.example.py
@@ -95,6 +95,7 @@ APIV2_POST_THROTTLING_RATES_PER_LEVELS = {
     99: [],  # No limit of requests
 }
 
+FEATURE_LOG_SOUND_DOWNLOADS = False
 
 # Sentry
 

--- a/freesound/local_settings.example.py
+++ b/freesound/local_settings.example.py
@@ -95,7 +95,7 @@ APIV2_POST_THROTTLING_RATES_PER_LEVELS = {
     99: [],  # No limit of requests
 }
 
-FEATURE_LOG_SOUND_DOWNLOADS = False
+LOG_DOWNLOADS = False
 
 # Sentry
 

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -309,6 +309,10 @@ MIRROR_AVATARS = None  # list of locations to mirror contents of AVATARS_PATH, s
 MIRROR_UPLOADS = None  # list of locations to mirror contents of MIRROR_UPLOADS, set to None to turn off
 LOG_START_AND_END_COPYING_FILES = True
 
+
+# Turn this option on to log every time a user downloads a pack or sound
+LOG_DOWNLOADS = False
+
 # Stripe keys for testing (never set real keys here!!!)
 STRIPE_PUBLIC_KEY = ""
 STRIPE_PRIVATE_KEY = ""

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -316,8 +316,12 @@ def sound_download(request, username, sound_id):
     if sound.user.username.lower() != username.lower():
         raise Http404
 
-    downloads_logger.info('Download sound', exc_info=True, extra={
-        'request': request,
+    downloads_logger.info('Download sound', extra={
+        'user_id': request.user.id,
+        'user_ip': request.META.get('HTTP_X_FORWARDED_FOR'),
+        'protocol': request.META.get('HTTP_X_FORWARDED_PROTOCOL'),
+        'session_id': request.session.session_key,
+        'user_agent': request.META.get('HTTP_USER_AGENT'),
         'sound_id': sound_id,
     })
 
@@ -334,8 +338,12 @@ def pack_download(request, username, pack_id):
     if pack.user.username.lower() != username.lower():
         raise Http404
 
-    downloads_logger.info('Download pack', exc_info=True, extra={
-        'request': request,
+    downloads_logger.info('Download pack', extra={
+        'user_id': request.user.id,
+        'user_ip': request.META.get('HTTP_X_FORWARDED_FOR'),
+        'protocol': request.META.get('HTTP_X_FORWARDED_PROTOCOL'),
+        'session_id': request.session.session_key,
+        'user_agent': request.META.get('HTTP_USER_AGENT'),
         'pack_id': pack_id,
     })
 

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -316,15 +316,16 @@ def sound_download(request, username, sound_id):
     if sound.user.username.lower() != username.lower():
         raise Http404
 
-    downloads_logger.info('Download sound', extra={
-        'user_id': request.user.id,
-        'user_ip': request.META.get('HTTP_X_FORWARDED_FOR'),
-        'protocol': request.META.get('HTTP_X_FORWARDED_PROTOCOL'),
-        'session_id': request.session.session_key,
-        'user_agent': request.META.get('HTTP_USER_AGENT'),
-        'sound_id': sound_id,
-        'range': request.META.get('HTTP_RANGE', None),
-    })
+    if settings.FEATURE_LOG_SOUND_DOWNLOADS:
+        downloads_logger.info('Download sound', extra={
+            'user_id': request.user.id,
+            'user_ip': request.META.get('HTTP_X_FORWARDED_FOR'),
+            'protocol': request.META.get('HTTP_X_FORWARDED_PROTOCOL'),
+            'session_id': request.session.session_key,
+            'user_agent': request.META.get('HTTP_USER_AGENT'),
+            'sound_id': sound_id,
+            'range': request.META.get('HTTP_RANGE', None),
+        })
 
     if not Download.objects.filter(user=request.user, sound=sound).exists():
         Download.objects.create(user=request.user, sound=sound, license=sound.license)
@@ -339,15 +340,16 @@ def pack_download(request, username, pack_id):
     if pack.user.username.lower() != username.lower():
         raise Http404
 
-    downloads_logger.info('Download pack', extra={
-        'user_id': request.user.id,
-        'user_ip': request.META.get('HTTP_X_FORWARDED_FOR'),
-        'protocol': request.META.get('HTTP_X_FORWARDED_PROTOCOL'),
-        'session_id': request.session.session_key,
-        'user_agent': request.META.get('HTTP_USER_AGENT'),
-        'pack_id': pack_id,
-        'range': request.META.get('HTTP_RANGE', None),
-    })
+    if settings.FEATURE_LOG_SOUND_DOWNLOADS:
+        downloads_logger.info('Download pack', extra={
+            'user_id': request.user.id,
+            'user_ip': request.META.get('HTTP_X_FORWARDED_FOR'),
+            'protocol': request.META.get('HTTP_X_FORWARDED_PROTOCOL'),
+            'session_id': request.session.session_key,
+            'user_agent': request.META.get('HTTP_USER_AGENT'),
+            'pack_id': pack_id,
+            'range': request.META.get('HTTP_RANGE', None),
+        })
 
     if not Download.objects.filter(user=request.user, pack=pack).exists():
         Download.objects.create(user=request.user, pack=pack)

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -323,6 +323,7 @@ def sound_download(request, username, sound_id):
         'session_id': request.session.session_key,
         'user_agent': request.META.get('HTTP_USER_AGENT'),
         'sound_id': sound_id,
+        'range': request.META.get('HTTP_RANGE', None),
     })
 
     if not Download.objects.filter(user=request.user, sound=sound).exists():
@@ -345,6 +346,7 @@ def pack_download(request, username, pack_id):
         'session_id': request.session.session_key,
         'user_agent': request.META.get('HTTP_USER_AGENT'),
         'pack_id': pack_id,
+        'range': request.META.get('HTTP_RANGE', None),
     })
 
     if not Download.objects.filter(user=request.user, pack=pack).exists():

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -316,7 +316,7 @@ def sound_download(request, username, sound_id):
     if sound.user.username.lower() != username.lower():
         raise Http404
 
-    if settings.FEATURE_LOG_SOUND_DOWNLOADS:
+    if settings.LOG_DOWNLOADS:
         downloads_logger.info('Download sound', extra={
             'user_id': request.user.id,
             'user_ip': request.META.get('HTTP_X_FORWARDED_FOR'),
@@ -340,7 +340,7 @@ def pack_download(request, username, pack_id):
     if pack.user.username.lower() != username.lower():
         raise Http404
 
-    if settings.FEATURE_LOG_SOUND_DOWNLOADS:
+    if settings.LOG_DOWNLOADS:
         downloads_logger.info('Download pack', extra={
             'user_id': request.user.id,
             'user_ip': request.META.get('HTTP_X_FORWARDED_FOR'),

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -68,7 +68,7 @@ import os
 
 
 logger = logging.getLogger('web')
-sentry_logger = logging.getLogger('sentry')
+downloads_logger = logging.getLogger('downloads')
 
 
 def get_sound_of_the_day_id():
@@ -316,7 +316,7 @@ def sound_download(request, username, sound_id):
     if sound.user.username.lower() != username.lower():
         raise Http404
 
-    sentry_logger.info('Download sound', exc_info=True, extra={
+    downloads_logger.info('Download sound', exc_info=True, extra={
         'request': request,
         'sound_id': sound_id,
     })
@@ -334,7 +334,7 @@ def pack_download(request, username, pack_id):
     if pack.user.username.lower() != username.lower():
         raise Http404
 
-    sentry_logger.info('Download pack', exc_info=True, extra={
+    downloads_logger.info('Download pack', exc_info=True, extra={
         'request': request,
         'pack_id': pack_id,
     })


### PR DESCRIPTION
Issue #840

Also changed logging.py in freesound-deploy to use GelfHandler which sends messages to Graylog using UDP (https://github.com/severb/graypy#usage)