### PR TITLE
Add object previews in spam report emails

### DIFF
--- a/accounts/templatetags/flag_user.py
+++ b/accounts/templatetags/flag_user.py
@@ -19,11 +19,9 @@
 #
 
 from django import template
-from comments.models import Comment
-from forum.models import Post
-from messages.models import Message
 from accounts.models import UserFlag
 register = template.Library()
+
 
 @register.inclusion_tag("accounts/flag_user.html", takes_context=True)
 def flag_user(context, flag_type, username, content_id, text = None, user_sounds = None):
@@ -35,8 +33,18 @@ def flag_user(context, flag_type, username, content_id, text = None, user_sounds
         no_show = True
         flagged = []
     else:
-        flagged = UserFlag.objects.filter(user__username = username, reporting_user = context['request'].user, object_id = content_id).values('reporting_user').distinct()
+        flagged = UserFlag.objects.filter(user__username=username,
+                                          reporting_user=context['request'].user,
+                                          object_id=content_id).values('reporting_user').distinct()
         if text:
             link_text = text
 
-    return {'user_sounds':user_sounds,'done_text':"Marked as spam/offensive", 'flagged':len(flagged),'flag_type':flag_type,'username':username, 'content_obj_id':content_id, 'media_url': context['media_url'], 'link_text':link_text, 'no_show':no_show}
+    return {'user_sounds': user_sounds,
+            'done_text': "Marked as spam/offensive",
+            'flagged': len(flagged),
+            'flag_type': flag_type,
+            'username': username,
+            'content_obj_id': content_id,
+            'media_url': context['media_url'],
+            'link_text': link_text,
+            'no_show': no_show}

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -30,7 +30,7 @@ from django.core.files.uploadedfile import InMemoryUploadedFile, SimpleUploadedF
 from django.core.management import call_command
 from django.core import mail
 from django.conf import settings
-from accounts.models import Profile, EmailPreferenceType, SameUser, ResetEmailRequest, OldUsername, EmailBounce
+from accounts.models import Profile, EmailPreferenceType, SameUser, ResetEmailRequest, OldUsername, EmailBounce, UserFlag
 from accounts.views import handle_uploaded_image
 from accounts.forms import FsPasswordResetForm, DeleteUserForm, UsernameField, RegistrationForm
 from accounts.management.commands.process_email_bounces import decode_idna_email
@@ -40,6 +40,7 @@ from utils.filesystem import File
 from tags.models import Tag
 from comments.models import Comment
 from forum.models import Thread, Post, Forum
+from messages.models import Message, MessageBody
 from tickets.models import Ticket
 from utils.mail import transform_unique_email, send_mail
 import accounts.models
@@ -1575,3 +1576,166 @@ class BulkDescribe(TestCase):
         self.client.login(username='testuser', password='testpass')
         resp = self.client.get(reverse('accounts-bulk-describe', args=[bulk.id]))
         self.assertIn('This bulk description process is closed', resp.content)
+
+
+class ReportSpamOffensive(TestCase):
+    """
+    Test the "report spam/offensive" feature available for sound comments, forum posts and private messages.
+    NOTE: for simplicity in  variable names, etc we only refer to the "spam" case.
+    """
+
+    fixtures = ['initial_data', 'sounds']
+
+    def setUp(self):
+        # Create users reporting spam
+        self.reporters = []
+        for i in range(0, settings.USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING + 1):
+            reporter = User.objects.create_user(username='reporter_{0}'.format(i),
+                                                email='reporter_{0}@example.com'.format(i), password='testpass')
+            self.reporters.append(reporter)
+
+        # Create user posting spam
+        self.spammer = User.objects.create_user(username='spammer', email='spammer@example.com', password='testpass')
+
+    def get_reporter_as_logged_in_user(self, i):
+        user = self.reporters[i]
+        self.client.force_login(user=user)
+        return user
+
+    def __test_report_object(self, flag_type, object):
+
+        # Flag the comment (no email to admins should be sent yet as only one reporter)
+        reporter = self.get_reporter_as_logged_in_user(0)
+        resp = self.client.post(reverse('flag-user', kwargs={'username': self.spammer.username}), data={
+            'object_id': object.id,
+            'flag_type': flag_type,
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(UserFlag.objects.count(), 1)  # One flag object created
+        self.assertEqual(UserFlag.objects.first().reporting_user, reporter)  # Flag object created by reporter
+        self.assertEqual(len(mail.outbox), 0)  # No email sent
+
+        # Flag the same comment by other users so email is sent
+        for i in range(1, settings.USERFLAG_THRESHOLD_FOR_NOTIFICATION):  # Start at 1 as first flag already done
+            reporter = self.get_reporter_as_logged_in_user(i)
+            resp = self.client.post(reverse('flag-user', kwargs={'username': self.spammer.username}), data={
+                'object_id': object.id,
+                'flag_type': flag_type,
+            })
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(UserFlag.objects.count(), i + 1)  # Now we have more flags
+            self.assertEqual(UserFlag.objects.all().order_by('id')[i].reporting_user,
+                             reporter)  # Flag object created by reporter
+
+            if i == settings.USERFLAG_THRESHOLD_FOR_NOTIFICATION - 1:  # Last iteration
+                self.assertEqual(len(mail.outbox), 1)  # Notification email sent
+                self.assertTrue("[freesound] Spam/offensive report for user" in mail.outbox[0].subject)
+                self.assertTrue("has been reported" in mail.outbox[0].body)
+
+        # Continue flagging object until it reaches blocked state
+        for i in range(settings.USERFLAG_THRESHOLD_FOR_NOTIFICATION,
+                       settings.USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING):  # Start at 1 as first flag already done
+            reporter = self.get_reporter_as_logged_in_user(i)
+            resp = self.client.post(reverse('flag-user', kwargs={'username': self.spammer.username}), data={
+                'object_id': object.id,
+                'flag_type': flag_type,
+            })
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(UserFlag.objects.count(), i + 1)  # Now we have more flags
+            self.assertEqual(UserFlag.objects.all().order_by('id')[i].reporting_user,
+                             reporter)  # Flag object created by reporter
+
+            if i == settings.USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING - 1:  # Last iteration
+                self.assertEqual(len(mail.outbox), 2)  # New notification email sent
+                self.assertTrue("[freesound] Spam/offensive report for user" in mail.outbox[1].subject)
+                self.assertTrue("has been blocked" in mail.outbox[1].body)
+
+            else:
+                self.assertEqual(len(mail.outbox), 1)  # No new wmail sent
+
+        # Flag the object again and no new notification emails are sent
+        reporter = self.get_reporter_as_logged_in_user(settings.USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING)
+        resp = self.client.post(reverse('flag-user', kwargs={'username': self.spammer.username}), data={
+            'object_id': object.id,
+            'flag_type': flag_type,
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(UserFlag.objects.count(), settings.USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING + 1)
+        self.assertEqual(len(mail.outbox), 2)  # New notification email sent
+
+    def test_report_sound_comment(self):
+        sound = Sound.objects.first()
+        sound.add_comment(self.spammer, 'This is a spammy comment')
+        comment = self.spammer.comment_set.first()
+        self.__test_report_object('SC', comment)
+
+    def test_report_forum_post(self):
+        thread = Thread.objects.create(author=self.spammer, title="Span thread",
+                                       forum=Forum.objects.create(name="Test forum"))
+        object = Post.objects.create(author=self.spammer, thread=thread, body="Spam post post body")
+        self.__test_report_object('FP', object)
+
+    def test_report_private_message(self):
+        object = Message.objects.create(user_from=self.spammer, user_to=self.reporters[0], subject='Spam subject',
+                                        body=MessageBody.objects.create(body='Spam body'), is_sent=True,
+                                        is_archived=False, is_read=False)
+        self.__test_report_object('PM', object)
+
+    def test_report_object_same_user(self):
+        # Test that when a user is reported many times but not by distinct users, no email is sent
+        # NOTE: we only test for the case of sound comments as the logic that handles this si common for all other
+        # kinds of reports
+
+        sound = Sound.objects.first()
+        sound.add_comment(self.spammer, 'This is a spammy comment')
+        comment = self.spammer.comment_set.first()
+
+        # Flag the comment many times by the same user (no email to admins should be sent yet as only one reporter)
+        reporter = self.get_reporter_as_logged_in_user(0)
+        for i in range(0, settings.USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING + 1):
+            resp = self.client.post(reverse('flag-user', kwargs={'username': self.spammer.username}), data={
+                'object_id': comment.id,
+                'flag_type': 'SC',  # Sound comment
+            })
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(UserFlag.objects.count(), i + 1)
+            self.assertEqual(len(mail.outbox), 0)  # No email sent
+
+    def test_report_multiple_objects(self):
+        # Make spammy objects
+        sound = Sound.objects.first()
+        sound.add_comment(self.spammer, 'This is a spammy comment')
+        comment = self.spammer.comment_set.first()
+        thread = Thread.objects.create(author=self.spammer, title="Span thread",
+                                       forum=Forum.objects.create(name="Test forum"))
+        post = Post.objects.create(author=self.spammer, thread=thread, body="Spam post post body")
+        message = Message.objects.create(user_from=self.spammer, user_to=self.reporters[0], subject='Spam subject',
+                                         body=MessageBody.objects.create(body='Spam body'), is_sent=True,
+                                         is_archived=False, is_read=False)
+        objects_flag_types = [
+            (comment, 'SC'),
+            (post, 'FP'),
+            (message, 'PM'),
+        ]
+
+        # Report objects by distinct users
+        for i in range(0, settings.USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING + 1):
+            reporter = self.get_reporter_as_logged_in_user(i)
+            object, flag_type = objects_flag_types[i % len(objects_flag_types)]
+            resp = self.client.post(reverse('flag-user', kwargs={'username': self.spammer.username}), data={
+                'object_id': object.id,
+                'flag_type': flag_type,
+            })
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(UserFlag.objects.count(), i + 1)
+            self.assertEqual(UserFlag.objects.all().order_by('id')[i].reporting_user,
+                             reporter)  # Flag object created by reporter
+
+            if i == settings.USERFLAG_THRESHOLD_FOR_NOTIFICATION - 1:  # Last iteration
+                self.assertEqual(len(mail.outbox), 1)  # New notification email sent
+                self.assertTrue("[freesound] Spam/offensive report for user" in mail.outbox[0].subject)
+                self.assertTrue("has been reported" in mail.outbox[0].body)
+            elif i == settings.USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING - 1:
+                self.assertEqual(len(mail.outbox), 2)  # New notification email sent
+                self.assertTrue("[freesound] Spam/offensive report for user" in mail.outbox[1].subject)
+                self.assertTrue("has been blocked" in mail.outbox[1].body)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -40,6 +40,7 @@ from django.shortcuts import get_object_or_404, render
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib import messages
 from django.core.cache import cache
+from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.tokens import default_token_generator
 from django.views.decorators.cache import never_cache
 from django.utils.http import base36_to_int
@@ -1149,19 +1150,23 @@ def email_reset_complete(request, uidb36=None, token=None):
 
 @login_required
 @transaction.atomic()
-def flag_user(request, username=None):
+def flag_user(request, username):
+
     if request.POST:
-        flagged_user = User.objects.get(username__iexact=request.POST["username"])
+        flagged_user = User.objects.get(username__iexact=username)
         reporting_user = request.user
         object_id = request.POST["object_id"]
         if object_id:
-            if request.POST["flag_type"] == "PM":
-                flagged_object = Message.objects.get(id=object_id)
-            elif request.POST["flag_type"] == "FP":
-                flagged_object = Post.objects.get(id=object_id)
-            elif request.POST["flag_type"] == "SC":
-                flagged_object = Comment.objects.get(id=object_id)
-            else:
+            try:
+                if request.POST["flag_type"] == "PM":
+                    flagged_object = Message.objects.get(id=object_id, user_from=flagged_user)
+                elif request.POST["flag_type"] == "FP":
+                    flagged_object = Post.objects.get(id=object_id, author=flagged_user)
+                elif request.POST["flag_type"] == "SC":
+                    flagged_object = Comment.objects.get(id=object_id, user=flagged_user)
+                else:
+                    return HttpResponse(json.dumps({"errors": True}), content_type='application/javascript')
+            except (Message.DoesNotExist, Post.DoesNotExist, Comment.DoesNotExist) as e:
                 return HttpResponse(json.dumps({"errors": True}), content_type='application/javascript')
         else:
             return HttpResponse(json.dumps({"errors": True}), content_type='application/javascript')
@@ -1179,7 +1184,7 @@ def flag_user(request, username=None):
 
             # Get all flagged objects by the user, create links to admin pages and send email
             flagged_objects = UserFlag.objects.filter(user=flagged_user)
-            urls = []
+            objects_data = []
             added_objects = []
             for f_object in flagged_objects:
                 key = str(f_object.content_type) + str(f_object.object_id)
@@ -1189,9 +1194,17 @@ def flag_user(request, username=None):
                         obj = f_object.content_type.get_object_for_this_type(id=f_object.object_id)
                         url = reverse('admin:%s_%s_change' %
                                       (obj._meta.app_label,  obj._meta.model_name), args=[obj.id])
-                        urls.append([str(f_object.content_type), request.build_absolute_uri(url)])
-                    except Exception:
-                        urls.append([str(f_object.content_type), "url not available"])
+                        if obj._meta.model_name == 'comment':
+                            content = obj.comment
+                        elif obj._meta.model_name == 'post':
+                            content = obj.body
+                        elif obj._meta.model_name == 'message':
+                            content = obj.body.body
+                        else:
+                            content = ''
+                        objects_data.append([str(f_object.content_type), request.build_absolute_uri(url), content])
+                    except ObjectDoesNotExist:
+                        objects_data.append([str(f_object.content_type), "url not available", ""])
             user_url = reverse('admin:%s_%s_delete' %
                                (flagged_user._meta.app_label, flagged_user._meta.model_name), args=[flagged_user.id])
             user_url = request.build_absolute_uri(user_url)
@@ -1203,7 +1216,7 @@ def flag_user(request, username=None):
                 template_to_use = 'accounts/report_blocked_spammer_admins.txt'
 
             tvars = {'flagged_user': flagged_user,
-                     'urls': urls,
+                     'objects_data': objects_data,
                      'user_url': user_url,
                      'clear_url': clear_url}
             send_mail_template_to_support(u'Spam/offensive report for user ' + flagged_user.username, template_to_use,

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1194,11 +1194,11 @@ def flag_user(request, username):
                         obj = f_object.content_type.get_object_for_this_type(id=f_object.object_id)
                         url = reverse('admin:%s_%s_change' %
                                       (obj._meta.app_label,  obj._meta.model_name), args=[obj.id])
-                        if obj._meta.model_name == 'comment':
+                        if isinstance(obj, Comment):
                             content = obj.comment
-                        elif obj._meta.model_name == 'post':
+                        elif isinstance(obj, Post):
                             content = obj.body
-                        elif obj._meta.model_name == 'message':
+                        elif isinstance(obj, Message):
                             content = obj.body.body
                         else:
                             content = ''

--- a/templates/accounts/flag_user.html
+++ b/templates/accounts/flag_user.html
@@ -6,7 +6,7 @@
 
     <script type="text/javascript">
 
-        function post_flag(div_id, uname, flag_type, object_id, url)
+        function post_flag(div_id, flag_type, object_id, url)
         {
             $("#" + div_id.toString() + "_info").html('<img width="12px" height="12px" src="{{ media_url }}images/indicator.gif"/>');
 
@@ -14,7 +14,6 @@
                 type: 'POST',
                 url: url,
                 data: {
-                    username: uname,
                     flag_type: flag_type,
                     object_id: object_id
                 },
@@ -55,7 +54,7 @@
     {% if flagged %}
         <span style="color:#808080;">{{ done_text }}</span>
     {% else %}
-        <a onclick="post_flag('{{content_obj_id}}{{flag_type}}','{{username}}','{{ flag_type }}',{{ content_obj_id }},'{% url "flag-user" username %}')" href="javascript:void(0)">{{ link_text }}</a>
+        <a onclick="post_flag('{{content_obj_id}}{{flag_type}}','{{ flag_type }}',{{ content_obj_id }},'{% url "flag-user" username %}')" href="javascript:void(0)">{{ link_text }}</a>
     {% endif %}
     </span>
 

--- a/templates/accounts/report_blocked_spammer_admins.txt
+++ b/templates/accounts/report_blocked_spammer_admins.txt
@@ -5,8 +5,9 @@ Hi there super admin!
 User {{ flagged_user.username }} has been blocked after several spam reports by different users.
 Here you have a list of the items that have been marked as spam:
 
-{% for url in urls %}
-    * {{url.0}}: {{url.1}}
+{% for type, url, content in objects_data %}
+    * {{ type }}: {{ url }}{% if content %}
+        > {{ content|truncatechars:30 }}{% endif %}
 {% endfor %}
 
 If you can confirm this user is a spammer, please delete him following {{user_url}}

--- a/templates/accounts/report_spammer_admins.txt
+++ b/templates/accounts/report_spammer_admins.txt
@@ -5,8 +5,9 @@ Hi there super admin!
 User {{ flagged_user.username }} has been reported as a spammer or offensive at least three times by different users.
 Here you have a list of the items that have been marked as bad content:
 
-{% for url in urls %}
-    * {{url.0}}: {{url.1}}
+{% for type, url, content in objects_data %}
+    * {{ type }}: {{ url }}{% if content %}
+        > {{ content|truncatechars:30 }}{% endif %}
 {% endfor %}
 
 If you can confirm this user is a spammer or offensive, please delete him following {{user_url}}


### PR DESCRIPTION
Addresses https://github.com/MTG/freesound/issues/1218

* Spam report emails now include object preview in the body of the email 
* Small refactorings in user flag code
* Add unit tests 