### PR TITLE
Add option to toggle map styles

### DIFF
--- a/media/css/all.css
+++ b/media/css/all.css
@@ -3129,6 +3129,24 @@ use classes from pack edition
     margin-bottom: 20px;
 }
 
+.map_terrain_menu {
+    position:absolute;
+    background: #fff;
+    padding: 8px;
+    right: 52px;
+    top: 8px;
+    border-radius: 5px;
+    line-height: 24px;
+    border: 2px solid rgba(100,100,100, 0.1);
+    cursor: pointer;
+    background-clip: padding-box;
+}
+
+.map_terrain_menu:hover {
+    background: #eeeeee;
+    background-clip: padding-box;
+}
+
 /* Describe google map
 ------------------------------------------------------*/
 .describe-geotag-form {

--- a/media/js/maps-mapbox.js
+++ b/media/js/maps-mapbox.js
@@ -1,3 +1,6 @@
+var FREESOUND_SATELLITE_STYLE_ID = 'cjgxefqkb00142roas6kmqneq';
+var FREESOUND_STREETS_STYLE_ID = 'cjkmk0h7p79z32spe9j735hrd';
+
 function setMaxZoomCenter(lat, lng, zoom) {
     window.map.flyTo({'center': [lng, lat], 'zoom': zoom - 1});  // Subtract 1 for compatibility with gmaps zoom levels
 }
@@ -44,7 +47,7 @@ function call_on_bounds_chage_callback(map, map_element_id, callback){
 }
 
 function make_sounds_map(geotags_url, map_element_id, on_built_callback, on_bounds_changed_callback,
-                         center_lat, center_lon, zoom, show_search, cluster){
+                         center_lat, center_lon, zoom, show_search, show_style_selector, cluster){
     /*
     This function is used to display maps with sounds. It is used in all pages where maps with markers (which represent
     sounds) are shown: user home/profile, pack page, geotags map, embeds. Parameters:
@@ -60,6 +63,7 @@ function make_sounds_map(geotags_url, map_element_id, on_built_callback, on_boun
     - center_lon: latitude where to center the map (if not specified, it is automatically determined based on markers)
     - zoom: initial zoom for the map (if not specified, it is automatically determined based on markers)
     - show_search: display search bar to fly to places in the map
+    - show_terrain_selector: display button to switch between streets and satellite styles
     - cluster: whether or not to perform point clustering (on by default)
 
     This function first calls the Freesound endpoint which returns the list of geotags to be displayed as markers.
@@ -88,7 +92,7 @@ function make_sounds_map(geotags_url, map_element_id, on_built_callback, on_boun
             // Init map and info window objects
             var map = new mapboxgl.Map({
               container: map_element_id, // HTML container id
-              style: 'mapbox://styles/freesound/cjgxefqkb00142roas6kmqneq', // style URL (custom style with satellite and labels)
+              style: 'mapbox://styles/freesound/' + FREESOUND_SATELLITE_STYLE_ID, // style URL
               center: [init_lon, init_lat], // starting position as [lng, lat]
               zoom: init_zoom - 1,  // Subtract 1 for compatibility with gmaps zoom levels
               maxZoom: 18,
@@ -123,6 +127,81 @@ function make_sounds_map(geotags_url, map_element_id, on_built_callback, on_boun
             });
 
             map.on('load', function() {
+
+                // Add satellite/streets controls
+                if (show_style_selector === true) {
+                    $('#' + map_element_id).append('<div class="map_terrain_menu" onclick="toggleMapStyle()">Show streets</div>');
+                }
+
+                // Add popups
+                map.on('click', 'sounds-unclustered', function (e) {
+
+                    stopAll();
+                    var coordinates = e.features[0].geometry.coordinates.slice();
+                    var sound_id = e.features[0].properties.id;
+
+                    ajaxLoad( '/geotags/infowindow/' + sound_id, function(data, responseCode)
+                    {
+                        // Ensure that if the map is zoomed out such that multiple
+                        // copies of the feature are visible, the popup appears
+                        // over the copy being pointed to.
+                        while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+                            coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+                        }
+                        var popup = new mapboxgl.Popup()
+                            .setLngLat(coordinates)
+                            .setHTML(data.response)
+                            .addTo(map);
+
+                        popup.on('close', function(e) {
+                            stopAll();  // Stop sound on popup close
+                        });
+                        makePlayer('.infowindow_player .player');
+                    });
+                });
+
+                // Change the cursor to a pointer when the mouse is over the places layer.
+                map.on('mouseenter', 'sounds-unclustered', function () {
+                    map.getCanvas().style.cursor = 'pointer';
+                });
+
+                // Change it back to a pointer when it leaves.
+                map.on('mouseleave', 'sounds-unclustered', function () {
+                    map.getCanvas().style.cursor = '';
+                });
+
+                // Zoom-in when clicking on clusters
+                map.on('click', 'sounds-clusters', function (e) {
+                    map.flyTo({'center': e.lngLat, 'zoom': map.getZoom() + 4});
+                });
+
+                // Adjust map boundaries
+                if (center_lat === undefined){
+                    // If initital center and zoom were not given, adjust map boundaries now based on the sounds
+                    if (nSounds > 1){
+                        map.fitBounds(bounds, {duration:0, padding: {top:40, right:40, left:40, bottom:40}});
+                    } else {
+                        map.setZoom(3);
+                        map.setCenter(geojson_features[0].geometry.coordinates);
+                    }
+                }
+
+                // Run callback function (if passed) after map is built
+                if (on_built_callback !== undefined){
+                    on_built_callback();
+                }
+
+                // Add listener for callback on bounds changed
+                if (on_bounds_changed_callback !== undefined) {
+                    call_on_bounds_chage_callback(map, map_element_id, on_bounds_changed_callback);
+                    map.on('moveend', function(e) {
+                        call_on_bounds_chage_callback(map, map_element_id, on_bounds_changed_callback);
+                    });
+                }
+            });
+
+
+            map.on('style.load', function () {  // Triggered when `setStyle` is called, add all data layers
                 map.loadImage('/media/images/map_marker.png', function(error, image) {
                     map.addImage("custom-marker", image);
 
@@ -202,72 +281,6 @@ function make_sounds_map(geotags_url, map_element_id, on_built_callback, on_boun
                             "icon-allow-overlap": true,
                         }
                     });
-
-                    // Add popups
-                    map.on('click', 'sounds-unclustered', function (e) {
-
-                        stopAll();
-                        var coordinates = e.features[0].geometry.coordinates.slice();
-                        var sound_id = e.features[0].properties.id;
-
-                        ajaxLoad( '/geotags/infowindow/' + sound_id, function(data, responseCode)
-                        {
-                            // Ensure that if the map is zoomed out such that multiple
-                            // copies of the feature are visible, the popup appears
-                            // over the copy being pointed to.
-                            while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
-                                coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
-                            }
-                            var popup = new mapboxgl.Popup()
-                                .setLngLat(coordinates)
-                                .setHTML(data.response)
-                                .addTo(map);
-
-                            popup.on('close', function(e) {
-                                stopAll();  // Stop sound on popup close
-                            });
-                            makePlayer('.infowindow_player .player');
-                        });
-                    });
-
-                    // Change the cursor to a pointer when the mouse is over the places layer.
-                    map.on('mouseenter', 'sounds-unclustered', function () {
-                        map.getCanvas().style.cursor = 'pointer';
-                    });
-
-                    // Change it back to a pointer when it leaves.
-                    map.on('mouseleave', 'sounds-unclustered', function () {
-                        map.getCanvas().style.cursor = '';
-                    });
-
-                    // Zoom-in when clicking on clusters
-                    map.on('click', 'sounds-clusters', function (e) {
-                        map.flyTo({'center': e.lngLat, 'zoom': map.getZoom() + 4});
-                    });
-
-                    // Adjust map boundaries
-                    if (center_lat === undefined){
-                        // If initital center and zoom were not given, adjust map boundaries now based on the sounds
-                        if (nSounds > 1){
-                            map.fitBounds(bounds, {duration:0, padding: {top:40, right:40, left:40, bottom:40}});
-                        } else {
-                            map.setZoom(3);
-                            map.setCenter(geojson_features[0].geometry.coordinates);
-                        }
-                    }
-
-                    // Run callback function (if passed) after map is built
-                    if (on_built_callback !== undefined){
-                        on_built_callback();
-                    }
-
-                    // Add listener for callback on bounds changed
-                    if (on_bounds_changed_callback !== undefined) {
-                        call_on_bounds_chage_callback(map, map_element_id, on_bounds_changed_callback);
-                        map.on('moveend', function(e) {
-                            call_on_bounds_chage_callback(map, map_element_id, on_bounds_changed_callback);
-                        });
-                    }
                 });
             });
         }
@@ -276,7 +289,7 @@ function make_sounds_map(geotags_url, map_element_id, on_built_callback, on_boun
 
 
 function make_geotag_edit_map(map_element_id, arrow_url, on_bounds_changed_callback,
-                              center_lat, center_lon, zoom){
+                              center_lat, center_lon, zoom, idx){
 
     /*
     This function is used to display the map used to add a geotag to a sound maps with sounds. It is used in the sound
@@ -290,6 +303,7 @@ function make_geotag_edit_map(map_element_id, arrow_url, on_bounds_changed_callb
     - center_lat: latitude where to center the map (if not specified, it uses a default one)
     - center_lon: latitude where to center the map (if not specified, it uses a default one)
     - zoom: initial zoom for the map (if not specified, it uses a default one)
+    - idx: map idx (used when creating multiple maps)
 
     This function returns the object of the map that has been created.
      */
@@ -313,8 +327,36 @@ function make_geotag_edit_map(map_element_id, arrow_url, on_bounds_changed_callb
     map.addControl(new mapboxgl.NavigationControl({ showCompass: false }));
     map.addControl(new MapboxGeocoder({ accessToken: mapboxgl.accessToken }), 'top-left');
 
+    map.toggleStyle = function() {
+        toggleMapStyle(map, map_element_id);
+    };
 
     map.on('load', function() {
+        // Add controls for toggling style
+        $('#' + map_element_id).append('<div class="map_terrain_menu" onclick="toggleMapStyle(' + idx + ')">Show streets</div>');
+
+        // Add listener for callback on bounds changed
+        if (on_bounds_changed_callback !== undefined) {
+            // Initial call to on_bounds_changed_callback
+            call_on_bounds_chage_callback(map, map_element_id, on_bounds_changed_callback);
+        }
+        map.on('move', function(e) {
+            if (on_bounds_changed_callback !== undefined) {
+                call_on_bounds_chage_callback(map, map_element_id, on_bounds_changed_callback);
+            }
+            var new_map_lat = map.getCenter().lat;
+            var new_map_lon = map.getCenter().lng;
+            map.getSource('position-marker').setData({
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [new_map_lon, new_map_lat]
+                }
+            });
+        });
+    });
+
+    map.on('style.load', function () {  // Triggered when `setStyle` is called, add all data layers
         map.loadImage('/media/images/map_marker.png', function(error, image) {
             map.addImage("custom-marker", image);
 
@@ -339,29 +381,40 @@ function make_geotag_edit_map(map_element_id, arrow_url, on_bounds_changed_callb
                 }
             });
 
-
-            // Add listener for callback on bounds changed
-            if (on_bounds_changed_callback !== undefined) {
-                // Initial call to on_bounds_changed_callback
-                call_on_bounds_chage_callback(map, map_element_id, on_bounds_changed_callback);
-            }
-            map.on('move', function(e) {
-                if (on_bounds_changed_callback !== undefined) {
-                    call_on_bounds_chage_callback(map, map_element_id, on_bounds_changed_callback);
+            // Update marker
+            var new_map_lat = map.getCenter().lat;
+            var new_map_lon = map.getCenter().lng;
+            map.getSource('position-marker').setData({
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [new_map_lon, new_map_lat]
                 }
-                var new_map_lat = map.getCenter().lat;
-                var new_map_lon = map.getCenter().lng;
-                map.getSource('position-marker').setData({
-                    "type": "Feature",
-                    "geometry": {
-                        "type": "Point",
-                        "coordinates": [new_map_lon, new_map_lat]
-                    }
-                });
-
             });
         });
     });
 
     return map;
+}
+
+function toggleMapStyle(idx){
+
+    if (window.map !== undefined){
+        var map = window.map;
+    } else {
+        // if idx is passed, it means map objects will have been saved in maps variable
+        var map = window.maps[idx];
+    }
+    var map_element_id = $(map.getCanvas()).parent().parent().attr('id');
+
+    if (map.getStyle().sprite.indexOf(FREESOUND_STREETS_STYLE_ID) !== -1){
+        // Using streets map, switch to satellite
+        map.setStyle('mapbox://styles/freesound/' + FREESOUND_SATELLITE_STYLE_ID);
+        $('#' + map_element_id).find('.map_terrain_menu')[0].innerText = 'Show streets';
+
+    } else {
+        // Using satellite map, switch to streets
+        map.setStyle('mapbox://styles/freesound/' + FREESOUND_STREETS_STYLE_ID);
+        $('#' + map_element_id).find('.map_terrain_menu')[0].innerText = 'Show terrain';
+    }
 }

--- a/templates/accounts/describe_sounds.html
+++ b/templates/accounts/describe_sounds.html
@@ -8,6 +8,7 @@
     <script>
         // Maps variables
         var maps = {};
+        window.maps = maps;
         var centerMarkers = {};
 
         // Tag recommendation variables
@@ -143,7 +144,7 @@
                 center_lon = $("#id_" + idx0 + "-lon").val();
                 zoom = $("#id_" + idx0 + "-zoom").val();
             }
-            maps[idx] = make_geotag_edit_map('gmap' + idx, '{{media_url}}/images/arrow.png', updateLatLonZoomFields, center_lat, center_lon, zoom);
+            maps[idx] = make_geotag_edit_map('gmap' + idx, '{{media_url}}/images/arrow.png', updateLatLonZoomFields, center_lat, center_lon, zoom, idx);
         }
 
 

--- a/templates/geotags/geotag_picker_help_tool.html
+++ b/templates/geotags/geotag_picker_help_tool.html
@@ -11,7 +11,7 @@
                 '<div style="text-align:center;"><i>latitude, longitude, zoom</i>: <input id="geotag_picker_out" size="24" type="text"></input> <a href="javascript:void(0);" onclick="copyValue();">copy to clipboard</a></div>' +
                 '</div>'
             );
-            make_geotag_edit_map('geotag_picker_map', '{{media_url}}/images/arrow.png', showLatLonZoomFields);
+            window.map = make_geotag_edit_map('geotag_picker_map', '{{media_url}}/images/arrow.png', showLatLonZoomFields);
         }
     }
 

--- a/templates/geotags/geotags.html
+++ b/templates/geotags/geotags.html
@@ -93,7 +93,8 @@
     {% endif %}
 
     var show_search = true;
-    make_sounds_map(url, 'map_canvas', hideLoadingIndicator, updateEmbedCode, center_lat, center_lon, zoom, show_search);
+    var show_style_selector = true;
+    make_sounds_map(url, 'map_canvas', hideLoadingIndicator, updateEmbedCode, center_lat, center_lon, zoom, show_search, show_style_selector);
 
     var current_lat;
     var current_lon;

--- a/templates/geotags/geotags_box_iframe.html
+++ b/templates/geotags/geotags_box_iframe.html
@@ -45,8 +45,9 @@
     {% endif %}
 
     var show_search = false;
+    var show_style_selector = true;
     var cluster = {{cluster|yesno:"true,false"}};
-    make_sounds_map(url, 'map_canvas', undefined, undefined, center_lat, center_lon, zoom, show_search, cluster);
+    make_sounds_map(url, 'map_canvas', undefined, undefined, center_lat, center_lon, zoom, show_search, show_style_selector, cluster);
 </script>
 
 </body>

--- a/templates/sounds/geotag.html
+++ b/templates/sounds/geotag.html
@@ -16,6 +16,8 @@
 </p>
 <div id="map_canvas" style="width: 800px; height: 600px; border: 1px solid black;"></div>
 <script type="text/javascript">
-    make_sounds_map('{% url "geotags-for-sound-barray" sound.id %}', 'map_canvas', undefined, undefined, {{sound.geotag.lat}}, {{sound.geotag.lon}}, {{sound.geotag.zoom}});
+    var show_search = false;
+    var show_style_selector = true;
+    make_sounds_map('{% url "geotags-for-sound-barray" sound.id %}', 'map_canvas', undefined, undefined, {{sound.geotag.lat}}, {{sound.geotag.lon}}, {{sound.geotag.zoom}}, show_search, show_style_selector);
 </script>
 {% endblock %}

--- a/templates/sounds/sound_edit.html
+++ b/templates/sounds/sound_edit.html
@@ -248,7 +248,7 @@
 <a id="geotag"></a>
 <form method="post" action="#geotag">{% csrf_token %}
  <p>Drag this map to set the geotag:</p>
-    	<div id="map" style="width: 400px; height:400px; margin-bottom: 1em; float:left"></div>
+    	<div id="map_canvas" style="width: 400px; height:400px; margin-bottom: 1em; float:left"></div>
     	<div style="float:ledt;margin-left:430px;">{{geotag_form.as_p}}</div>
         <br style="clear: both;" />
     <input type="submit" name="submit" value="submit" />
@@ -271,7 +271,7 @@
         zoom = {{sound.geotag.zoom}};
     {% endif %}
 
-    make_geotag_edit_map('map', '{{media_url}}/images/arrow.png', updateLatLonZoomFields, center_lat, center_lon, zoom);
+    window.map = make_geotag_edit_map('map_canvas', '{{media_url}}/images/arrow.png', updateLatLonZoomFields, center_lat, center_lon, zoom);
 
     function updateLatLonZoomFields(map_element_id, lat, lon, zoom, box_bl_lat, box_bl_lon, box_tr_lat, box_tr_lon) {
         $("#{{geotag_form.lon.auto_id}}").val(lon);


### PR DESCRIPTION
Addresses issue https://github.com/MTG/freesound/issues/1212
See forum discussion https://freesound.org/forum/bug-reports-errors-and-feature-requests/41157/?page=1#post91806

This adds an option to switch between "terrain" and "street" map styles (see screenshots below). This is added in the following places where maps are displayed:

- Main geotags map
- Sound edit geotag map
- Sound description geotag map
- Individual sound geotag page

It can be easily added to other maps with a parameter sent to `make_geotag_map`, but I did not consider it necessary.

The "terrain" map style could be improved by adding more labels of place names. This can be done directly in our Mapbox account so I'll make some changes there. This won't affect any code here. [DONE]

DEV note: I had to restructure the code in which we add layers to the map (sound points) to repeat the process every time style is changed. This is due to how Mapbox works.

![screen shot 2018-08-10 at 08 03 05](https://user-images.githubusercontent.com/478615/43941426-6971550c-9c74-11e8-9aa6-6d5fbd0be913.png)
![screen shot 2018-08-10 at 08 03 13](https://user-images.githubusercontent.com/478615/43941427-69922c64-9c74-11e8-801c-23b80fedc1d4.png)
![screen shot 2018-08-10 at 08 04 19](https://user-images.githubusercontent.com/478615/43941433-6c6fc608-9c74-11e8-9f6a-f7284d07b933.png)
![screen shot 2018-08-10 at 08 04 28](https://user-images.githubusercontent.com/478615/43941434-6c8e36a6-9c74-11e8-89b1-d380e71a7267.png)
