### PR TITLE
Proc err handling

### DIFF
--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -108,6 +108,7 @@ class FreesoundAudioProcessorBase(object):
                                            "make sure that format conversion executables exist: %s" % e)
         except AudioProcessingException as e:
             # Conversion with format codecs has failed (or skipped using 'force_use_ffmpeg' argument)
+            self.log_info("conversion to PCM failed, now trying conversion with ffmpeg")
             try:
                 audioprocessing.convert_using_ffmpeg(sound_path, tmp_wavefile, mono_out=mono)
             except AudioProcessingException as e:


### PR DESCRIPTION
**Description**
Small updates in processing to improve error handling when converting to PCM using `faad` and failing. These improvements should allow fallback to `ffmpeg` which should result in successful conversion of some sounds that used to fail.

EDIT: also removed timeout from `convert_using_ffmpeg` as we have global timeouts for workers now.
