### PR TITLE
labels in advanced search allow clicking text, not just checkboxes

### DIFF
--- a/media/css/all.css
+++ b/media/css/all.css
@@ -241,17 +241,9 @@ form {
     margin-bottom: 10px;
 }
 
-form label {
-    display: block;
-}
-
 form input,form textarea {
     padding: 3px;
     font-size: 13px;
-}
-
-form#search_form  label {
-    display: inline;
 }
 
 #content textarea {

--- a/media/css/all.css
+++ b/media/css/all.css
@@ -249,6 +249,11 @@ form input,form textarea {
     padding: 3px;
     font-size: 13px;
 }
+
+form#search_form  label {
+    display: inline;
+}
+
 #content textarea {
     width: 530px;
 }

--- a/templates/accounts/registration.html
+++ b/templates/accounts/registration.html
@@ -3,7 +3,7 @@
 {% block title %}registration{% endblock %}
 
 {% block section_content %}
-<style> label[for=id_accepted_tos] {display: inline} #username_check, #check_success, #spinner { display:none; color: #bd2d33; font-style: italic; } #check_success {color:green;}</style>
+<style> label:not([for=id_accepted_tos]) {display: block} #username_check, #check_success, #spinner { display:none; color: #bd2d33; font-style: italic; } #check_success {color:green;}</style>
 <script type="text/javascript">
     $(function () {
         $("#id_username").focus()

--- a/templates/search/advanced_search_form.html
+++ b/templates/search/advanced_search_form.html
@@ -30,19 +30,19 @@
 <input id="advanced_search_hidden" type="hidden" name="advanced" value="{% if advanced == "1" %}1{% else %}0{% endif %}" />
 
 <div style="margin-top:8px;"></div>Search in:&nbsp
-<input type="checkbox" name="a_tag" value="1" {% if a_tag %}checked{% endif %}/> Tags&nbsp&nbsp
-<input type="checkbox" name="a_filename" value="1" {% if a_filename %}checked{% endif %}/> File names&nbsp&nbsp
-<input type="checkbox" name="a_description" value="1" {% if a_description %}checked{% endif %}/> Descriptions&nbsp&nbsp
-<input type="checkbox" name="a_packname" value="1" {% if a_packname %}checked{% endif %}/> Pack names&nbsp&nbsp
-<input type="checkbox" name="a_soundid" value="1" {% if a_soundid %}checked{% endif %}/> Sound Ids&nbsp&nbsp
-<input type="checkbox" name="a_username" value="1" {% if a_username %}checked{% endif %}/> User names
+<label><input type="checkbox" name="a_tag" value="1" {% if a_tag %}checked{% endif %}/> Tags</label>&nbsp&nbsp
+<label><input type="checkbox" name="a_filename" value="1" {% if a_filename %}checked{% endif %}/> File names</label>&nbsp&nbsp
+<label><input type="checkbox" name="a_description" value="1" {% if a_description %}checked{% endif %}/> Descriptions</label>&nbsp&nbsp
+<label><input type="checkbox" name="a_packname" value="1" {% if a_packname %}checked{% endif %}/> Pack names</label>&nbsp&nbsp
+<label><input type="checkbox" name="a_soundid" value="1" {% if a_soundid %}checked{% endif %}/> Sound Ids</label>&nbsp&nbsp
+<label><input type="checkbox" name="a_username" value="1" {% if a_username %}checked{% endif %}/> User names</label>
 <span class="advanced_search_indication">(if none is selected, all will be used)</span>
 <br>
 
-Duration between <input class="inputtext" id="filter_duration_min" value="0" size="6" /> (min)
-and <input class="inputtext" id="filter_duration_max" value="*" size="6" /> (max) seconds<br>
-<input id="filter_is_geotagged" type="checkbox" value="1" /> Only geotagged sounds<br>
-<input id="grouping_geotagged" type="checkbox" onchange="set_hidden_grouping_value()" {% if grouping == "1" %}checked{% endif %}/> Group sounds by pack
+Duration between <input class="inputtext" id="filter_duration_min" value="0" size="6" /> <label for="filter_duration_min">(min)</label>
+and <input class="inputtext" id="filter_duration_max" value="*" size="6" /> <label for="filter_duration_max">(max)</label> seconds<br>
+<input id="filter_is_geotagged" type="checkbox" value="1" /> <label for="filter_is_geotagged">Only geotagged sounds</label><br>
+<input id="grouping_geotagged" type="checkbox" onchange="set_hidden_grouping_value()" {% if grouping == "1" %}checked{% endif %}/> <label for="grouping_geotagged">Group sounds by pack</label>
 <input id="grouping_geotagged_hidden" type="hidden" name="g" {% ifequal grouping "1" %}value="1"{% else %}value=""{% endifequal %} />
 
 <br>


### PR DESCRIPTION
**Issue(s)**
none

**Description**
This allows to click text and not just the checkboxes in advanced search. A Usability improvement.
Video demo: https://youtu.be/fQ02W3SmBBo

**Deployment steps**:
I don't think so. hard reload in browser was enough for it to work on my end.

If it is possible to force that browsers get `all.css` anew, that would be good, as without the change in `all.css`, the advanced search form puts every option in its own block.