### PR TITLE
Redirect old sound/pack links if the id has a space in it

### DIFF
--- a/sounds/tests.py
+++ b/sounds/tests.py
@@ -64,6 +64,10 @@ class OldSoundLinksRedirectTestCase(TestCase):
         response = self.client.get(reverse('old-sound-page'), data={'id': self.sound.id})
         self.assertEqual(response.status_code, 301)
 
+        # id is valid but has a space after it
+        response = self.client.get(reverse('old-sound-page'), data={'id': '%d ' % self.sound.id})
+        self.assertEqual(response.status_code, 301)
+
     def test_old_sound_link_redirect_not_exists_id(self):
         # 404 id does not exist
         response = self.client.get(reverse('old-sound-page'), data={'id': 0}, follow=True)
@@ -85,6 +89,10 @@ class OldPackLinksRedirectTestCase(TestCase):
 
     def test_old_pack_link_redirect_ok(self):
         response = self.client.get(reverse('old-pack-page'), data={'id': self.pack.id})
+        self.assertEqual(response.status_code, 301)
+
+        # id is valid but has a space after it
+        response = self.client.get(reverse('old-pack-page'), data={'id': '%d ' % self.pack.id})
         self.assertEqual(response.status_code, 301)
 
     def test_old_pack_link_redirect_not_exists_id(self):

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -803,7 +803,8 @@ def __redirect_old_link(request, cls, url_name):
     obj_id = request.GET.get('id', False)
     if obj_id:
         try:
-            obj = get_object_or_404(cls, id=int(obj_id))
+            obj_id = int(obj_id)
+            obj = get_object_or_404(cls, id=obj_id)
             return HttpResponsePermanentRedirect(reverse(url_name, args=[obj.user.username, obj_id]))
         except ValueError:
             raise Http404


### PR DESCRIPTION
**Issue(s)**
Fixes #1242

**Description**
We were checking `int(id)` of a sound/pack id to see if it existed in the database, but then didn't use this value in the call to `reverse`.
