### PR TITLE
Add cache name back to cache tag.

### DIFF
--- a/templates/sounds/packs.html
+++ b/templates/sounds/packs.html
@@ -15,7 +15,7 @@
 <li><a href="?order=-num_sounds" {% ifequal order "-num_sounds" %}class="selected"{% endifequal %}>number of sounds</a></li>
 <li><a href="?order=-num_downloads" {% ifequal order "-num_downloads" %}class="selected"{% endifequal %}>number of downloads</a></li>
 </ul>
-{% cache 3600 user.id order current_page %}
+{% cache 3600 packs user.id order current_page %}
 <p>{% show_paginator paginator page current_page request "pack" %}</p>
 
 {% for pack in page.object_list %}


### PR DESCRIPTION
I incorrectly thought that all parameters of the cache template tag
were variables to make the cache on, but the first parameter is a
name. This was causing users to see cached pages for other user's
pack lists. Bug introduced in db15d13e7c
reported at https://freesound.org/forum/bug-reports-errors-and-feature-requests/41145/