### PR TITLE
Remove <> from around URLs in emails that we send. Fixes #1257

### DIFF
--- a/templates/accounts/email_activation.txt
+++ b/templates/accounts/email_activation.txt
@@ -9,7 +9,7 @@ Thank you for signing up at Freesound!
 
 In order to activate your Freesound account, please click this link:
 
-<{% absurl 'accounts-activate' username hash %}>
+{% absurl 'accounts-activate' username hash %}
 
-If for some reason this fails, try copy-pasting the complete link into you browser. Some mail clients break up long lines, or do strange things to URL's!
+If for some reason this fails, try copy-pasting the complete link into you browser. Some mail clients break up long lines, or do strange things to URLs!
 {% endblock %}

--- a/templates/forum/email_new_post_notification.txt
+++ b/templates/forum/email_new_post_notification.txt
@@ -10,7 +10,7 @@ A thread you are subscribed to over at Freesound has been replied to by user {{p
 Thread: "{{thread.title}}"
 Post URL:
 
-<{% absurl "forums-post" forum.name_slug thread.id post.id %}>
+{% absurl "forums-post" forum.name_slug thread.id post.id %}
 
 
 

--- a/templates/messages/email_new_message.txt
+++ b/templates/messages/email_new_message.txt
@@ -9,6 +9,6 @@ You have a new message at freesound, sent by {{user_from.username}}!
 
 To read the message go to:
 
-<{% absurl "messages" %}>
+{% absurl "messages" %}
 
 {% endblock %}

--- a/templates/sounds/email_remix_update.txt
+++ b/templates/sounds/email_remix_update.txt
@@ -9,10 +9,10 @@ The user '{{remix.user.username}}' has {{action}} a sound you uploaded as a remi
 
 The sound was {{source.original_filename}}, listen to it here:
 
-<{% absurl 'sound' source.user.username source.id %}>
+{% absurl 'sound' source.user.username source.id %}
 
 The remix is called {{remix.original_filename}}, listen to it here:
 
-<{% absurl 'sound' remix.user.username remix.id %}>
+{% absurl 'sound' remix.user.username remix.id %}
 
 {% endblock %}

--- a/templates/tickets/email_notification_approved.txt
+++ b/templates/tickets/email_notification_approved.txt
@@ -10,7 +10,7 @@ approved by a Freesound moderator and is now available in Freesound.
 
 You can access the sound's page here:
 
-<{% absurl "sound" ticket.sound.user ticket.sound.id %}>
+{% absurl "sound" ticket.sound.user ticket.sound.id %}
 
 Thank you for adding to Freesound!
 {% endblock %}

--- a/templates/tickets/email_notification_approved_but.txt
+++ b/templates/tickets/email_notification_approved_but.txt
@@ -11,11 +11,11 @@ approved by a Freesound moderator and is now available in Freesound.
 However, the moderator had some remarks. Please see the following link
 to see the moderator's message:
 
-<{% absurl "tickets-ticket" ticket.key %}>
+{% absurl "tickets-ticket" ticket.key %}
 
 You can access the sound's page here:
 
-<{% absurl "sound" ticket.sound.user ticket.sound.id  %}>
+{% absurl "sound" ticket.sound.user ticket.sound.id  %}
 
 Thank you for adding to Freesound!
 {% endblock %}

--- a/templates/tickets/email_notification_deleted.txt
+++ b/templates/tickets/email_notification_deleted.txt
@@ -10,7 +10,7 @@ deleted by a Freesound moderator.
 
 You can see the moderator's explanation here:
 
-<{% absurl 'tickets-ticket' ticket.key %}>
+{% absurl 'tickets-ticket' ticket.key %}
 
 If you do not agree with the decision please write a message to 
 the moderator using the link above.

--- a/templates/tickets/email_notification_question.txt
+++ b/templates/tickets/email_notification_question.txt
@@ -10,7 +10,7 @@ of your uploads ({{ ticket.sound.original_filename }}).
 
 Please go to:
 
-<{% absurl 'tickets-ticket' ticket.key %}>
+{% absurl 'tickets-ticket' ticket.key %}
 
  to see the message the moderator has
 left for you. Your upload will not be part of Freesound until the moderator

--- a/templates/tickets/email_notification_updated.txt
+++ b/templates/tickets/email_notification_updated.txt
@@ -9,6 +9,6 @@ The ticket "{{ ticket.title }}" has been updated.
 
 To see the update see the following link:
 
-<{% absurl 'tickets-ticket' ticket.key %}>
+{% absurl 'tickets-ticket' ticket.key %}
 
 {% endblock %}


### PR DESCRIPTION
We've seen a few places where web-based email clients tend to
eat text inside <> tags, which is where we traditionally put
URLs (#1257, #901) even though the email is marked as text/plain.

As the angle brackets don't bring too much to the message (they're
already all on their own lines) I propose that we remove the brackets.