### PR TITLE
Moderation UI update

### DIFF
--- a/templates/accounts/pending.html
+++ b/templates/accounts/pending.html
@@ -43,6 +43,13 @@
                     </div>
                 </div>
                 <div class="sample_information" style="width: 250px;">
+                    <span>
+                        {% if ticket.assignee %}
+                            Assigned to {{ ticket.assignee.username }}
+                        {% else %}
+                            Not assigned yet
+                        {% endif %}
+                    </span><br />
 
                     <span class="date">{{sound.created|date:"F jS, Y"}}</span><br />
                     {% if not moderators_version %}

--- a/templates/accounts/pending.html
+++ b/templates/accounts/pending.html
@@ -81,6 +81,13 @@
         have any uploaded sounds awaiting moderation.</p>
     {% endfor %}
 
+    {# TODO: provide info on how many sounds by this user are assigned to you, and if all - don't show 'assign to me' #}
+    <div class="moderation-user-list"><p>
+        <a href="{% url "tickets-moderation-assign-user" user.id %}">
+        <img src="{{media_url}}images/moderation_plus.png"/>
+            Assign all to me</a>
+    </p></div>
+
     {% if show_pagination %}
         {% show_paginator paginator page current_page request "moderation ticket" %}
     {% endif %}

--- a/templates/accounts/pending.html
+++ b/templates/accounts/pending.html
@@ -10,6 +10,11 @@
 
     <h2>Uploaded sounds awaiting moderation {% if moderators_version %} by  <a class="title" href="{% url "account" user.username %}">{{user.username}}</a>{% endif %}</h2>
 
+    {% if not no_assign_button %}
+    <p><a href="{% url 'tickets-moderation-assign-user-pending' user.id %}">
+        <img src="{{media_url}}images/moderation_plus.png" style="position: relative; top: 5px;"/>Assign all to me</a></p>
+    {% endif %}
+
     {% if show_pagination %}
         {% show_paginator paginator page current_page request "moderation ticket" %}
     {% endif %}
@@ -45,9 +50,9 @@
                 <div class="sample_information" style="width: 250px;">
                     <span>
                         {% if ticket.assignee %}
-                            Assigned to {{ ticket.assignee.username }}
+                            Assigned to <a href="{% url "account" ticket.assignee.username %}">{{ ticket.assignee.username }}</a>
                         {% else %}
-                            Not assigned yet
+                            <b>New</b>
                         {% endif %}
                     </span><br />
 
@@ -56,10 +61,17 @@
                         <a href="{% url "sound-edit" sound.user.username sound.id %}" class="icon" id="edit_link" title="edit sound">Edit sound information</a><br />
                     {% endif %}
                     See full <a href="{% url "tickets-ticket" ticket.key %}">moderation ticket</a><br />
+
                     {% with comments|first as last_comment %}
                         {% ifnotequal last_comment.sender_id user.id %}
                             <br><img src="{{media_url}}images/info_red.png" width="12" height="12" valign="middle" />
-                            <span style="color:#c65c56">The moderator handling this upload is waiting you to answer his last comment on the ticket ({{ last_comment.created|timesince}} ago).</span>
+                            <span style="color:#c65c56">The moderator handling this upload is waiting for
+                                {% if own_page %}
+                                you
+                                {%  else %}
+                                user
+                                {% endif %}
+                                to answer his last comment on the ticket ({{ last_comment.created|timesince}} ago).</span>
                         {% endifnotequal %}
                     {% endwith %}
                 </div>
@@ -87,13 +99,6 @@
         {% endif %}
         have any uploaded sounds awaiting moderation.</p>
     {% endfor %}
-
-    {# TODO: provide info on how many sounds by this user are assigned to you, and if all - don't show 'assign to me' #}
-    <p>
-        <a href="{% url 'tickets-moderation-assign-user-pending' user.id %}">
-        <img src="{{media_url}}images/moderation_plus.png" style="position: relative; top: 5px;"/>
-            Assign all to me</a>
-    </p>
 
     {% if show_pagination %}
         {% show_paginator paginator page current_page request "moderation ticket" %}

--- a/templates/accounts/pending.html
+++ b/templates/accounts/pending.html
@@ -50,7 +50,7 @@
                 <div class="sample_information" style="width: 250px;">
                     <span>
                         {% if ticket.assignee %}
-                            Assigned to <a href="{% url "account" ticket.assignee.username %}">{{ ticket.assignee.username }}</a>
+                            Assigned to moderator <a href="{% url "account" ticket.assignee.username %}">{{ ticket.assignee.username }}</a>
                         {% else %}
                             <b>New</b>
                         {% endif %}

--- a/templates/accounts/pending.html
+++ b/templates/accounts/pending.html
@@ -82,11 +82,11 @@
     {% endfor %}
 
     {# TODO: provide info on how many sounds by this user are assigned to you, and if all - don't show 'assign to me' #}
-    <div class="moderation-user-list"><p>
-        <a href="{% url "tickets-moderation-assign-user" user.id %}">
-        <img src="{{media_url}}images/moderation_plus.png"/>
+    <p>
+        <a href="{% url 'tickets-moderation-assign-user-pending' user.id %}">
+        <img src="{{media_url}}images/moderation_plus.png" style="position: relative; top: 5px;"/>
             Assign all to me</a>
-    </p></div>
+    </p>
 
     {% if show_pagination %}
         {% show_paginator paginator page current_page request "moderation ticket" %}

--- a/templates/tickets/moderation_home.html
+++ b/templates/tickets/moderation_home.html
@@ -45,7 +45,7 @@
             <div style="margin-top:-20px;height:30px;width:100px;margin-bottom:18px">
             {% if ticket.assignee.id != request.user.id %}
                 <p>
-                    <a href="{% url "tickets-moderation-assign-signle-ticket" user.id ticket.id %}">
+                    <a href="{% url 'tickets-moderation-assign-single-ticket' user.id ticket.id %}">
                         <img style="position: relative; top: 5px;" src="{{media_url}}images/moderation_plus.png" />Assign to me
                     </a>
                 </p>
@@ -65,7 +65,7 @@
             <div style="margin-top:-20px;height:30px;width:100px;margin-bottom:18px">
             {% if ticket.assignee.id != request.user.id %}
                 <p>
-                    <a href="{% url "tickets-moderation-assign-signle-ticket" user.id ticket.id %}">
+                    <a href="{% url 'tickets-moderation-assign-single-ticket' user.id ticket.id %}">
                         <img style="position: relative; top: 5px;" src="{{media_url}}images/moderation_plus.png" />Assign to me
                     </a>
                 </p>
@@ -82,7 +82,7 @@
                 {% include 'tickets/ticket_sound.html' %}
                 <div style="margin-top:-20px;height:30px;width:100px;margin-bottom:18px">
                 <p>
-                    <a href="{% url "tickets-moderation-assign-signle-ticket" user.id ticket.id %}">
+                    <a href="{% url 'tickets-moderation-assign-single-ticket' user.id ticket.id %}">
                         <img style="position: relative; top: 5px;" src="{{media_url}}images/moderation_plus.png" />Assign to me
                     </a>
                 </p>

--- a/templates/tickets/moderation_home.html
+++ b/templates/tickets/moderation_home.html
@@ -20,8 +20,8 @@
                     <div class="moderation-user-list-user-right">
                         <p>
                             <a href="{% url "account" user.username %}">{{ user.username }}</a>
-                            <br><a href="{% url "tickets-user-pending_sounds" user.username %}">{{ new_count }} new sounds</a>, {{ time }} day{{ time|pluralize }} in queue
-                            <br><a href="{% url "tickets-moderation-assign-user" user.id %}">
+                            <br><a href="{% url "tickets-user-pending_sounds" user.username %}">{{ new_count }} new sound{{ new_count|pluralize }}</a>, {{ time }} day{{ time|pluralize }} in queue
+                            <br><a href="{% url 'tickets-moderation-assign-user-new' user.id %}">
                             <img src="{{media_url}}images/moderation_plus.png"/>Assign to me</a>
                         </p>
                     </div>

--- a/templates/tickets/moderation_tardy_moderators.html
+++ b/templates/tickets/moderation_tardy_moderators.html
@@ -19,7 +19,7 @@
             <div style="margin-top:-20px;height:30px;width:100px;margin-bottom:18px">
             {% if ticket.assignee.id != request.user.id %}
                 <p>
-                    <a href="{% url "tickets-moderation-assign-signle-ticket" user.id ticket.id %}?next=tardy_moderators&p={{ current_page }}">
+                    <a href="{% url 'tickets-moderation-assign-single-ticket' user.id ticket.id %}?next=tardy_moderators&p={{ current_page }}">
                         <img style="position: relative; top: 5px;" src="{{media_url}}images/moderation_plus.png" />Assign to me
                     </a>
                 </p>

--- a/templates/tickets/moderation_tardy_users.html
+++ b/templates/tickets/moderation_tardy_users.html
@@ -20,7 +20,7 @@
             <div style="margin-top:-20px;height:30px;width:100px;margin-bottom:18px">
             {% if ticket.assignee.id != request.user.id %}
                 <p>
-                    <a href="{% url "tickets-moderation-assign-signle-ticket" user.id ticket.id %}?next=tardy_users&p={{ current_page }}">
+                    <a href="{% url 'tickets-moderation-assign-single-ticket' user.id ticket.id %}?next=tardy_users&p={{ current_page }}">
                         <img style="position: relative; top: 5px;" src="{{media_url}}images/moderation_plus.png" />Assign to me
                     </a>
                 </p>

--- a/templates/tickets/ticket.html
+++ b/templates/tickets/ticket.html
@@ -24,7 +24,13 @@
                      {{ ticket.assignee.username }}
                  {% else %}
                      no one
-                 {% endif %}</li>
+                 {% endif %}
+
+                 {# Show 'assign to me' link if the assigned moderator is not you #}
+                 {% if ticket.assignee.id != user.id %}
+                 (<a href="{% url 'tickets-moderation-assign-single-ticket' ticket.sender.id ticket.id %}?next=ticket">assign to me</a>)
+                 {% endif %}
+            </li>
             <li><em>status is</em> {{ ticket.status|capfirst }}</li>
             <li><em>queue is</em> {{ ticket.queue.name }}</li>
         </ul>

--- a/templates/tickets/ticket.html
+++ b/templates/tickets/ticket.html
@@ -74,7 +74,7 @@
             </form>
             {% endif %}
             
-            <h3>Ticket linked content</h3>
+            <h3>Ticket sound</h3>
             {% if ticket.sound %}
                   <div class="sound_list_moderation">
                       {% display_sound ticket.sound %}
@@ -90,12 +90,10 @@
                                                               Pending {% else %} OK {% endif %}</b>
                   <br>Sound's processing state is set to <b>{% if ticket.sound.processing_state == 'PE' %}
                                                               Pending {% else %} OK {% endif %}</b>
+                  </p>
             {% else %}
-                <p>No linked content
+                <p>This ticket has no assigned sound or the sound assigned to this ticket was deleted.</p>
             {% endif %}
-
-            
-
 
         </div> <!-- /#ticket-right -->
         <br style="clear: both;">

--- a/templates/tickets/ticket.html
+++ b/templates/tickets/ticket.html
@@ -66,10 +66,9 @@
         </div> <!-- /#ticket-left -->
 
         <div id="ticket-right">
-            {% if perms.tickets.can_moderate %}
+            {% if perms.tickets.can_moderate and ticket.sound %}
             <h3>Ticket controls</h3>
             <form action="." method="post">{% csrf_token %}
-                {{ ticket_form.as_p }}
                 {{ sound_form.as_p }}
                 <input type="submit" value="send" />
             </form>

--- a/templates/tickets/ticket.html
+++ b/templates/tickets/ticket.html
@@ -21,7 +21,7 @@
                  {% endif %}</li>
             <li><em>assigned to</em>
                  {% if ticket.assignee %}
-                     {{ ticket.assignee.username }}
+                     <a href="{% url "account" ticket.assignee.username %}">{{ ticket.assignee.username }}</a>
                  {% else %}
                      no one
                  {% endif %}

--- a/tickets/forms.py
+++ b/tickets/forms.py
@@ -63,8 +63,9 @@ class AnonymousContactForm(AnonymousMessageForm):
         super(AnonymousContactForm, self).__init__(*args, **kwargs)
         self.fields.keyOrder = ['email', 'title', 'message']
 
+
 # Sound moderation forms
-MODERATION_CHOICES = [(x,x) for x in \
+MODERATION_CHOICES = [(x, x) for x in
                       ['Approve',
                        'Delete',
                        'Defer',
@@ -96,27 +97,7 @@ class UserAnnotationForm(forms.Form):
                                  label='')
 
 
-TICKET_STATUS_CHOICES = [(x,x.capitalize()) for x in \
-                         [TICKET_STATUS_ACCEPTED,
-                          TICKET_STATUS_CLOSED,
-                          TICKET_STATUS_DEFERRED,
-                          TICKET_STATUS_NEW]]
-
-class TicketModerationForm(forms.Form):
-    status      = forms.ChoiceField(choices=TICKET_STATUS_CHOICES,
-                                    required=False,
-                                    label='Ticket status')
-
-    def __init__(self, *args, **kwargs):
-        super(TicketModerationForm, self).__init__(*args, **kwargs)
-        if 'initial' in kwargs:
-            state = kwargs['initial']['status']
-            if state == TICKET_STATUS_CLOSED:
-                self.fields['status'].widget.attrs['disabled'] = 'disabled'
-
 class SoundStateForm(forms.Form):
-    state       = forms.ChoiceField(choices=[("OK", "OK"),
-                                             ("PE", "Pending"),
-                                             ("DE", "Delete")],
-                                    required=False,
-                                    label='Sound state')
+    action = forms.ChoiceField(choices=MODERATION_CHOICES,
+                               required=False,
+                               label='Action:')

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -25,17 +25,18 @@ from django.test import TestCase
 from django.urls import reverse
 from models import Ticket, Queue
 from tickets import QUEUE_SOUND_MODERATION, QUEUE_SUPPORT_REQUESTS
-from tickets import TICKET_STATUS_NEW
+from tickets import TICKET_STATUS_NEW, TICKET_STATUS_ACCEPTED, TICKET_STATUS_CLOSED, TICKET_STATUS_DEFERRED
 from sounds.models import Sound
 import mock
 import sounds
 import tickets
 
 
-class TicketsTest(TestCase):
+class NewTicketTests(TestCase):
     fixtures = ['initial_data.json', 'moderation_test_users.json']
 
     def test_new_ticket(self):
+        """New tickets shouldn't have an assignee"""
         ticket = Ticket()
         ticket.status = 'new'
         ticket.sender = User.objects.get(username='test_user')
@@ -44,6 +45,7 @@ class TicketsTest(TestCase):
         self.assertEqual(ticket.assignee, None)
 
     def test_new_ticket_linked_sound(self):
+        """Sound should be properly linked to the ticket"""
         test_user = User.objects.get(username='test_user')
         ticket = Ticket()
         ticket.status = 'new'
@@ -58,76 +60,85 @@ class TicketsTest(TestCase):
         ticket.save()
         self.assertEqual(s.id, ticket.sound.id)
 
-    def _create_test_sound(self, moderation_state, processing_state, user, filename):
+
+class TicketTests(TestCase):
+    """Superclass that has several helper methods"""
+    fixtures = ['initial_data.json', 'moderation_test_users.json']
+
+    @staticmethod
+    def _create_test_sound(user, filename='test_sound.wav', moderation_state='PE', processing_state='OK'):
+        """Creates a sound with specified states"""
         sound = sounds.models.Sound.objects.create(
-                moderation_state=moderation_state,
-                processing_state=processing_state,
-                license=sounds.models.License.objects.get(pk=1),
-                user=user,
-                md5=hashlib.md5(filename).hexdigest(),
-                original_filename=filename)
+            moderation_state=moderation_state,
+            processing_state=processing_state,
+            license=sounds.models.License.objects.get(pk=1),
+            user=user,
+            md5=hashlib.md5(filename).hexdigest(),
+            original_filename=filename)
         return sound
 
-    def _create_ticket(self, sound, user):
+    @staticmethod
+    def _create_ticket(sound, user, ticket_status=TICKET_STATUS_NEW, ticket_assignee=None):
+        """Creates a ticket with specified parameters"""
         ticket = tickets.models.Ticket.objects.create(
-                title='Moderate sound test_sound.wav',
-                queue=Queue.objects.get(name='sound moderation'),
-                status=TICKET_STATUS_NEW,
-                sender=user,
-                sound=sound,
+            title='Moderate sound test_sound.wav',
+            queue=Queue.objects.get(name='sound moderation'),
+            status=ticket_status,
+            sender=user,
+            sound=sound,
+            assignee=ticket_assignee
         )
         return ticket
 
+    def setUp(self):
+        """Gets references to user and moderator, creates a sound and logs in as moderator"""
+        self.test_user = User.objects.get(username='test_user')
+        self.test_moderator = User.objects.get(username='test_moderator')
+        self.sound = self._create_test_sound(self.test_user)
+        self.client.login(username=self.test_moderator.username, password='123456')
+
+    def _create_assigned_ticket(self):
+        """Creates ticket that is already assigned to the moderator"""
+        return self._create_ticket(self.sound, self.test_user, ticket_status=TICKET_STATUS_ACCEPTED,
+                                   ticket_assignee=self.test_moderator)
+
+
+class MiscTicketTests(TicketTests):
     def test_new_sound_tickets_count(self):
-        test_user = User.objects.get(username='test_user')
-        sound = self._create_test_sound(moderation_state='PE', processing_state='OK',
-                                        user=test_user, filename='test_sound1.wav')
-        self._create_ticket(sound, test_user)
+        """New ticket count should only include new tickets without an assignee"""
+        # Normal ticket that is new and unassigned
+        self.ticket = self._create_ticket(self.sound, self.test_user)
 
         # New ticket for a moderated sound doesn't count
-        moderated_sound = self._create_test_sound(moderation_state='OK', processing_state='OK',
-                                                  user=test_user, filename='test_sound2.wav')
-        self._create_ticket(moderated_sound, test_user)
+        moderated_sound = self._create_test_sound(self.test_user, filename='test_sound2.wav', moderation_state='OK')
+        self._create_ticket(moderated_sound, self.test_user)
 
         # Accepted ticket doesn't count
-        accepted_sound = self._create_test_sound(moderation_state='PE', processing_state='OK',
-                                                 user=test_user, filename='test_sound3.wav')
-        acc_ticket = self._create_ticket(accepted_sound, test_user)
-        acc_ticket.status = tickets.TICKET_STATUS_ACCEPTED
-        acc_ticket.save()
+        accepted_sound = self._create_test_sound(self.test_user, filename='test_sound3.wav')
+        self._create_ticket(accepted_sound, self.test_user, ticket_status=TICKET_STATUS_ACCEPTED)
 
         # Ticket with an assigned moderator doesn't count
-        assigned_sound = self._create_test_sound(moderation_state='PE', processing_state='OK',
-                                                 user=test_user, filename='test_sound4.wav')
-        assigned_ticket = self._create_ticket(assigned_sound, test_user)
-        test_moderator = User.objects.get(username='test_moderator')
-        assigned_ticket.assignee = test_moderator
-        assigned_ticket.save()
+        assigned_sound = self._create_test_sound(self.test_user, filename='test_sound4.wav')
+        self._create_ticket(assigned_sound, self.test_user, ticket_assignee=self.test_moderator)
 
         count = tickets.views.new_sound_tickets_count()
         self.assertEqual(1, count)
 
     @mock.patch('tickets.models.send_mail_template')
     def test_send_notification_user(self, send_mail_mock):
-        test_user = User.objects.get(username='test_user')
-        assigned_sound = self._create_test_sound(moderation_state='PE', processing_state='OK',
-                                                 user=test_user, filename='test_sound4.wav')
-        assigned_ticket = self._create_ticket(assigned_sound, test_user)
-        test_moderator = User.objects.get(username='test_moderator')
-        assigned_ticket.assignee = test_moderator
-        assigned_ticket.save()
+        """Emails should be properly configured and sent with notifications"""
+        ticket = self._create_assigned_ticket()
 
-
-        assigned_ticket.send_notification_emails(
+        ticket.send_notification_emails(
                 tickets.models.Ticket.NOTIFICATION_APPROVED_BUT,
                 tickets.models.Ticket.USER_ONLY)
 
         local_vars = {
                 'send_to': [],
-                'ticket': assigned_ticket,
-                'self': assigned_ticket,
-                'user_to': assigned_ticket.sender,
-                'email_to': assigned_ticket.sender.email,
+                'ticket': ticket,
+                'self': ticket,
+                'user_to': ticket.sender,
+                'email_to': ticket.sender.email,
                 'notification_type': tickets.models.Ticket.NOTIFICATION_APPROVED_BUT,
                 'sender_moderator': tickets.models.Ticket.USER_ONLY
                 }
@@ -136,24 +147,75 @@ class TicketsTest(TestCase):
                 tickets.models.Ticket.NOTIFICATION_APPROVED_BUT,
                 local_vars,
                 'noreply@freesound.org',
-                 assigned_ticket.sender.email)
+                ticket.sender.email)
+
+
+class TicketTestsFromQueue(TicketTests):
+    """Ticket state changes in a response to actions from moderation queue"""
+    def setUp(self):
+        TicketTests.setUp(self)
+        self.ticket = self._create_assigned_ticket()
+
+    def _perform_action(self, action):
+        return self.client.post(reverse('tickets-moderation-assigned', args=[self.test_moderator.id]), {
+            'action': action, 'message': u'', 'ticket': self.ticket.id})
 
     @mock.patch('sounds.models.delete_sound_from_solr')
-    def test_delete_ticket(self, delete_sound_solr):
-        test_user = User.objects.get(username='test_user')
-        test_moderator = User.objects.get(username='test_moderator')
-        sound = self._create_test_sound(moderation_state='PE', processing_state='OK',
-                                        user=test_user, filename='test_sound1.wav')
-        ticket = self._create_ticket(sound, test_user)
+    def test_delete_ticket_from_queue(self, delete_sound_solr):
+        resp = self._perform_action(u'Delete')
 
-        self.client.login(username=test_moderator.username, password='123456')
-        resp = self.client.post(reverse('tickets-moderation-assigned', args=[test_moderator.id]),
-                                {
-                                    'action': u'Delete',
-                                    'message': u'',
-                                    'ticket': ticket.id
-                                })
         self.assertEqual(resp.status_code, 200)
-        delete_sound_solr.assert_called_once_with(sound.id)
+        delete_sound_solr.assert_called_once_with(self.sound.id)
 
-    # TODO: write moderation state change tests from mod queue as well as from ticket
+        self.ticket.refresh_from_db()
+        self.assertEqual(self.ticket.status, TICKET_STATUS_CLOSED)
+        self.assertIsNone(self.ticket.sound)
+
+    @mock.patch('tickets.views._whitelist_gearman')
+    def test_whitelist_from_queue(self, _whitelist_gearman):
+        self._perform_action(u'Whitelist')
+
+        _whitelist_gearman.assert_called_once_with([self.ticket.id])
+
+    def _assert_ticket_and_sound_fields(self, status, assignee, moderation_state):
+        self.ticket.refresh_from_db()
+        self.ticket.sound.refresh_from_db()
+        self.assertEqual(self.ticket.status, status)
+        self.assertEqual(self.ticket.sound.moderation_state, moderation_state)
+        if assignee is None:
+            self.assertIsNone(self.ticket.assignee)
+        else:
+            self.assertEqual(self.ticket.assignee, assignee)
+
+    def test_approve_ticket_from_queue(self):
+        resp = self._perform_action(u'Approve')
+        self.assertEqual(resp.status_code, 200)
+        self._assert_ticket_and_sound_fields(TICKET_STATUS_CLOSED, self.test_moderator, 'OK')
+
+    def test_return_ticket_from_queue(self):
+        resp = self._perform_action(u'Return')
+        self.assertEqual(resp.status_code, 200)
+        self._assert_ticket_and_sound_fields(TICKET_STATUS_NEW, None, 'PE')
+
+    def test_defer_ticket_from_queue(self):
+        resp = self._perform_action(u'Defer')
+        self.assertEqual(resp.status_code, 200)
+        self._assert_ticket_and_sound_fields(TICKET_STATUS_DEFERRED, self.test_moderator, 'PE')
+
+
+class TicketTestsFromTicketViewOwn(TicketTestsFromQueue):
+    """Ticket state changes in a response to actions from ticket inspection page for own ticket"""
+    def _perform_action(self, action):
+        return self.client.post(reverse('tickets-ticket', args=[self.ticket.key]), {
+            'ss-action': action})
+
+
+class TicketTestsFromTicketViewNew(TicketTestsFromQueue):
+    """Ticket state changes in a response to actions from ticket inspection page for new ticket"""
+    def setUp(self):
+        TicketTests.setUp(self)
+        self.ticket = self._create_ticket(self.sound, self.test_user)
+
+    def _perform_action(self, action):
+        return self.client.post(reverse('tickets-ticket', args=[self.ticket.key]), {
+            'ss-action': action})

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -155,3 +155,5 @@ class TicketsTest(TestCase):
                                 })
         self.assertEqual(resp.status_code, 200)
         delete_sound_solr.assert_called_once_with(sound.id)
+
+    # TODO: write moderation state change tests from mod queue as well as from ticket

--- a/tickets/urls.py
+++ b/tickets/urls.py
@@ -38,9 +38,13 @@ urlpatterns = [
         moderation_tardy_moderators_sounds,
         name='tickets-moderation-tardy-moderators'),
 
-    url(r'^moderation/assign/(?P<user_id>\d+)/$',
+    url(r'^moderation/assign/(?P<user_id>\d+)/new$',
         moderation_assign_user,
-        name='tickets-moderation-assign-user'),
+        name='tickets-moderation-assign-user-new'),
+
+    url(r'^moderation/assign/(?P<user_id>\d+)/pending$',
+        moderation_assign_user_pending,
+        name='tickets-moderation-assign-user-pending'),
 
     url(r'^moderation/assigned/(?P<user_id>\d+)/$',
         moderation_assigned,

--- a/tickets/urls.py
+++ b/tickets/urls.py
@@ -48,7 +48,7 @@ urlpatterns = [
 
     url(r'^moderation/assign/ticket/(?P<user_id>\d+)/(?P<ticket_id>\d+)/$',
         moderation_assign_single_ticket,
-        name='tickets-moderation-assign-signle-ticket'),
+        name='tickets-moderation-assign-single-ticket'),
 
     url(r'^moderation/annotations/(?P<user_id>\d+)/$',
         user_annotations,

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -535,7 +535,7 @@ def get_pending_sounds(user):
     # gets all tickets from a user that have not been closed
 
     ret = []
-    user_tickets = Ticket.objects.filter(sender=user).exclude(status=TICKET_STATUS_CLOSED)
+    user_tickets = Ticket.objects.filter(sender=user).exclude(status=TICKET_STATUS_CLOSED).order_by('-assignee')
 
     for user_ticket in user_tickets:
         sound = user_ticket.sound

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -342,6 +342,8 @@ def moderation_assign_single_ticket(request, user_id, ticket_id):
             return redirect("tickets-moderation-tardy-users")
         elif next == "tardy_moderators":
             return redirect(reverse("tickets-moderation-tardy-moderators")+"?page=%s" % p)
+        elif next == "ticket":
+            return redirect(reverse("tickets-ticket", kwargs={'ticket_key': ticket.key}))
         else:
             return redirect(reverse("tickets-moderation-home")+"?page=%s" % p)
     else:

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -108,51 +108,66 @@ def ticket(request, ticket_key):
             else:
                 clean_comment_form = False
         # update sound ticket
-        elif is_selected(request, 'tm') or is_selected(request, 'ss'):
-            ticket_form = TicketModerationForm(request.POST, prefix="tm")
-            sound_form = SoundStateForm(request.POST, prefix="ss")
-            if ticket_form.is_valid() and sound_form.is_valid():
+        elif is_selected(request, 'ss'):
+            sound_form = SoundStateForm(request.POST, prefix='ss')
+            if sound_form.is_valid():
                 clean_status_forms = True
                 clean_comment_form = True
-                sound_state = sound_form.cleaned_data.get('state')
-                # Sound should be deleted
-                if sound_state == 'DE':
+                sound_action = sound_form.cleaned_data.get('action')
+                comment = 'Moderator {} '.format(request.user)
+                notification = None
+
+                # If there is no one assigned, then changing the state self-assigns the ticket
+                if ticket.assignee is None:
+                    ticket.assignee = request.user
+
+                if sound_action == 'Delete':
                     if ticket.sound:
                         ticket.sound.delete()
                         ticket.sound = None
                     ticket.status = TICKET_STATUS_CLOSED
-                    tc = TicketComment(sender=request.user,
-                                       text="Moderator %s deleted the sound and closed the ticket" % request.user,
-                                       ticket=ticket,
-                                       moderator_only=False)
-                    tc.save()
-                    ticket.send_notification_emails(ticket.NOTIFICATION_DELETED,
+                    comment += 'deleted the sound and closed the ticket'
+                    notification = ticket.NOTIFICATION_DELETED
+
+                elif sound_action == 'Defer':
+                    ticket.status = TICKET_STATUS_DEFERRED
+                    ticket.sound.change_moderation_state('PE')  # not sure if this state have been used before
+                    comment += 'deferred the ticket'
+
+                elif sound_action == "Return":
+                    ticket.status = TICKET_STATUS_NEW
+                    ticket.assignee = None
+                    ticket.sound.change_moderation_state('PE')
+                    comment += 'returned the ticket to new sounds queue'
+
+                elif sound_action == 'Approve':
+                    ticket.status = TICKET_STATUS_CLOSED
+                    ticket.sound.change_moderation_state('OK')
+                    comment += 'approved the sound and closed the ticket'
+                    notification = ticket.NOTIFICATION_APPROVED
+
+                elif sound_action == 'Whitelist':
+                    _whitelist_gearman([ticket.id])  # async job should take care of whitelisting
+                    comment += 'whitelisted all sounds from user {}'.format(ticket.sender)
+                    notification = ticket.NOTIFICATION_WHITELISTED
+
+                if notification is not None:
+                    ticket.send_notification_emails(notification,
                                                     ticket.USER_ONLY)
-                # Set another sound state that's not delete
-                else:
-                    if ticket.sound:
-                        ticket.sound.moderation_state = sound_state
-                        # Mark the index as dirty so it'll be indexed in Solr
-                        if sound_state == "OK":
-                            ticket.sound.mark_index_dirty()
-                        ticket.sound.save()
-                    ticket.status = ticket_form.cleaned_data.get('status')
-                    tc = TicketComment(sender=request.user,
-                                       text="Moderator %s set the sound to %s and the ticket to %s." %
-                                            (request.user,
-                                             'pending' if sound_state == 'PE' else sound_state,
-                                             ticket.status),
-                                       ticket=ticket,
-                                       moderator_only=False)
-                    tc.save()
-                    ticket.send_notification_emails(ticket.NOTIFICATION_UPDATED,
-                                                    ticket.USER_ONLY)
+
+                if ticket.sound is not None:
+                    ticket.sound.save()
+
                 ticket.save()
+                tc = TicketComment(sender=request.user,
+                                   text=comment,
+                                   ticket=ticket,
+                                   moderator_only=False)
+                tc.save()
 
     if clean_status_forms:
-        ticket_form = TicketModerationForm(initial={'status': ticket.status}, prefix="tm")
-        state = ticket.sound.moderation_state if ticket.sound else 'DE'
-        sound_form = SoundStateForm(initial={'state': state}, prefix="ss")
+        default_action = 'Return' if ticket.sound and ticket.sound.moderation_state == 'OK' else 'Approve'
+        sound_form = SoundStateForm(initial={'action': default_action}, prefix="ss")
     if clean_comment_form:
         tc_form = _get_tc_form(request, False)
 
@@ -160,7 +175,6 @@ def ticket(request, ticket_key):
     tvars = {"ticket": ticket,
              "num_sounds_pending": num_sounds_pending,
              "tc_form": tc_form,
-             "ticket_form": ticket_form,
              "sound_form": sound_form,
              "can_view_moderator_only_messages": can_view_moderator_only_messages}
     return render(request, 'tickets/ticket.html', tvars)
@@ -360,6 +374,12 @@ def moderation_assign_single_ticket(request, user_id, ticket_id):
         return redirect("tickets-moderation-home")
 
 
+def _whitelist_gearman(ticket_ids):
+    gm_client = gearman.GearmanClient(settings.GEARMAN_JOB_SERVERS)
+    gm_client.submit_job("whitelist_user", json.dumps(ticket_ids),
+                         wait_until_complete=False, background=True)
+
+
 @permission_required('tickets.can_moderate')
 @transaction.atomic()
 def moderation_assigned(request, user_id):
@@ -422,9 +442,7 @@ def moderation_assigned(request, user_id):
 
             elif action == "Whitelist":
                 ticket_ids = list(tickets.values_list('id',flat=True))
-                gm_client = gearman.GearmanClient(settings.GEARMAN_JOB_SERVERS)
-                gm_client.submit_job("whitelist_user", json.dumps(ticket_ids),
-                        wait_until_complete=False, background=True)
+                _whitelist_gearman(ticket_ids)
                 notification = Ticket.NOTIFICATION_WHITELISTED
 
                 users = set(tickets.values_list('sender__username', flat=True))

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -551,9 +551,11 @@ def pending_tickets_per_user(request, username):
     user = get_object_or_404(User, username=username)
     tickets_sounds = get_pending_sounds(user)
     pendings = []
+    mods = set()
     for ticket, sound in tickets_sounds:
         last_comments = ticket.get_n_last_non_moderator_only_comments(3)
         pendings.append( (ticket, sound, last_comments) )
+        mods.add(ticket.assignee)
 
     show_pagination = len(pendings) > settings.SOUNDS_PENDING_MODERATION_PER_PAGE
 
@@ -567,12 +569,14 @@ def pending_tickets_per_user(request, username):
 
     moderators_version = True
     own_page = user == request.user
+    no_assign_button = len(mods) == 0 or (len(mods) == 1 and request.user in mods)
 
     paginated = paginate(request, pendings, settings.SOUNDS_PENDING_MODERATION_PER_PAGE)
     tvars = {"show_pagination": show_pagination,
              "moderators_version": moderators_version,
              "user": user,
-             "own_page": own_page}
+             "own_page": own_page,
+             "no_assign_button": no_assign_button}
     tvars.update(paginated)
 
     return render(request, 'accounts/pending.html', tvars)


### PR DESCRIPTION
Addresses issues #1092 and #1142 
- In the ticket view page:
  - the sidebar with ticket and sound state change has been changed to be similar to ticket actions in the moderation queue page
  - added "assign to me" button that shows up if the assignee is different from you
- In the pending sounds by user page:
  - sounds with no mod assigned to the ticket are shown on top and have indication of it in the info box
  - sounds with mod assigned have the assignee shown in the info box to the right 
  - if there are some sounds that are not assigned to you, the button 'assign all to me' is shown that assigns all sounds (new and already assigned)
- Fixed some display inconsistencies, typos and errors
- Added tests to verify that ticket and sound state change are working as intended