### PR TITLE
Add management command to synchronize old paypal donations

### DIFF
--- a/donations/management/commands/check_missing_donations.py
+++ b/donations/management/commands/check_missing_donations.py
@@ -1,0 +1,94 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+import datetime
+import logging
+import requests
+import json
+from urlparse import parse_qs
+from django.conf import settings
+from donations.models import Donation, DonationCampaign
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger("web")
+
+
+class Command(BaseCommand):
+    help = 'Synchronize Paypal donations'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-d', '--days',
+            action='store_true',
+            dest='days',
+            default=1,
+            help='Use this option to get the donations older than 1 day.')
+
+    def handle(self, **options):
+        days = options['days']
+        logger.info("Synchronizing donations from paypal")
+
+        td = datetime.timedelta(days=days)
+        start = datetime.datetime.now() - td
+
+        one_day = datetime.timedelta(days=1)
+        stop_date = datetime.datetime.now() - one_day
+        params = {
+            'METHOD': 'TransactionSearch',
+            'STARTDATE': start,
+            'ENDDATE': start + one_day,
+            'VERSION': 94,
+            'USER' : settings.PAYPAL_USERNAME,
+            'PWD': settings.PAYPAL_PASSWORD,
+            'SIGNATURE': settings.PAYPAL_SIGNATURE
+        }
+        while stop_date >= start:
+            req = requests.post(settings.PAYPAL_PAYMENTS_API_URL, data=params)
+            raw_rsp = parse_qs(req.text)
+            if raw_rsp['ACK'] == ['Success']:
+                campaign = DonationCampaign.objects.order_by('date_start').last()
+                Donation._meta.get_field('created').auto_now_add = False
+                for i in range(100):
+                    if ('L_EMAIL%d' % i) in raw_rsp:
+                        created = datetime.datetime.strptime(raw_rsp['L_TIMESTAMP%d' % i][0],'%Y-%m-%dT%H:%M:%SZ')
+                        donation_data = {
+                            'email': raw_rsp['L_EMAIL%d' % i][0],
+                            'display_name': 'Anonymous',
+                            'amount': raw_rsp['L_AMT%d' % i][0],
+                            'currency': raw_rsp['L_CURRENCYCODE%d' % i][0],
+                            'display_amount': False,
+                            'is_anonymous': True,
+                            'campaign': campaign,
+                            'created': created,
+                            'source': 'p'
+                        }
+                        obj, created = donations = Donation.objects.get_or_create(
+                                 transaction_id=raw_rsp['L_TRANSACTIONID%d'%i][0], defaults=donation_data)
+                        if created:
+                            del donation_data['campaign']
+                            donation_data['created'] = raw_rsp['L_TIMESTAMP%d' % i][0]
+                            logger.info('Recevied donation (%s)' % json.dumps(donation_data))
+                    else:
+                        break
+
+                    start = start + one_day
+                    params['STARTDATE'] = start
+                    params['ENDDATE'] = start + one_day
+        logger.info("Synchronizing donations from paypal ended")

--- a/donations/views.py
+++ b/donations/views.py
@@ -52,22 +52,24 @@ def _save_donation(encoded_data, email, amount, currency, transaction_id, source
         'campaign': campaign,
         'source': source
     }
-    Donation.objects.get_or_create(transaction_id=transaction_id, defaults=donation_data)
+    donation, created = Donation.objects.get_or_create(transaction_id=transaction_id, defaults=donation_data)
 
-    send_mail_template(
-            u'Thanks for your donation!',
-            'donations/email_donation.txt', {
-                'user': user,
-                'amount': amount,
-                'display_name': display_name
-                }, None, email)
+    if created:
+        send_mail_template(
+                u'Thanks for your donation!',
+                'donations/email_donation.txt', {
+                    'user': user,
+                    'amount': amount,
+                    'display_name': display_name
+                    }, None, email)
 
-    log_data = donation_data
-    log_data.update({'user_id': user_id})
-    del log_data['user']  # Don't want to serialize user
-    del log_data['campaign']  # Don't want to serialize campaign
-    log_data['amount_float'] = float(log_data['amount'])
-    logger.info('Recevied donation (%s)' % json.dumps(log_data))
+        log_data = donation_data
+        log_data.update({'user_id': user_id})
+        log_data.update({'created': str(donation.created)})
+        del log_data['user']  # Don't want to serialize user
+        del log_data['campaign']  # Don't want to serialize campaign
+        log_data['amount_float'] = float(log_data['amount'])
+        logger.info('Recevied donation (%s)' % json.dumps(log_data))
     return True
 
 

--- a/freesound/local_settings.example.py
+++ b/freesound/local_settings.example.py
@@ -50,6 +50,10 @@ GEARMAN_JOB_SERVERS = ["localhost:4730"]
 STRIPE_KEY = "sk_test_..."
 PAYPAL_EMAIL = "paypal@freesound.org"
 PAYPAL_VALIDATION_URL = "https://www.sandbox.paypal.com/cgi-bin/webscr"
+PAYPAL_PAYMENTS_API_URL = "https://api-3t.sandbox.paypal.com/nvp"
+PAYPAL_PASSWORD = ""
+PAYPAL_USERNAME= ""
+PAYPAL_SIGNATURE = ""
 DONATIONS_PER_PAGE = 40
 
 GRAYLOG_USERNAME = "apiuser"


### PR DESCRIPTION
issue #1047

Make sure the settings are placed in the local_settings file, the value on PAYPAL_USERNAME is also given by paypal (is not the regular username):

https://developer.paypal.com/developer/accounts/

Regarding Stripe, I don't  see how we could have donations not registered, since is our server that requests the donations. Maybe we can check first the amounts donated vs donations records before implementing it.