### PR TITLE
Check if a username is valid when checking against existing users

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -303,6 +303,23 @@ class SimpleUserTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['result'], False)
 
+        # Check that a username that doesn't fit the registration guidelines returns "False", even
+        # if the username doesn't exist
+        resp = self.client.get(reverse('check_username'),
+                {'username': 'username@withat'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['result'], False)
+
+        resp = self.client.get(reverse('check_username'),
+                {'username': 'username^withcaret'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['result'], False)
+
+        resp = self.client.get(reverse('check_username'),
+                {'username': 'username_withunderscore'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['result'], True)
+
 
 class OldUserLinksRedirect(TestCase):
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -40,7 +40,7 @@ from django.shortcuts import get_object_or_404, render
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib import messages
 from django.core.cache import cache
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.contrib.auth.tokens import default_token_generator
 from django.views.decorators.cache import never_cache
 from django.utils.http import base36_to_int
@@ -50,8 +50,9 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.db import transaction
 from django.contrib.auth.models import Group
 from django.contrib.auth.decorators import user_passes_test
-from accounts.forms import UploadFileForm, FlashUploadFileForm, FileChoiceForm, RegistrationForm, ReactivationForm, UsernameReminderForm, \
-    ProfileForm, AvatarForm, TermsOfServiceForm, DeleteUserForm, EmailSettingsForm, BulkDescribeForm
+from accounts.forms import UploadFileForm, FlashUploadFileForm, FileChoiceForm, RegistrationForm, ReactivationForm, \
+    UsernameReminderForm, \
+    ProfileForm, AvatarForm, TermsOfServiceForm, DeleteUserForm, EmailSettingsForm, BulkDescribeForm, UsernameField
 from accounts.models import Profile, ResetEmailRequest, UserFlag, UserEmailSetting, EmailPreferenceType, SameUser, \
     EmailBounce
 from accounts.forms import EmailResetForm
@@ -148,11 +149,23 @@ def multi_email_cleanup(request):
 
 
 def check_username(request):
+    """AJAX endpoint to check if a specified username is available to be registered.
+    This checks against the normal username validator, and then also verifies to see
+    if the username already exists in the database.
+
+    Returns JSON {'result': true} if the username is valid and can be used"""
     username = request.GET.get('username', None)
     username_valid = False
+    username_field = UsernameField()
     if username:
-        user = get_user_from_username_or_oldusername(username)
-        username_valid = user == None
+        try:
+            username_field.run_validators(username)
+            # If the validator passes, check if the username exists in the database
+            user = get_user_from_username_or_oldusername(username)
+            username_valid = user is None
+        except ValidationError:
+            username_valid = False
+
     return JsonResponse({'result': username_valid})
 
 

--- a/templates/accounts/registration.html
+++ b/templates/accounts/registration.html
@@ -7,7 +7,7 @@
 <script type="text/javascript">
     $(function () {
         $("#id_username").focus()
-            $('#id_username').parent().append('<div id="spinner"> Checking...<img src="{{ media_url }}images/indicator.gif" /></div><div id="username_check">Sorry, this username is already being used by someone else.</div><div id="check_success">Username is available</div>');
+            $('#id_username').parent().append('<div id="spinner"> Checking...<img src="{{ media_url }}images/indicator.gif" /></div><div id="username_check">Sorry, this username is not valid or is already being used by someone else.</div><div id="check_success">Username is available</div>');
             $("#id_username").focusout(function(){
             if ($("#id_username").val()) {
                 $('#spinner').show();


### PR DESCRIPTION
Fixes #1258
We give feedback to users before they create their account if the username is already taken, but if the username is invalid (e.g. has a @ symbol in it) then we say that it's available, and then fail
the validation after the form is submitted.
Now we do a Validation of the field before checking if the username exists to give faster feedback to the user.

The reported message here is a little bit false now, because we say "Sorry, this username is already being used by someone else." if the username is invalid (e.g. it has a @ in it). We could change this message to "Sorry, this username is unavailable". Does this sound good?