### PR TITLE
Extra improvements in processing

### DIFF
--- a/_sandbox/stereofy/main.cpp
+++ b/_sandbox/stereofy/main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
 	// open the soundfile
 	if(!(fileIn = sf_open (inputFilename.c_str(), SFM_READ, &sfinfoIn)))
 	{
-		std::cout << "stereofy: failed to open file" << sf_strerror(fileIn) << std::endl;
+		std::cout << "stereofy: failed to open file: " << sf_strerror(fileIn) << std::endl;
 		return  1;
 	}
 	else

--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -168,8 +168,16 @@ class FreesoundAudioProcessor(FreesoundAudioProcessorBase):
                     # other occasions where "convert_to_pcm" generates bad PCM files. In this case we try to re-create
                     # the PCM file using ffmpeg and try re-running stereofy
                     self.log_info("stereofy failed, trying re-creating PCM file with ffmpeg and re-running stereofy")
-                    tmp_wavefile = self.convert_to_pcm(sound_path, tmp_directory, force_use_ffmpeg=True)
-                    info = audioprocessing.stereofy_and_find_info(settings.STEREOFY_PATH, tmp_wavefile, tmp_wavefile2)
+                    try:
+                        tmp_wavefile = self.convert_to_pcm(sound_path, tmp_directory, force_use_ffmpeg=True)
+                        info = audioprocessing.stereofy_and_find_info(settings.STEREOFY_PATH,
+                                                                      tmp_wavefile, tmp_wavefile2)
+                    except AudioProcessingException as e:
+                        self.set_failure("re-run of stereofy with ffmpeg conversion has failed", str(e))
+                        return False
+                    except Exception as e:
+                        self.set_failure("unhandled exception while re-running stereofy with ffmpeg conversion", e)
+                        return False
                 else:
                     self.set_failure("stereofy has failed", str(e))
                     return False

--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -162,7 +162,7 @@ class FreesoundAudioProcessor(FreesoundAudioProcessorBase):
                                  "make stereofy sure executable exists at %s: %s" % (settings.SOUNDS_PATH, e))
                 return False
             except AudioProcessingException as e:
-                if "stereofy: failed to open fileFile contains data in an unknown format" in str(e):
+                if "File contains data in an unknown format" in str(e):
                     # Stereofy failed most probably because PCM file is corrupted. This can happen if "convert_to_pcm"
                     # above is skipped because the file is already PCM but it has wrong format. It can also happen in
                     # other occasions where "convert_to_pcm" generates bad PCM files. In this case we try to re-create

--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -108,7 +108,7 @@ class FreesoundAudioProcessorBase(object):
                                            "make sure that format conversion executables exist: %s" % e)
         except AudioProcessingException as e:
             # Conversion with format codecs has failed (or skipped using 'force_use_ffmpeg' argument)
-            self.log_info("conversion to PCM failed, now trying conversion with ffmpeg")
+            self.log_info("conversion to PCM failed or skipped, now trying conversion with ffmpeg")
             try:
                 audioprocessing.convert_using_ffmpeg(sound_path, tmp_wavefile, mono_out=mono)
             except AudioProcessingException as e:

--- a/utils/audioprocessing/processing.py
+++ b/utils/audioprocessing/processing.py
@@ -473,7 +473,8 @@ def convert_to_pcm(input_filename, output_filename):
     elif sound_type == "m4a":
         cmd = ["faad", "-o", output_filename, input_filename]
         error_messages = ["Unable to find correct AAC sound track in the MP4 file",
-                          "Error: Bitstream value not allowed by specification"]
+                          "Error: Bitstream value not allowed by specification",
+                          "Error opening file"]
     else:
         return False
 

--- a/utils/audioprocessing/processing.py
+++ b/utils/audioprocessing/processing.py
@@ -463,12 +463,17 @@ def convert_to_pcm(input_filename, output_filename):
 
     if sound_type == "mp3":
         cmd = ["lame", "--decode", input_filename, output_filename]
+        error_messages = ["WAVE file contains 0 PCM samples"]
     elif sound_type == "ogg":
         cmd = ["oggdec", input_filename, "-o", output_filename]
+        error_messages = []
     elif sound_type == "flac":
         cmd = ["flac", "-f", "-d", "-s", "-o", output_filename, input_filename]
+        error_messages = []
     elif sound_type == "m4a":
         cmd = ["faad", "-o", output_filename, input_filename]
+        error_messages = ["Unable to find correct AAC sound track in the MP4 file",
+                          "Error: Bitstream value not allowed by specification"]
     else:
         return False
 
@@ -483,18 +488,11 @@ def convert_to_pcm(input_filename, output_filename):
         raise AudioProcessingException("failed converting to pcm data:\n"
                                        + " ".join(cmd) + "\n" + stderr + "\n" + stdout)
 
-    # If external process apparently returned no error (return code = 0) but we see some errors have
-    # been printed in stderr, raise an exception as well
-    specific_error_messages = {
-        "mp3": ["WAVE file contains 0 PCM samples"],
-        "m4a": ["Unable to find correct AAC sound track in the MP4 file",
-                "Error: Bitstream value not allowed by specification"],
-    }
-    for error_sound_type, error_messages in specific_error_messages.items():
-        if sound_type == error_sound_type:
-            if any([error_message in stderr for error_message in error_messages]):
-                raise AudioProcessingException("failed converting to pcm data:\n"
-                                               + " ".join(cmd) + "\n" + stderr + "\n" + stdout)
+    # If external process apparently returned no error (return code = 0) but we see some errors from our list of
+    # known errors have been printed in stderr, raise an exception as well
+    if any([error_message in stderr for error_message in error_messages]):
+        raise AudioProcessingException("failed converting to pcm data:\n"
+                                       + " ".join(cmd) + "\n" + stderr + "\n" + stdout)
 
     return True
 

--- a/utils/audioprocessing/processing.py
+++ b/utils/audioprocessing/processing.py
@@ -584,6 +584,8 @@ def convert_to_ogg(input_filename, output_filename, quality=1):
 def convert_using_ffmpeg(input_filename, output_filename, mono_out=False):
     """
     converts the incoming wave file to 16bit, 44kHz pcm using fffmpeg
+    unlike the convert_to_pcm function above, this one does not try to preserve
+    the original sample rate and bit depth.
     """
 
     if not os.path.exists(input_filename):


### PR DESCRIPTION
This should be the last PR with processing-related improvements. In this PR we optimize the logic for checking error messages in `convert_to_pcm` and re-introduce a processing step that solves `stereofy` crashes if the PCM file has no correct format. The step consists in trying conversion to PCM suing `ffmpeg` in case `stereofy` fails because existing PCM file has bad format. This was removed in a recent refactoring because it was not clear why it was needed. Now we've seen this is useful for a (very low**) fraction of sounds and we re introduce it. Typical case is when a sound is already PCM format so `convert_to_pcm` is not run even though the sound might be corrupted.

** This only affects 19 sounds out of 410000+ so the impact is rather little.