### PR TITLE
Don't show user's description if didn't downloaded any sound

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -106,6 +106,10 @@ class Profile(SocialModel):
             return True
         except SameUser.DoesNotExist:
             return False
+    @property
+    def get_total_downloads(self):
+        # We consider each pack download as a single download
+        return self.num_sound_downloads + self.num_pack_downloads
 
     def get_absolute_url(self):
         return reverse('account', args=[smart_unicode(self.user.username)])

--- a/templates/accounts/account.html
+++ b/templates/accounts/account.html
@@ -120,8 +120,8 @@
             <div class="account_information_and_home_options">
             <ul>
                 <li><a href="{% url "messages-new" user.username %}">Send a private message to this user</a></li>
-                {% if user.profile.home_page %}
-                <li>Home page: <a href="{{user.profile.home_page}}" rel="nofollow">{{user.profile.home_page}}</a></li>
+                {% if user.profile.home_page and user.profile.get_total_downloads > 0 %}
+                    <li>Home page: <a href="{{user.profile.home_page}}" rel="nofollow">{{user.profile.home_page}}</a></li>
                 {% endif %}
                 <li>Has been a user for {{user.date_joined|timesince}}</li>
                 {% if user.profile.num_sounds %}

--- a/templates/accounts/account.html
+++ b/templates/accounts/account.html
@@ -130,8 +130,8 @@
                 {% if user.profile.num_posts %}
                 <li>Number of forum posts: {{user.profile.num_posts}}</li>
                 {% endif %}
-                <li><a href="{% url "user-downloaded-sounds" user.username %}">Sounds downloaded</a> by {{user.username}}</li>
-                <li><a href="{% url "user-downloaded-packs" user.username %}">Packs downloaded</a> by {{user.username}}</li>
+                <li><a href="{% url "user-downloaded-sounds" user.username %}">Sounds downloaded</a> ({{ user.profile.num_sound_downloads}}) by {{user.username}}</li>
+                <li><a href="{% url "user-downloaded-packs" user.username %}">Packs downloaded</a> ({{ user.profile.num_pack_downloads}}) by {{user.username}}</li>
                 {% if user.profile.num_sounds %}
                 <li><a href="{% url "comments-for-user" user.username %}">All comments</a> on {{user.username}}'s sounds</li>
                 {% endif %}
@@ -153,7 +153,7 @@
             </ul>
             </div>
             <br style="clear: both;" />
-            {% if user.profile.about %}
+            {% if user.profile.about and user.profile.get_total_downloads > 0 %}
                 <div class="about">
                     {{user.profile.about|replace_img|safe|linebreaksbr }}
                 </div>


### PR DESCRIPTION
Added property to Profile which returns number of downloaded sounds and packs, then if this value is zero we don't show the description in users profile page.

issue #935