### PR TITLE
Add projection of donations for a year

### DIFF
--- a/media/js/stats.js
+++ b/media/js/stats.js
@@ -4,6 +4,7 @@ $( document ).ready(function() {
     $('#total-users').html(data.total_users);
     $('#users-with-sounds').html(data.users_with_sounds);
     $('#total-donations').html(data.total_donations);
+    $('#proj-donations').html((data.donations_last_month * 12).toFixed(2));
     $('#total-sounds').html(data.sounds);
     $('#total-packs').html(data.packs);
     $('#total-downloads').html(data.downloads);

--- a/monitor/management/commands/generate_stats.py
+++ b/monitor/management/commands/generate_stats.py
@@ -156,6 +156,10 @@ class Command(BaseCommand):
         num_donations = donations.models.Donation.objects\
             .aggregate(Sum('amount'))['amount__sum']
 
+        time_span = datetime.datetime.now()-datetime.timedelta(30)
+        sum_donations_month = donations.models.Donation.objects\
+            .filter(created__gt=time_span).aggregate(Sum('amount'))['amount__sum']
+
         num_sounds = sounds.models.Sound.objects.filter(processing_state="OK",
             moderation_state="OK").count()
         packs = sounds.models.Pack.objects.all().count()
@@ -174,6 +178,7 @@ class Command(BaseCommand):
             "total_users": users_num,
             "users_with_sounds": users_with_sounds,
             "total_donations": num_donations,
+            "donations_last_month": sum_donations_month,
             "sounds": num_sounds,
             "packs": packs,
             "downloads": downloads,

--- a/templates/monitor/stats.html
+++ b/templates/monitor/stats.html
@@ -84,7 +84,7 @@
       <tr>
         <td><b>Downloads:</b> </td><td id="total-downloads"></td>
         <td><b>Unique tags:</b> </td><td id="total-tags"></td>
-        <td><b>Donations by year:</b></td><td id="proj-donations"></td>
+        <td><b>Donations by year (estimated with last 30 days data):</b></td><td id="proj-donations"></td>
       </tr>
       <tr>
         <td><b>Avg downloads per sound:</b> </td><td id="avg-downloads"></td>

--- a/templates/monitor/stats.html
+++ b/templates/monitor/stats.html
@@ -84,7 +84,7 @@
       <tr>
         <td><b>Downloads:</b> </td><td id="total-downloads"></td>
         <td><b>Unique tags:</b> </td><td id="total-tags"></td>
-        <td></td><td></td>
+        <td><b>Donations by year:</b></td><td id="proj-donations"></td>
       </tr>
       <tr>
         <td><b>Avg downloads per sound:</b> </td><td id="avg-downloads"></td>


### PR DESCRIPTION
I added in the stats page table a simple projection of a year of donations. It's calculated using the total donations from the last 30 days.