### PR TITLE
Add more checks for unsafe img src in forms

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -334,6 +334,8 @@ class ProfileForm(forms.ModelForm):
         model = Profile
         fields = ('home_page', 'about', 'signature', 'sound_signature', 'is_adult', 'not_shown_in_online_users_list', )
 
+    def get_img_fields(self):
+        return [self['about'], self['signature'], self['sound_signature']]
 
 class EmailResetForm(forms.Form):
     email = forms.EmailField(label=_("New e-mail address"), max_length=254)

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -334,7 +334,8 @@ class ProfileForm(forms.ModelForm):
         model = Profile
         fields = ('home_page', 'about', 'signature', 'sound_signature', 'is_adult', 'not_shown_in_online_users_list', )
 
-    def get_img_fields(self):
+    def get_img_check_fields(self):
+        """ Returns fields that should show JS notification for unsafe `img` sources links (http://) """
         return [self['about'], self['signature'], self['sound_signature']]
 
 class EmailResetForm(forms.Form):

--- a/templates/accounts/edit.html
+++ b/templates/accounts/edit.html
@@ -66,8 +66,9 @@
 
 <script>
   $(function() {
-    unsecureImageCheck($('#id_profile-about'));
-    unsecureImageCheck($('#id_profile-signature'));
+      {% for field in profile_form.get_img_fields %}
+          unsecureImageCheck($('#{{ field.id_for_label }}'));
+      {% endfor %}
   })
 </script>
 

--- a/templates/accounts/edit.html
+++ b/templates/accounts/edit.html
@@ -66,7 +66,7 @@
 
 <script>
   $(function() {
-      {% for field in profile_form.get_img_fields %}
+      {% for field in profile_form.get_img_check_fields %}
           unsecureImageCheck($('#{{ field.id_for_label }}'));
       {% endfor %}
   })

--- a/templates/forum/new_thread.html
+++ b/templates/forum/new_thread.html
@@ -20,5 +20,11 @@
 <input type="submit" value="create thread" />
 </form>
 
+<script>
+  $(function() {
+    unsecureImageCheck($('#{{ form.body.id_for_label }}'));
+  })
+</script>
+
 
 {% endblock %}

--- a/templates/forum/reply.html
+++ b/templates/forum/reply.html
@@ -27,7 +27,7 @@
 
 <script>
   $(function() {
-    unsecureImageCheck($('#id_body'));
+    unsecureImageCheck($('#{{ form.body.id_for_label }}'));
   })
 </script>
 

--- a/templates/messages/new.html
+++ b/templates/messages/new.html
@@ -11,6 +11,8 @@
 <script type="text/javascript" src="{{media_url}}js/jquery.autocomplete.min.js"></script>
 <script>
     $(function() {
+      unsecureImageCheck($('#{{ form.body.id_for_label }}'));
+
       $.get('{% url "messages-username_lookup" %}', function(data){
         $('#id_to').autocomplete(data);
       });

--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -332,8 +332,7 @@
     document.getElementById("tumblr_button_abc123").appendChild(tumblr_button);
 
     $(function() {
-        unsecureImageCheck($('#id_comment'));
-
+        unsecureImageCheck($('#{{ form.comment.id_for_label }}'));
 
         var is_following;
         if ("{{ is_following }}" == "True") is_following = true;

--- a/templates/sounds/sound_edit.html
+++ b/templates/sounds/sound_edit.html
@@ -54,7 +54,7 @@
             log("UsingRecommendation:No", "-");
         }
 
-        unsecureImageCheck($('#id_description-description'));
+        unsecureImageCheck($('#{{ description_form.description.id_for_label }}'));
     });
 
 

--- a/templates/tickets/moderation_assigned.html
+++ b/templates/tickets/moderation_assigned.html
@@ -108,8 +108,10 @@
           $('#row_'+ selectedTickets[t]).find('.ticket-check').attr("checked", true);
         }
         updateSelectedTickets();
-        
+
       {% endif %}
+
+        unsecureImageCheck($('#{{ msg_form.message.id_for_label }}'));
     });
 
     function updateSelectedTickets() {

--- a/templates/tickets/ticket.html
+++ b/templates/tickets/ticket.html
@@ -95,4 +95,11 @@
         </div> <!-- /#ticket-right -->
         <br style="clear: both;">
     </div> <!-- /#ticket-wrapper -->
+
+<script>
+  $(function() {
+    unsecureImageCheck($('#{{ tc_form.message.id_for_label }}'));
+  })
+</script>
+
 {% endblock content %}

--- a/templates/tickets/user_annotations.html
+++ b/templates/tickets/user_annotations.html
@@ -34,3 +34,9 @@
                    function(data) { $('#user-annotations-section').html(data); });">
     </form>
 </div>
+
+<script>
+  $(function() {
+    unsecureImageCheck($('#{{ form.text.id_for_label }}'));
+  })
+</script>


### PR DESCRIPTION
Went through instances of `HtmlCleaningCharField` in forms and made sure that templates have `unsecureImageCheck` JS calls on proper fields (#1054)