### PR TITLE
Fix problems with wrong num comments/ratings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 - pip install django-nose
 - pip install -r requirements.txt
 script:
-- python manage.py test --noinput --settings=freesound.test_settings accounts apiv2 bookmarks donations follow forum geotags ratings search sounds support tags tickets utils wiki
+- python manage.py test --noinput --settings=freesound.test_settings accounts apiv2 bookmarks donations follow forum geotags ratings search sounds support tags tickets utils wiki general
 notifications:
   hipchat:
     rooms:

--- a/general/management/commands/report_count_statuses.py
+++ b/general/management/commands/report_count_statuses.py
@@ -21,6 +21,7 @@
 
 import logging
 import pprint
+from collections import defaultdict
 
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
@@ -58,27 +59,8 @@ class Command(BaseCommand):
             if count % 10000 == 0:
                 console_logger.info(message % (total, 100 * float(count + 1) / total))
 
-        # Iterate over all sounds to check: num_comments, num_downloads, avg_rating, num_ratings
-        # While iterating, we keep a list of user ids and pack ids for then iterating over them
-
-        mismatches_report = {
-            'Sound.num_comments': 0,
-            'Sound.num_downloads': 0,
-            'Sound.num_ratings': 0,
-            'Pack.num_sounds': 0,
-            'Pack.num_downloads': 0,
-            'User.num_sounds': 0,
-            'User.num_posts': 0,
-        }
-        mismatches_object_ids = {
-            'Sound.num_comments': list(),
-            'Sound.num_downloads': list(),
-            'Sound.num_ratings': list(),
-            'Pack.num_sounds': list(),
-            'Pack.num_downloads': list(),
-            'User.num_sounds': list(),
-            'User.num_posts': list(),
-        }
+        mismatches_report = defaultdict(int)
+        mismatches_object_ids = defaultdict(list)
 
         # IMPLEMENTATION NOTE: on the code below we iterate multiple times on Sounds, Packs and Users tables.
         # This is done in this way because due to our DB structure and the way that Django ORM works, if we annotate
@@ -205,5 +187,4 @@ class Command(BaseCommand):
 
         console_logger.info("Number of mismatched counts: ")
         console_logger.info('\n' + pprint.pformat(mismatches_report))
-        mismatches_object_ids = {key: value for key, value in mismatches_object_ids.items() if value}
         console_logger.info('\n' + pprint.pformat(mismatches_object_ids))

--- a/general/management/commands/report_count_statuses.py
+++ b/general/management/commands/report_count_statuses.py
@@ -81,10 +81,11 @@ class Command(BaseCommand):
         }
 
         # IMPLEMENTATION NOTE: on the code below we iterate multiple times on Sounds, Packs and Users tables.
-        # This is done in this way because using the Django ORM we can't annotate counts from different tables in a
-        # single queryset (annotations that would require SQL JOINs with more than one table). If we do that, we
-        # get wrong results for the annotated fields as the generated SQL duplicates results for each table (see
-        # https://code.djangoproject.com/ticket/10060).
+        # This is done in this way because due to our DB structure and the way that Django ORM works, if we annotate
+        # counts from different tables in a single queryset (annotations that require SQL JOINs with more than one
+        # table), the result we obtain is not the count that we want (see https://code.djangoproject.com/ticket/10060)
+        # The easier solution for us is to do the queries individually for each kind of "count" that we want to
+        # annotate.
 
         # Sounds
         total = Sound.objects.all().count()

--- a/general/management/commands/report_count_statuses.py
+++ b/general/management/commands/report_count_statuses.py
@@ -19,15 +19,17 @@
 #
 
 
-import sys
-from pprint import pprint
+import logging
+import pprint
 
+from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 from django.db.models import Count, Avg
-from django.contrib.auth.models import User
 
-from sounds.models import Sound, Pack
 from forum.models import Post
+from sounds.models import Sound, Pack
+
+console_logger = logging.getLogger("console")
 
 
 class Command(BaseCommand):
@@ -53,12 +55,8 @@ class Command(BaseCommand):
     def handle(self,  *args, **options):
 
         def report_progress(message, total, count):
-            if count % 100 == 0:
-                sys.stdout.write(
-                    '\r' + message % (total, 100 * float(count + 1) / total))
-                sys.stdout.flush()
-            if count + 1 == total:
-                print ' done!'
+            if count % 10000 == 0:
+                console_logger.info(message % (total, 100 * float(count + 1) / total))
 
         # Iterate over all sounds to check: num_comments, num_downloads, avg_rating, num_ratings
         # While iterating, we keep a list of user ids and pack ids for then iterating over them
@@ -204,7 +202,7 @@ class Command(BaseCommand):
                     user_profile.save()
             report_progress('Checking number of posts in %i users... %.2f%%', total, count)
 
-        print "\nNumber of mismatched counts: "
-        pprint(mismatches_report)
-        mismatches_object_ids = {key:value for key, value in mismatches_object_ids.items() if value}
-        pprint(mismatches_object_ids)
+        console_logger.info("Number of mismatched counts: ")
+        console_logger.info('\n' + pprint.pformat(mismatches_report))
+        mismatches_object_ids = {key: value for key, value in mismatches_object_ids.items() if value}
+        console_logger.info('\n' + pprint.pformat(mismatches_object_ids))

--- a/general/management/commands/report_count_statuses.py
+++ b/general/management/commands/report_count_statuses.py
@@ -47,13 +47,21 @@ class Command(BaseCommand):
             action='store_true',
             dest='skip-downloads',
             default=False,
-            help='Using the option --skip-downloads the command will not checked for mismatched downloads (to save time).')
+            help='Using the option --skip-downloads the command will not checked for mismatched downloads '
+                 '(to save time).')
 
     def handle(self,  *args, **options):
 
+        def report_progress(message, total, count):
+            if count % 100 == 0:
+                sys.stdout.write(
+                    '\r' + message % (total, 100 * float(count + 1) / total))
+                sys.stdout.flush()
+            if count + 1 == total:
+                print 'done!'
+
         # Iterate over all sounds to check: num_comments, num_downloads, avg_rating, num_ratings
         # While iterating, we keep a list of user ids and pack ids for then iterating over them
-        all_user_ids = set()
 
         mismatches_report = {
             'Sound.num_comments': 0,
@@ -74,67 +82,61 @@ class Command(BaseCommand):
             'User.num_posts': list(),
         }
 
+        # IMPLEMENTATION NOTE: on the code below we iterate multiple times on Sounds, Packs and Users tables.
+        # This is done in this way because using the Django ORM we can't annotate counts from different tables in a
+        # single queryset (annotations that would require SQL JOINs with more than one table). If we do that, we
+        # get wrong results for the annotated fields as the generated SQL duplicates results for each table (see
+        # https://code.djangoproject.com/ticket/10060).
+
         # Sounds
         total = Sound.objects.all().count()
-        print "Iterating over existing %i sounds..." % total,
 
-        annotations = {
-            'real_num_comments': Count('comments'),
-            'real_num_ratings': Count('ratings'),
-            'real_avg_rating': Avg('ratings__rating'),
-        }
-        if not options['skip-downloads']:
-            annotations['real_num_downloads'] = Count('downloads')
-
-        for count, sound in enumerate(Sound.objects.all().annotate(**annotations).iterator()):
-
-            needs_save = False
-
-            # Check num_comments
+        # Look at number of comments
+        for count, sound in enumerate(Sound.objects.all().annotate(real_num_comments=Count('comments')).iterator()):
             real_num_comments = sound.real_num_comments
             if real_num_comments != sound.num_comments:
                 mismatches_report['Sound.num_comments'] += 1
                 mismatches_object_ids['Sound.num_comments'].append(sound.id)
                 sound.num_comments = real_num_comments
-                needs_save = True
+                if not options['no-changes']:
+                    sound.is_index_dirty = True
+                    sound.save()
+            report_progress('Checking number of comments in %i sounds... %.2f%%', total, count)
 
-            # Check num_downloads
-            if not options['skip-downloads']:
-                real_num_downloads = sound.real_num_downloads
-                if real_num_downloads != sound.num_downloads:
-                    mismatches_report['Sound.num_downloads'] += 1
-                    mismatches_object_ids['Sound.num_downloads'].append(sound.id)
-                    sound.num_downloads = real_num_downloads
-                    needs_save = True
-
-            # Check num_ratings and avg_rating
+        # Look at number of rartings and average rating
+        for count, sound in enumerate(Sound.objects.all().annotate(
+                real_num_ratings=Count('ratings'), real_avg_rating=Avg('ratings__rating')).iterator()):
             real_num_ratings = sound.real_num_ratings
             if real_num_ratings != sound.num_ratings:
                 mismatches_report['Sound.num_ratings'] += 1
                 mismatches_object_ids['Sound.num_ratings'].append(sound.id)
                 sound.num_ratings = real_num_ratings
                 sound.avg_rating = sound.real_avg_rating
-                needs_save = True
+                if not options['no-changes']:
+                    sound.is_index_dirty = True
+                    sound.save()
+            report_progress('Checking number and average of ratings in %i sounds... %.2f%%', total, count)
 
-            if needs_save and not options['no-changes']:
-                sound.is_index_dirty = True
-                sound.save()
+        # Look at number of downloads
+        if not options['skip-downloads']:
+            for count, sound in enumerate(Sound.objects.all().annotate(
+                    real_num_downloads=Count('downloads')).iterator()):
 
-            # Report progress
-            if count % 100 == 0:
-                sys.stdout.write("\rIterating over existing %i sounds... %.2f%%" % (total, 100 * float(count + 1)/total))
-                sys.stdout.flush()
-        print " done!"
+                real_num_downloads = sound.real_num_downloads
+                if real_num_downloads != sound.num_downloads:
+                    mismatches_report['Sound.num_downloads'] += 1
+                    mismatches_object_ids['Sound.num_downloads'].append(sound.id)
+                    sound.num_downloads = real_num_downloads
+                    if not options['no-changes']:
+                        sound.is_index_dirty = True
+                        sound.save()
+                report_progress('Checking number of downloads in %i sounds... %.2f%%', total, count)
 
         # Packs
         total = Pack.objects.all().count()
-        print "Iterating over existing %i packs..." % total,
 
-        annotations = {}
-        if not options['skip-downloads']:
-            annotations['real_num_downloads'] = Count('downloads')
-
-        for count, pack in enumerate(Pack.objects.all().annotate(**annotations).extra(select={
+        # Look at number of sounds
+        for count, pack in enumerate(Pack.objects.all().extra(select={
             'real_num_sounds': """
                 SELECT COUNT(U0."id") AS "count"
                 FROM "sounds_sound" U0
@@ -142,83 +144,65 @@ class Command(BaseCommand):
                 AND U0."processing_state" = 'OK' AND U0."moderation_state" = 'OK'
             """
         }).iterator()):
-
-            needs_save = False
-
-            # Check num_sounds
             real_num_sounds = pack.real_num_sounds
             if real_num_sounds != pack.num_sounds:
                 mismatches_report['Pack.num_sounds'] += 1
                 mismatches_object_ids['Pack.num_sounds'].append(pack.id)
                 pack.num_sounds = real_num_sounds
-                needs_save = True
+                if not options['no-changes']:
+                    pack.save()
+            report_progress("Checking number of sounds in %i packs... %.2f%%", total, count)
 
-            # Check num_downloads
-            if not options['skip-downloads']:
+        # Look at number of downloads
+        if not options['skip-downloads']:
+            for count, pack in enumerate(Pack.objects.all().annotate(real_num_downloads=Count('downloads')).iterator()):
                 real_num_downloads = pack.real_num_downloads
                 if real_num_downloads != pack.real_num_sounds:
                     mismatches_report['Pack.num_downloads'] += 1
                     mismatches_object_ids['Pack.num_downloads'].append(pack.id)
                     pack.num_downloads = real_num_downloads
-                    needs_save = True
-
-            if needs_save and not options['no-changes']:
-                pack.save()
-
-            # Report progress
-            if count % 100 == 0:
-                sys.stdout.write("\rIterating over existing %i packs... %.2f%%" % (total, 100 * float(count + 1)/total))
-                sys.stdout.flush()
-        print " done!"
+                    if not options['no-changes']:
+                        pack.save()
+                report_progress("Checking number of downloads in %i packs... %.2f%%", total, count)
 
         # Users
         potential_user_ids = set()
         potential_user_ids.update(Sound.objects.all().values_list('user_id', flat=True))  # Add ids of uploaders
         potential_user_ids.update(Post.objects.all().values_list('author_id', flat=True))  # Add ids of forum posters
         total = len(potential_user_ids)
-        print "Iterating over existing %i users..." % total,
 
-        annotations = {
-            'real_num_posts': Count('posts'),
-        }
-
-        for count, user in enumerate(User.objects.filter(id__in=potential_user_ids)
-                                                 .select_related('profile').annotate(**annotations).extra(select={
-            'real_num_sounds': """
-                SELECT COUNT(U0."id") AS "count"
-                FROM "sounds_sound" U0
-                WHERE U0."user_id" = ("auth_user"."id") 
-                AND U0."processing_state" = 'OK' AND U0."moderation_state" = 'OK'
-            """
-        }).iterator()):
-
-            needs_save = False
+        # Look at number of sounds
+        for count, user in enumerate(User.objects.filter(id__in=potential_user_ids).select_related('profile').extra(
+                select={
+                    'real_num_sounds': """
+                        SELECT COUNT(U0."id") AS "count"
+                        FROM "sounds_sound" U0
+                        WHERE U0."user_id" = ("auth_user"."id") 
+                        AND U0."processing_state" = 'OK' AND U0."moderation_state" = 'OK'
+                    """
+                }).iterator()):
             user_profile = user.profile
-
-            # Check num_sounds
             real_num_sounds = user.real_num_sounds
             if real_num_sounds != user_profile.num_sounds:
                 mismatches_report['User.num_sounds'] += 1
                 mismatches_object_ids['User.num_sounds'].append(user.id)
                 user_profile.num_sounds = real_num_sounds
-                needs_save = True
+                if not options['no-changes']:
+                    user_profile.save()
+            report_progress('Checking number of sounds in %i users... %.2f%%', total, count)
 
-            # Check num_posts
+        # Look at number of posts
+        for count, user in enumerate(User.objects.filter(id__in=potential_user_ids).select_related('profile').annotate(
+                real_num_posts=Count('posts'),).iterator()):
+            user_profile = user.profile
             real_num_posts = user.real_num_posts
             if real_num_posts != user_profile.num_posts:
                 mismatches_report['User.num_posts'] += 1
                 mismatches_object_ids['User.num_posts'].append(user.id)
                 user_profile.num_posts = real_num_posts
-                needs_save = True
-
-            if needs_save and not options['no-changes']:
-                user_profile.save()
-
-            # Report progress
-            if count % 100 == 0:
-                sys.stdout.write("\rIterating over existing %i users... %.2f%%" % (total, 100 * float(count)/total))
-                sys.stdout.flush()
-        print " done!"
+                if not options['no-changes']:
+                    user_profile.save()
+            report_progress('Checking number of posts in %i users... %.2f%%', total, count)
 
         print "\nNumber of mismatched counts: "
         pprint(mismatches_report)

--- a/general/management/commands/report_count_statuses.py
+++ b/general/management/commands/report_count_statuses.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
                     '\r' + message % (total, 100 * float(count + 1) / total))
                 sys.stdout.flush()
             if count + 1 == total:
-                print 'done!'
+                print ' done!'
 
         # Iterate over all sounds to check: num_comments, num_downloads, avg_rating, num_ratings
         # While iterating, we keep a list of user ids and pack ids for then iterating over them
@@ -157,7 +157,7 @@ class Command(BaseCommand):
         if not options['skip-downloads']:
             for count, pack in enumerate(Pack.objects.all().annotate(real_num_downloads=Count('downloads')).iterator()):
                 real_num_downloads = pack.real_num_downloads
-                if real_num_downloads != pack.real_num_sounds:
+                if real_num_downloads != pack.num_downloads:
                     mismatches_report['Pack.num_downloads'] += 1
                     mismatches_object_ids['Pack.num_downloads'].append(pack.id)
                     pack.num_downloads = real_num_downloads

--- a/general/tests.py
+++ b/general/tests.py
@@ -1,0 +1,40 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class GeneralManagementCommandTestCase(TestCase):
+    """Tests for the managment commands under the general app"""
+
+    def test_report_count_statuses(self):
+        # TODO
+        # 1) create sound/pack/user/post objects and manually set counts to be wrong
+        # 2) run command
+        # 3) check that counts are ok
+        # 4) manually set the counts to something wrong
+        # 5) run command with -n option
+        # 6) check that counts are still wrong
+        # 7) run command with -d option
+        # 8) check that all counts are ok except for download related ones
+        # 9) run command
+        # 10) check that all counts are ok
+        call_command('report_count_statuses', '-nd')

--- a/general/tests.py
+++ b/general/tests.py
@@ -25,8 +25,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 
-class GeneralManagementCommandTestCase(TestCase):
-    """Tests for the managment commands under the general app"""
+class ReportCountStatusesManagementCommandTestCase(TestCase):
 
     fixtures = ['initial_data']  # Needed for loading licenses, etc
 


### PR DESCRIPTION
Issue https://github.com/MTG/freesound/issues/1073

Summary: The `report_count_statuses` command has a problem as using Django's `annotate` functionality when joining over multiple tables returns "wrong" count results. This PR fixes this problem and adds unit tests for the command.