### PR TITLE
 Only check fields on the profile edit page for spam if they are set

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -312,25 +312,27 @@ class ProfileForm(forms.ModelForm):
 
     def clean_about(self):
         about = self.cleaned_data['about']
-        if is_spam(self.request, about):
+        if about and is_spam(self.request, about):
             raise forms.ValidationError("Your 'about' text was considered spam, please edit and resubmit. If it keeps "
                                         "failing please contact the admins.")
         return about
 
     def clean_signature(self):
         signature = self.cleaned_data['signature']
-        if is_spam(self.request, signature):
+        if signature and is_spam(self.request, signature):
             raise forms.ValidationError("Your signature was considered spam, please edit and resubmit. If it keeps "
                                         "failing please contact the admins.")
         return signature
 
     def clean_sound_signature(self):
         sound_signature = self.cleaned_data['sound_signature']
-        if is_spam(self.request, sound_signature):
-            raise forms.ValidationError("Your sound signature was considered spam, please edit and resubmit. If it "
-                                        "keeps failing please contact the admins.")
+
         if len(sound_signature) > 256:
             raise forms.ValidationError("Your sound signature must not exeed 256 chars, please edit and resubmit.")
+
+        if sound_signature and is_spam(self.request, sound_signature):
+            raise forms.ValidationError("Your sound signature was considered spam, please edit and resubmit. If it "
+                                        "keeps failing please contact the admins.")
 
         return sound_signature
 

--- a/utils/spam.py
+++ b/utils/spam.py
@@ -18,13 +18,17 @@
 #     See AUTHORS file.
 #
 
-from akismet import Akismet, AkismetError
-from django.contrib.sites.models import Site
 from urllib2 import HTTPError, URLError
+
+from akismet import Akismet, AkismetError
 from django.conf import settings
+from django.contrib.sites.models import Site
+
 from general.models import AkismetSpam
 
+
 def is_spam(request, comment):
+    """Check if a user's comment is spam"""
 
     # If request user has uploaded, moderated sounds, we don't check for spam
     if request.user.profile.num_sounds > 0:
@@ -32,7 +36,7 @@ def is_spam(request, comment):
 
     domain = "http://%s" % Site.objects.get_current().domain
     api = Akismet(key=settings.AKISMET_KEY, blog_url=domain)
-    
+
     data = {
         'user_ip': request.META.get('REMOTE_ADDR', '127.0.0.1'),
         'user_agent': request.META.get('HTTP_USER_AGENT', ''),
@@ -40,10 +44,10 @@ def is_spam(request, comment):
         'comment_type': 'comment',
         'comment_author': request.user.username.encode("utf-8") if request.user.is_authenticated else '',
     }
-    
+
     if False: # set this to true to force a spam detection
         data['comment_author'] = "viagra-test-123"
-    
+
     try:
         if api.comment_check(comment.encode('utf-8'), data=data, build_data=True):
             if request.user.is_authenticated:

--- a/utils/spam.py
+++ b/utils/spam.py
@@ -26,8 +26,8 @@ from general.models import AkismetSpam
 
 def is_spam(request, comment):
 
-    # If request user has uploaded sounds, we don't check for spam
-    if request.user.sounds.count() > 0:
+    # If request user has uploaded, moderated sounds, we don't check for spam
+    if request.user.profile.num_sounds > 0:
         return False
 
     domain = "http://%s" % Site.objects.get_current().domain


### PR DESCRIPTION
**Issue(s)**
#1292

**Description**
We were checking fields on a user's profile when they edited it for spam, even if they had it set to an empty value. Now, only check it if it's set.
Additionally, we were skipping the test if a user had any sounds, but this meant that a spammy user with non-moderated sounds could skip the test. Now only skip if they have moderated sounds.
