### PR TITLE
Only show 'assign to me' link if the user is a moderator

### DIFF
--- a/templates/tickets/ticket.html
+++ b/templates/tickets/ticket.html
@@ -27,7 +27,7 @@
                  {% endif %}
 
                  {# Show 'assign to me' link if the assigned moderator is not you #}
-                 {% if ticket.assignee.id != user.id %}
+                 {% if perms.tickets.can_moderate and ticket.assignee.id != user.id %}
                  (<a href="{% url 'tickets-moderation-assign-single-ticket' ticket.sender.id ticket.id %}?next=ticket">assign to me</a>)
                  {% endif %}
             </li>


### PR DESCRIPTION
**Issue(s)**
Fixes #1293

**Description**
Previously, the 'assign to me' link on tickets would show for all users
including the sound uploader (though the link would do nothing).
Only show this link if the user viewing the ticket is a ticket moderator

