### PR TITLE
Atomic transaction added to multiple views

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -104,6 +104,7 @@ def login(request, template_name, authentication_form):
 
 
 @login_required
+@transaction.atomic()
 def multi_email_cleanup(request):
 
     # If user does not have shared email problems, then it should have not visited this page
@@ -336,6 +337,7 @@ def edit_email_settings(request):
 
 
 @login_required
+@transaction.atomic()
 def edit(request):
     profile = request.user.profile
 
@@ -388,6 +390,7 @@ def edit(request):
     return render(request, 'accounts/edit.html', tvars)
 
 
+@transaction.atomic()
 def handle_uploaded_image(profile, f):
     logger.info("\thandling profile image upload")
     try:
@@ -922,6 +925,7 @@ def upload(request, no_flash=False):
 
 
 @login_required
+@transaction.atomic()
 def delete(request):
     num_sounds = request.user.sounds.all().count()
     error_message = None
@@ -958,6 +962,7 @@ def old_user_link_redirect(request):
 
 
 @login_required
+@transaction.atomic()
 def email_reset(request):
     if request.method == "POST":
         form = EmailResetForm(request.POST, user=request.user)
@@ -1008,6 +1013,7 @@ def email_reset_done(request):
 
 
 @never_cache
+@transaction.atomic()
 def email_reset_complete(request, uidb36=None, token=None):
     # Check that the link is valid and the base36 corresponds to a user id
     assert uidb36 is not None and token is not None  # checked by URLconf
@@ -1036,6 +1042,7 @@ def email_reset_complete(request, uidb36=None, token=None):
 
 
 @login_required
+@transaction.atomic()
 def flag_user(request, username=None):
     if request.POST:
         flagged_user = User.objects.get(username__iexact=request.POST["username"])

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -23,6 +23,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
+from django.db import transaction
 from django.shortcuts import render, get_object_or_404
 from django.urls import reverse
 
@@ -61,6 +62,7 @@ def bookmarks(request, username, category_id=None):
 
 
 @login_required
+@transaction.atomic()
 def delete_bookmark_category(request, category_id):
 
     category = get_object_or_404(BookmarkCategory, id=category_id, user=request.user)
@@ -76,6 +78,7 @@ def delete_bookmark_category(request, category_id):
 
 
 @login_required
+@transaction.atomic()
 def add_bookmark(request, sound_id):
     sound = get_object_or_404(Sound, id=sound_id)
 

--- a/comments/views.py
+++ b/comments/views.py
@@ -27,12 +27,14 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render_to_response, render
 from django.template.context import RequestContext
+from django.db import transaction
 from sounds.models import Sound
 from utils.functional import combine_dicts
 from utils.pagination import paginate
 
 
 @login_required
+@transaction.atomic()
 def delete(request, comment_id):
     comment = get_object_or_404(Comment, id=comment_id)
     # User can delete if has permission or if is the owner of the comment

--- a/follow/views.py
+++ b/follow/views.py
@@ -23,6 +23,7 @@
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from follow import follow_utils
 from follow.models import FollowingUserItem
 from follow.models import FollowingQueryItem
@@ -124,6 +125,7 @@ def unfollow_tags(request, slash_tags):
 
 
 @login_required
+@transaction.atomic()
 def stream(request):
 
     SELECT_OPTIONS = OrderedDict([

--- a/forum/views.py
+++ b/forum/views.py
@@ -28,6 +28,7 @@ from django.http import HttpResponseRedirect, Http404, \
 from django.shortcuts import render, get_object_or_404
 from django.template import loader
 from django.urls import reverse
+from django.db import transaction
 
 from forum.forms import PostReplyForm, NewThreadForm, PostModerationForm
 from forum.models import Forum, Thread, Post, Subscription
@@ -104,6 +105,7 @@ def forum(request, forum_name_slug):
 
 
 @last_action
+@transaction.atomic()
 def thread(request, forum_name_slug, thread_id):
     forum = get_object_or_404(Forum, name_slug=forum_name_slug)
     thread = get_object_or_404(Thread, forum=forum, id=thread_id, first_post__moderation_state="OK")
@@ -150,6 +152,7 @@ def post(request, forum_name_slug, thread_id, post_id):
 
 
 @login_required
+@transaction.atomic()
 def reply(request, forum_name_slug, thread_id, post_id=None):
     forum = get_object_or_404(Forum, name_slug=forum_name_slug)
     thread = get_object_or_404(Thread, id=thread_id, forum=forum, first_post__moderation_state="OK")
@@ -228,6 +231,7 @@ def reply(request, forum_name_slug, thread_id, post_id=None):
 
 
 @login_required
+@transaction.atomic()
 def new_thread(request, forum_name_slug):
     forum = get_object_or_404(Forum, name_slug=forum_name_slug)
     user_can_post_in_forum = request.user.profile.can_post_in_forum()
@@ -346,6 +350,7 @@ def post_delete_confirm(request, post_id):
 
 
 @login_required
+@transaction.atomic()
 def post_edit(request, post_id):
     post = get_object_or_404(Post, id=post_id)
     if post.author == request.user or request.user.has_perm('forum.change_post'):
@@ -366,6 +371,7 @@ def post_edit(request, post_id):
 
 
 @permission_required('forum.can_moderate_forum')
+@transaction.atomic()
 def moderate_posts(request):
     if request.method == 'POST':
         mod_form = PostModerationForm(request.POST)

--- a/messages/views.py
+++ b/messages/views.py
@@ -21,6 +21,7 @@
 from django.contrib.auth.decorators import login_required
 from django.urls import reverse
 from django.db.models import Q
+from django.db import transaction
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.template import RequestContext
@@ -82,6 +83,7 @@ def archived_messages(request):
 
 
 @login_required
+@transaction.atomic()
 def message(request, message_id):
     try:
         message = base_qs.get(id=message_id)
@@ -99,6 +101,7 @@ def message(request, message_id):
     return render(request, 'messages/message.html', locals())
 
 @login_required
+@transaction.atomic()
 def new_message(request, username=None, message_id=None):
     
     if request.method == 'POST':

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -504,6 +504,7 @@ def sound_edit(request, username, sound_id):
 
 
 @login_required
+@transaction.atomic()
 def pack_edit(request, username, pack_id):
     pack = get_object_or_404(Pack, id=pack_id)
     if pack.user.username.lower() != username.lower():
@@ -532,6 +533,7 @@ def pack_edit(request, username, pack_id):
 
 
 @login_required
+@transaction.atomic()
 def pack_delete(request, username, pack_id):
     pack = get_object_or_404(Pack, id=pack_id)
     if pack.user.username.lower() != username.lower():
@@ -565,6 +567,7 @@ def pack_delete(request, username, pack_id):
 
 
 @login_required
+@transaction.atomic()
 def sound_edit_sources(request, username, sound_id):
     sound = get_object_or_404(Sound, id=sound_id)
     if sound.user.username.lower() != username.lower():
@@ -637,6 +640,7 @@ def similar(request, username, sound_id):
     return render(request, 'sounds/similar.html', locals())
 
 
+@transaction.atomic()
 def pack(request, username, pack_id):
     try:
         pack = Pack.objects.select_related().get(id=pack_id)
@@ -703,6 +707,7 @@ def for_user(request, username):
 
 
 @login_required
+@transaction.atomic()
 def delete(request, username, sound_id):
     sound = get_object_or_404(Sound, id=sound_id)
     if sound.user.username.lower() != username.lower():
@@ -744,6 +749,7 @@ def delete(request, username, sound_id):
     return render(request, 'sounds/delete.html', tvars)
 
 
+@transaction.atomic()
 def flag(request, username, sound_id):
     sound = get_object_or_404(Sound, id=sound_id, moderation_state="OK", processing_state="OK")
     if sound.user.username.lower() != username.lower():

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -320,6 +320,7 @@ def moderation_assign_user(request, user_id):
 
 
 @permission_required('tickets.can_moderate')
+@transaction.atomic()
 def moderation_assign_single_ticket(request, user_id, ticket_id):
     # REASSIGN SINGLE TICKET
     ticket = Ticket.objects.get(id=ticket_id)
@@ -493,6 +494,7 @@ def moderation_assigned(request, user_id):
 
 
 @permission_required('tickets.can_moderate')
+@transaction.atomic()
 def user_annotations(request, user_id):
     user = get_object_or_404(User, id=user_id)
     num_sounds_ok = Sound.objects.filter(user=user, moderation_state="OK").count()


### PR DESCRIPTION
According to #967 we want to prevent code to run multiple times but also
to prevent inconsistencies because of uncompleted executions.

Here we add transaction.atomic decorator to multiple views, depending on
whether they modify to database or not.

Together with this changes PR #1031 should be enough to solve all the issues related with double-clicks