### PR TITLE
Further improvements in sound flag admin management

### DIFF
--- a/sounds/admin.py
+++ b/sounds/admin.py
@@ -21,6 +21,8 @@
 #
 
 from django.contrib import admin
+from django.db import models
+from django.template.defaultfilters import truncatechars
 from django.urls import reverse
 from sounds.models import License, Sound, Pack, Flag, DeletedSound, SoundOfTheDay, BulkUploadProgress
 
@@ -62,33 +64,52 @@ admin.site.register(Pack, PackAdmin)
 
 class FlagAdmin(admin.ModelAdmin):
     raw_id_fields = ('reporting_user', 'sound')
-    list_display = ('id', 'reporting_user_link', 'email_link', 'sound_uploader_link', 'sound_link', 'reason_summary', 'reason_type')
-    list_filter = ('reason_type',)
+    list_display = ('id', 'reporting_user_link', 'email_link', 'sound_link', 'sound_uploader_link', 'sound_is_explicit',
+                    'reason_type', 'reason_summary', )
+    list_filter = ('reason_type', 'sound__is_explicit')
+
+    def get_queryset(self, request):
+        # overrride 'get_queryset' to optimize query by using select_related on 'sound' and 'reporting_user'
+        qs = super(FlagAdmin, self).get_queryset(request)
+        qs = qs.select_related('sound', 'reporting_user')
+        return qs
 
     def reporting_user_link(self, obj):
         return '<a href="{0}" target="_blank">{1}</a>'.format(
             reverse('account', args=[obj.reporting_user.username]), obj.reporting_user.username) \
             if obj.reporting_user else '-'
     reporting_user_link.allow_tags = True
+    reporting_user_link.admin_order_field = 'reporting_user__username'
+    reporting_user_link.short_description = 'Reporting User'
 
     def email_link(self, obj):
         return '<a href="mailto:{0}" target="_blank">{1}</a>'.format(obj.email, obj.email) \
             if obj.email else '-'
     email_link.allow_tags = True
+    email_link.admin_order_field = 'email'
+    email_link.short_description = 'Email'
 
     def sound_uploader_link(self, obj):
         return '<a href="{0}" target="_blank">{1}</a>'.format(reverse('account', args=[obj.sound.user.username]),
                                                               obj.sound.user.username)
     sound_uploader_link.allow_tags = True
+    sound_uploader_link.admin_order_field = 'sound__user__username'
+    sound_uploader_link.short_description = 'Uploader'
 
     def sound_link(self, obj):
         return '<a href="{0}" target="_blank">{1}</a>'.format(reverse('short-sound-link', args=[obj.sound_id]),
-                                                              obj.sound_id)
+                                                              truncatechars(obj.sound.original_filename, 50))
     sound_link.allow_tags = True
+    sound_link.admin_order_field = 'sound__original_filename'
+    sound_link.short_description = 'Sound'
 
     def reason_summary(self, obj):
         reason_no_newlines = obj.reason.replace('\n', '|')
-        return reason_no_newlines if len(reason_no_newlines) < 50 else reason_no_newlines[:50] + '...'
+        return truncatechars(reason_no_newlines, 100)
+
+    def sound_is_explicit(self, obj):
+        return obj.sound.is_explicit
+    sound_is_explicit.short_description = 'Is Explicit'
 
 
 admin.site.register(Flag, FlagAdmin)


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1263

**Description**
New improvements include:
 * Double length of reason summary
 * Display sound name instead of sound id
 * Add is_explicit field
 * Optimize query
 * Enable sorting in columns
 * Enable filtering by is_explicit field
 * Show more convenient labels in list display

That's how the admin looks like now (with fake data of course):
![Screenshot 2019-06-11 at 11 48 34](https://user-images.githubusercontent.com/478615/59262370-5a75ab00-8c3f-11e9-972f-06374c40d3b5.png)
