### PR TITLE
Make username change case insensitive

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -484,7 +484,7 @@ post_save.connect(create_user_profile, sender=User)
 def presave_user(sender, instance, **kwargs):
     try:
         old_username = User.objects.get(pk=instance.id).username
-        if old_username != instance.username:
+        if old_username.lower() != instance.username.lower():
             # We use .get_or_create below to avoid having 2 OldUsername objects with the same user/username pair
             OldUsername.objects.get_or_create(user=instance, username=old_username)
     except User.DoesNotExist:

--- a/accounts/tests/test_user.py
+++ b/accounts/tests/test_user.py
@@ -697,6 +697,19 @@ class ChangeUsernameTest(TestCase):
         self.assertEqual(OldUsername.objects.filter(username='userANewNewName', user=userA).count(), 1)
         self.assertEqual(OldUsername.objects.filter(user=userA).count(), 3)
 
+    def test_change_username_case_insensitiveness(self):
+        """Test that changing the username for a new version of the username with different capitalization does not
+        create a new OldUsername object.
+        """
+        # Create user and login
+        userA = User.objects.create_user('userA', email='userA@freesound.org', password='testpass')
+        self.client.login(username='userA', password='testpass')
+
+        # Rename "userA" to "UserA", should not create OldUsername object
+        resp = self.client.post(reverse('accounts-edit'), data={u'profile-username': [u'UserA']})
+        self.assertRedirects(resp, reverse('accounts-home'))
+        self.assertEqual(OldUsername.objects.filter(username='userA', user=userA).count(), 0)
+
 
 class UsernameValidatorTest(TestCase):
     """ Makes sure that username validation works as intended """


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1282

**Description**
When users change their profiles we check if username has changed so
we can create `OldUsername` objects that we'll use to redirect URLs of
old username to new username. Because usernames are treated as case
insensitive, username changes should only create `OldUsername` objects
when the username update includes changes other than capitalization.
Otherwise this can create problems as described in the issue.

**Deployment steps**:
Run the following commands in console to remove all existing `OldUsername` objects that link versions of the same username with different cases (there should be ~85 cases in production)

```python
for ou in OldUsername.objects.select_related('user').all():
    if ou.username.lower() == ou.user.username.lower():
        print 'deleting:', ou
        ou.delete()
```