### PR TITLE
Remove unused hipchat notifications and add slack integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,5 @@ install:
 script:
 - python manage.py test --noinput --settings=freesound.test_settings accounts apiv2 bookmarks donations follow forum geotags ratings search sounds support tags tickets utils wiki general monitor
 notifications:
-  hipchat:
-    rooms:
-      secure: Ve8Xt4Y+lhhnuyJQbp7u7RyzjMs/7U97fAM+lh/FtEEhQrR8DmxA75dXoy4yS1wvijY8Ob/AQEAtbU1LRdaqPUNetu+KL2ip6mTlb+BIGK3EzZh8iCXVZRZFjkEs9uLsUFYS38GdmALvUtYRKCXsATvvznvp22z3x0FRkGkL+b4=
+  slack:
+    secure: aVyN2TqUMPbHJ4gmp2U/NEZC2rom5KZvvd3YCvcxlNt9ec/r4RlnHM2R+U0SV1aMhz3qmtlol20TEMPVgp9jWN/PTp6/6ryr6v30CEAczEoWwYvvMEX4+juqAn5lQrOujmsTwyyOB9mxHi19rYJd9g9gdekerp242lZ8yBdt3c4=


### PR DESCRIPTION
**Description**
We were still notifying github/travis builds to hipchat, which no longer exists. Change it to notify to slack

**Deployment steps**:
None
