### PR TITLE
Add check for src attribute in replace_img filter

### DIFF
--- a/general/templatetags/filter_img.py
+++ b/general/templatetags/filter_img.py
@@ -11,7 +11,7 @@ def replace_img(string):
 
     soup = BeautifulSoup(string,  "html.parser")
     for img in soup.find_all('img'):
-        if not img['src'].lower().startswith("https"):
+        if img.has_attr('src') and not img['src'].lower().startswith("https"):
             a = soup.new_tag("a", href=img['src'])
             a.string = img['src']
             img.replace_with(a)

--- a/sounds/tests.py
+++ b/sounds/tests.py
@@ -185,6 +185,10 @@ class CommentSoundsTestCase(TestCase):
         comment = 'Test <img src="https://test.com/img.png" /> test'
         self.assertEqual(replace_img(comment), comment)
 
+        # make sure lack of src doesn't break anything
+        comment = 'Test <img/> test, http://test.com/img.png'
+        self.assertEqual(replace_img(comment), comment)
+
     def test_post_delete_comment(self):
         sound = Sound.objects.get(id=19)
         sound.is_index_dirty = False


### PR DESCRIPTION
Html5lib filters that are used in Bleach seem to be less elegant way to replace `img` tags with `a`, thus keeping BeautifulSoup (#1112) 