### PR TITLE
Warn if tags include characters outside of a-zA-Z0-9

### DIFF
--- a/sounds/forms.py
+++ b/sounds/forms.py
@@ -71,7 +71,8 @@ class SoundDescriptionForm(forms.Form):
     is_explicit = forms.BooleanField(required=False)
     tags = TagField(widget=forms.Textarea(attrs={'cols': 80, 'rows': 3}),
                     help_text="<br>Add at least 3 tags, separating them with spaces. Join multi-word tags with dashes. "
-                              "For example: <i>field-recording</i> is a popular tag.")
+                              "For example: <i>field-recording</i> is a popular tag."
+                              "<br>Only use letters a-z and numbers 0-9 with no accents or diacritics")
     description = HtmlCleaningCharField(widget=forms.Textarea(attrs={'cols': 80, 'rows': 10}))
 
     def __init__(self, *args, **kwargs):

--- a/utils/forms.py
+++ b/utils/forms.py
@@ -17,8 +17,12 @@
 # Authors:
 #     See AUTHORS file.
 #
+import re
 
 from django import forms
+from django.core import validators
+from django.core.exceptions import ValidationError
+
 from utils.text import clean_html, is_shouting
 from django.conf import settings
 from recaptcha.client import captcha
@@ -38,23 +42,27 @@ class HtmlCleaningCharField(forms.CharField):
         value = super(HtmlCleaningCharField, self).clean(value)
         if is_shouting(value):
             raise forms.ValidationError('Please moderate the amount of upper case characters in your post...')
-        try:
-            return clean_html(value)
-        except (HTMLParseError, UnicodeEncodeError):
-            raise forms.ValidationError('The text you submitted is badly formed HTML, please fix it')
+        return clean_html(value)
 
 
 class TagField(forms.CharField):
     """ Gets the value of tags as a single string (with tags separated by spaces or commas) and cleans it to a set of
     unique tag strings """
-    def clean(self, value):
-        tags = clean_and_split_tags(str(value))
-        if len(tags) < 3:
-            raise forms.ValidationError('You should add at least 3 different tags. Tags must be separated by spaces '
-                                        '(and/or commas).')
-        elif len(tags) > 30:
-            raise forms.ValidationError('There can be maximum 30 tags, please select the most relevant ones!')
-        return tags
+
+    def __init__(self, **kwargs):
+        super(TagField, self).__init__(**kwargs)
+        self.validators.append(
+            validators.MinLengthValidator(3, 'You should add at least 3 different tags. Tags must be separated by '
+                                             'spaces'))
+        self.validators.append(
+            validators.MaxLengthValidator(30, 'There can be maximum 30 tags, please select the most relevant ones!'))
+
+    def to_python(self, value):
+        value = super(TagField, self).to_python(value)
+        alphanum_only = re.compile(r"[^ a-zA-Z0-9-,]")
+        if alphanum_only.search(value):
+            raise ValidationError("Tags must contain only letters a-z, digits 0-9 and hyphen")
+        return clean_and_split_tags(value)
 
 
 class RecaptchaWidget(forms.Widget):

--- a/utils/tests/test_forms.py
+++ b/utils/tests/test_forms.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from utils.forms import filename_has_valid_extension, TagField
+
+
+class UtilsTest(TestCase):
+    def test_filename_has_valid_extension(self):
+        cases = [
+            ("filaneme.wav", True),
+            ("filaneme.aiff", True),
+            ("filaneme.aif", True),
+            ("filaneme.mp3", True),
+            ("filaneme.ogg", True),
+            ("filaneme.flac", True),
+            ("filaneme.xyz", False),
+            ("wav", False),
+        ]
+        for filename, expected_result in cases:
+            self.assertEqual(filename_has_valid_extension(filename), expected_result)
+
+
+class TagFieldTest(TestCase):
+    def test_tag_field(self):
+        f = TagField()
+        # Split on spaces
+        self.assertEqual({"One", "two2", "3three"}, f.clean("3three One two2"))
+        
+        # Split on commas
+        self.assertEqual({"one", "two", "three"}, f.clean("three, one,two"))
+        
+        # Funny characters not allowed
+        err_message = "Tags must contain only letters a-z, digits 0-9 and hyphen"
+        with self.assertRaisesMessage(ValidationError, err_message):
+            f.clean("One t%wo")
+        
+        # accents not allowed
+        with self.assertRaisesMessage(ValidationError, err_message):
+            f.clean("One twó")
+        
+        # hyphens allowed
+        self.assertEqual({"tag", "tag-name", "another-name"}, f.clean("tag-name tag another-name"))
+        
+        # multiple hyphens cut down to one
+        self.assertEqual({"tag", "tag-name", "another-name"}, f.clean("tag--name tag another----name"))
+
+        # minimum number tags
+        err_message = "You should add at least 3 different tags. Tags must be separated by spaces"
+        with self.assertRaisesMessage(ValidationError, err_message):
+            f.clean("One two")
+
+        # maximum number tags
+        err_message = "There can be maximum 30 tags, please select the most relevant ones!"
+        with self.assertRaisesMessage(ValidationError, err_message):
+            tags = " ".join(["tag%s" % i for i in range(35)])
+            f.clean(tags)
+
+        # remove common words
+        self.assertEqual({"one", "two", "three"}, f.clean("three the of one to two one"))
+
+        # duplicate tags removed
+        self.assertEqual({"one", "two", "three"}, f.clean("three one two three one"))

--- a/utils/tests/tests.py
+++ b/utils/tests/tests.py
@@ -35,7 +35,6 @@ from sounds.models import Sound, Pack, License, Download
 from utils.audioprocessing.freesound_audio_analysis import FreesoundAudioAnalyzer
 from utils.audioprocessing.freesound_audio_processing import FreesoundAudioProcessor
 from utils.audioprocessing.processing import AudioProcessingException
-from utils.forms import filename_has_valid_extension
 from utils.sound_upload import get_csv_lines, validate_input_csv_file, bulk_describe_from_csv, create_sound, \
     NoAudioException, AlreadyExistsException
 from utils.tags import clean_and_split_tags
@@ -48,20 +47,6 @@ from utils.test_helpers import create_test_files, create_user_and_sounds, overri
 class UtilsTest(TestCase):
 
     fixtures = ['initial_data']
-
-    def test_filename_has_valid_extension(self):
-        cases = [
-            ('filaneme.wav', True),
-            ('filaneme.aiff', True),
-            ('filaneme.aif', True),
-            ('filaneme.mp3', True),
-            ('filaneme.ogg', True),
-            ('filaneme.flac', True),
-            ('filaneme.xyz', False),
-            ('wav', False),
-        ]
-        for filename, expected_result in cases:
-            self.assertEqual(filename_has_valid_extension(filename), expected_result)
 
     def test_download_sounds(self):
         user = User.objects.create_user("testuser", password="testpass")


### PR DESCRIPTION
**Issue(s)**
Fixes #1254
Fixes #1210

**Description**
We don't support any other characters, but we shouldn't raise an
uncaught exception either.


**Deployment steps**:
Resolve issue in sentry: https://logserver.mtg.upf.edu/sentry/freesound-web/issues/1133/
https://logserver.mtg.upf.edu/sentry/freesound-web/issues/1216/

