### PR TITLE
Extra email bounce functionality

### DIFF
--- a/accounts/management/commands/process_email_bounces.py
+++ b/accounts/management/commands/process_email_bounces.py
@@ -24,12 +24,21 @@ from django.contrib.auth.models import User
 from django.utils.dateparse import parse_datetime
 from django.db import IntegrityError
 from accounts.models import EmailBounce
+from utils.filesystem import create_directories
 from boto3 import client
 import json
 import logging
+import time
+import os
 
 logger_web = logging.getLogger('web')
 logger_console = logging.getLogger('console')
+
+
+def create_dump_file():
+    path = os.path.join(settings.DATA_PATH, 'bounced_emails')
+    create_directories(path)
+    return os.path.join(path, time.strftime('%Y%m%d_%H%M') + '.json')
 
 
 class Command(BaseCommand):
@@ -41,6 +50,23 @@ class Command(BaseCommand):
     # can speed up the process, but there will be redundancy in the received data, thus among 10 messages received there
     # might be only 4~5 unique ones. FIFO queues don't have the duplication issue, but the messages are delivered in
     # FIFO manner.
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--save',
+            action='store_true',
+            dest='save',
+            default=False,
+            help="Save all bounce messages on disk",
+        )
+
+        parser.add_argument(
+            '--no-delete',
+            action='store_true',
+            dest='no_delete',
+            default=False,
+            help="Don't delete messages from queue",
+        )
 
     def handle(self, *args, **options):
         if not settings.AWS_REGION or not settings.AWS_SECRET_ACCESS_KEY or not settings.AWS_SECRET_ACCESS_KEY:
@@ -57,6 +83,11 @@ class Command(BaseCommand):
             logger_console.warn('Invalid value for number messages to process per call: {}, using 1'.format(messages_per_call))
             messages_per_call = 1
 
+        save_messages = options['save']
+        no_delete = options['no_delete']
+        if no_delete:
+            logger_console.info('Running without deleting messages from queue (one batch)')
+
         sqs = client('sqs', region_name=settings.AWS_REGION,
                      aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
                      aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
@@ -64,6 +95,7 @@ class Command(BaseCommand):
         total_messages = 0
         total_bounces = 0  # counts multiple recipients of the same mail
         has_messages = True
+        all_messages = []
 
         while has_messages:
             # Receive message from SQS queue
@@ -74,13 +106,13 @@ class Command(BaseCommand):
                 WaitTimeSeconds=0
             )
             messages = response.get('Messages', [])
-            has_messages = len(messages) > 0
+            has_messages = not no_delete and len(messages) > 0
 
             for message in messages:
                 receipt_handle = message['ReceiptHandle']
                 body = json.loads(message['Body'])
-
                 data = json.loads(body['Message'])
+
                 if data['notificationType'] == 'Bounce':
                     bounce_data = data['bounce']
                     bounce_type = EmailBounce.type_from_string(bounce_data['bounceType'])
@@ -98,12 +130,21 @@ class Command(BaseCommand):
                         except IntegrityError:  # message duplicated
                             is_duplicate = True
 
-                    sqs.delete_message(
-                        QueueUrl=queue_url,
-                        ReceiptHandle=receipt_handle
-                    )
+                    if not no_delete:
+                        sqs.delete_message(
+                            QueueUrl=queue_url,
+                            ReceiptHandle=receipt_handle
+                        )
+
                     if not is_duplicate:
                         total_messages += 1
+                        if save_messages:
+                            all_messages.append(data)
+
+        if save_messages:
+            filename = create_dump_file()
+            with open(filename, 'w') as fp:
+                json.dump(all_messages, fp)
 
         result = {'nMailsBounced': total_messages, 'nBounces': total_bounces}
         logger_web.info('Finished processing messages from queue ({})'.format(json.dumps(result)))

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -33,6 +33,7 @@ from django.conf import settings
 from accounts.models import Profile, EmailPreferenceType, SameUser, ResetEmailRequest, OldUsername, EmailBounce
 from accounts.views import handle_uploaded_image
 from accounts.forms import FsPasswordResetForm, DeleteUserForm, UsernameField, RegistrationForm
+from accounts.management.commands.process_email_bounces import decode_idna_email
 from sounds.models import License, Sound, Pack, DeletedSound, SoundOfTheDay, BulkUploadProgress
 from tags.models import TaggedItem
 from utils.filesystem import File
@@ -1397,6 +1398,11 @@ class EmailBounceTests(TestCase):
         call_command('process_email_bounces')
 
         self.assertFalse(user.profile.email_is_valid())
+
+    def test_idna_email(self):
+        encoded_email = u'user@xn--eb-tbv.de'
+        decoded_email = u'user@\u2211eb.de'
+        self.assertEquals(decoded_email, decode_idna_email(encoded_email))
 
 
 class ProfileEmailIsValid(TestCase):

--- a/utils/filesystem.py
+++ b/utils/filesystem.py
@@ -21,6 +21,7 @@
 import os
 import zlib
 import hashlib
+import errno
 
 
 class File:
@@ -88,3 +89,12 @@ def crc32file(filename):
 def remove_directory_if_empty(path):
     if not os.listdir(path):
         os.rmdir(path)
+
+
+def create_directories(path):
+    if not os.path.exists(path):
+        try:
+            os.makedirs(path)
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise


### PR DESCRIPTION
- Add --save option for `process_email_bounces` command that saves bounce messages as a JSON array in the `freesound-data/bounced_emails` directory. Creates one file per execution with the name being the datetime of execution.
- Address problem of IDNA (punycode) encoded email domains that are returned from AWS (`user@xn--...`)