### PR TITLE
Only display sound signature when needed

### DIFF
--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -87,9 +87,9 @@
     </div>
     <div id="sound_description">
         {{sound.description|replace_img|safe|linebreaks}}
-        {% if user.profile.sound_signature %}
+        {% if sound.user.profile.sound_signature %}
         <div class="sound_signature">
-            {{user.profile.sound_signature|sound_signature_replace:sound|replace_img|safe|linebreaks}}</p>
+            <p>{{sound.user.profile.sound_signature|sound_signature_replace:sound|replace_img|safe|linebreaks}}</p>
         </div>
         {% endif %}
     </div>


### PR DESCRIPTION
Issue https://github.com/MTG/freesound/issues/1074

Summary: visitor's sound signature is displayed instead of creator's signature. This PR fixes this issue and adds a unit test.