### PR TITLE
Explicit warning now dismisses in moderation

### DIFF
--- a/media/js/freesound.js
+++ b/media/js/freesound.js
@@ -39,16 +39,15 @@ $(function() {
             $(this).find("a").css("background-image", "url(/media/images/tag_edge_group.png)");
         }
     );
-    
-    $(".explicit_content_text span a").click(function(e) {
-        var warning = $(this).parent().parent('.explicit_content_text');
-        var sample_player_small = $(this).parent().parent().parent();
-        sample_player_small.find('.sample_player').removeClass('blur');
-        sample_player_small.find('.sample_information').removeClass('blur');
-        warning.remove();
-        e.preventDefault()
-    })
 });
+
+function remove_explicit_content_warning(element){
+    var warning = $(element).parent().parent('.explicit_content_text');
+    var player = $(element).parent().parent().parent();
+    player.find('.sample_player').removeClass('blur');
+    player.find('.sample_information').removeClass('blur');
+    warning.remove();
+}
 
 function d()
 {

--- a/templates/sounds/display_sound.html
+++ b/templates/sounds/display_sound.html
@@ -13,7 +13,7 @@
 
     {% if is_explicit %}
     <div class="explicit_content_text">
-        <span>Warning: this sound may be inappropriate for some users <a href="#">Dismiss</a></span>
+        <span>Warning: this sound may be inappropriate for some users <a href="javascript:void(0);" onclick="remove_explicit_content_warning(this);">Dismiss</a></span>
     </div>
     {% endif %}
 

--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -57,7 +57,7 @@
               <span>Content warning</span>
               <p>This sound may be inappropriate for some users
               <br>You can turn these warnings off in your <a href="{% url 'accounts-edit' %}">user settings</a> page</p>
-              <p><a id="remove_warning_link" href="#">Dismiss</a></p>
+              <p><a id="remove_warning_link" href="javascript:void(0);" onclick="remove_explicit_content_warning(this);">Dismiss</a></p>
           </div>
         </div>
         <script type="text/javascript">


### PR DESCRIPTION
Addresses https://github.com/MTG/freesound/issues/1227

I refactored the code so the dismiss button calls the function
[remove_explicit_content_warning](https://github.com/MTG/freesound/blob/80219540199616ca5a9805b50880f5f65279e1c4/media/js/freesound.js#L44) and no post-binding of the "a" tag
is necessary. This fixes the problem in the moderation page in which the
sound players were loaded after the binding code for the dismiss buttons
was run. It also fixes potential similar future issues.

