### PR TITLE
Upgrade python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 BeautifulSoup==3.2.0
 beautifulsoup4==4.6.0
-html5lib==1.0b10 # this is required for bleach, but needs to be installed separately to avoid this bug: https://github.com/mozilla/bleach/issues/337
-bleach==2.1.2
+bleach==3.1.0
 #apt-get install libyaml-dev (to allow the cloader)
 PyYAML==3.11
 pycrypto==2.6.1
@@ -15,7 +14,7 @@ networkx==1.5
 gearman==2.0.2
 recaptcha-client==1.0.6
 graypy==0.2.12
-Django==1.11
+Django==1.11.20
 django-extensions==1.7.8
 django-debug-toolbar==1.7
 gunicorn==19.9.0

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -227,9 +227,12 @@ class ShouldSuggestDonationTest(TestCase):
         # Change downloads date again to be recent (however modal won't show because probability is 0.0)
         self.assertEqual(utils.downloads.should_suggest_donation(user, times_shown_in_last_day), False)
 
+
+class CleanHtmlTest(TestCase):
+
     def test_clean_html(self):
         # Test if the text input contains allowed html tags
-        # The only supported tags are : a, img, strong, b, em, li, u, p, br, blockquotea and code
+        # The only supported tags are : a, img, strong, b, em, li, u, p, br, blockquote and code
         ret = clean_html(u'a b c d')
         self.assertEqual(u'a b c d', ret)
 

--- a/utils/text.py
+++ b/utils/text.py
@@ -21,7 +21,7 @@
 import re
 import unicodedata
 import bleach
-from html5lib.filters.base import Filter
+from bleach.html5lib_shim import Filter
 from functools import partial
 from htmlentitydefs import name2codepoint
 from django.utils.encoding import smart_unicode


### PR DESCRIPTION
**Description**

These dependencies had reported security issues, upgrade them
Bleach now bundles html5lib as part of the package, so use that
instead of installing separately and make the necessary changes
to use the bundled version in our filters

**Deployment steps**:
We should explicitly uninstall html5lib from our virtualenvs. I don't know if we have a procedure to do this?
