### PR TITLE
Add extra options in post_dirty_sounds_to_solr

### DIFF
--- a/search/management/commands/post_dirty_sounds_to_solr.py
+++ b/search/management/commands/post_dirty_sounds_to_solr.py
@@ -31,8 +31,16 @@ console_logger = logging.getLogger("console")
 
 
 class Command(BaseCommand):
-    args = ''
-    help = 'Add all sounds with index_dirty flag True to SOLR index'
+    help = 'Add all sounds with is_index_dirty flag True to SOLR index'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-d', '--delete-if-existing',
+            action='store_true',
+            dest='delete-if-existing',
+            default=False,
+            help='Using the option --delete-if-existing, sounds already existing in the SOLR index will be removed'
+                 ' before (re-)indexing.')
 
     def handle(self, *args, **options):
 
@@ -42,7 +50,8 @@ class Command(BaseCommand):
         logger.info("Starting posting dirty sounds to solr. %i sounds to be added/updated to the solr index"
                     % num_sounds)
 
-        num_correctly_indexed_sounds = add_all_sounds_to_solr(sounds_to_index, mark_index_clean=True)
+        num_correctly_indexed_sounds = add_all_sounds_to_solr(
+            sounds_to_index, mark_index_clean=True, delete_if_existing=options['delete-if-existing'])
 
         logger.info("Finished posting dirty sounds to solr. %i sounds have been added/updated"
                     % num_correctly_indexed_sounds)

--- a/utils/search/search_general.py
+++ b/utils/search/search_general.py
@@ -93,7 +93,7 @@ def add_sounds_to_solr(sounds):
     console_logger.info("creating XML")
     documents = [convert_to_solr_document(s) for s in sounds]
     console_logger.info("adding %d sounds to solr index" % len(documents))
-    console_logger.info("posting to Solr")
+    logger.info("adding %d sounds to solr index" % len(documents))
     solr.add(documents)
 
 

--- a/utils/search/search_general.py
+++ b/utils/search/search_general.py
@@ -97,7 +97,15 @@ def add_sounds_to_solr(sounds):
     solr.add(documents)
 
 
-def add_all_sounds_to_solr(sound_queryset, slice_size=1000, mark_index_clean=False):
+def add_all_sounds_to_solr(sound_queryset, slice_size=1000, mark_index_clean=False, delete_if_existing=False):
+    """
+    Add all sounds from the sound_queryset to the SOLR index.
+    :param sound_queryset: queryset of Sound objects.
+    :param slice_size: sounds are indexed iteratively in chunks of this size.
+    :param mark_index_clean: if True, set 'is_index_dirty=False' for the Sound objects corresponding to indexed sounds.
+    :param delete_if_existing: if True, delete sounds from SOLR index before (re-)indexing them.
+    :return: number of correctly indexed sounds
+    """
     num_correctly_indexed_sounds = 0
     all_sound_ids = sound_queryset.values_list('id', flat=True).all()
     n_slices = int(math.ceil(float(len(all_sound_ids))/slice_size))
@@ -106,6 +114,8 @@ def add_all_sounds_to_solr(sound_queryset, slice_size=1000, mark_index_clean=Fal
         try:
             sound_ids = all_sound_ids[i:i+slice_size]
             sounds_qs = sounds.models.Sound.objects.bulk_query_solr(sound_ids)
+            if delete_if_existing:
+                delete_sounds_from_solr(sound_ids=sound_ids)
             add_sounds_to_solr(sounds_qs)
 
             if mark_index_clean:


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1276

**Description**
The update of AudioCommons descriptors (which use dynamic fields in SOLR) requires that sound documents are removed form the index before being re-indexed with new descriptor values. This PR adds an option falg to `post_dirty_sounds_to_solr` to remove sounds from the index before re-indexing them. This will happen before adding each new slice of sounds in `add_all_sounds_to_solr`. Slice size defaults to 1000. Therefore, the time each slice of sounds will be unavailable (time between removal and re-index) is minimal (in the order of milliseconds).

