### PR TITLE
Add silk profiling software

### DIFF
--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -18,6 +18,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'silk.middleware.SilkyMiddleware',
     'freesound.middleware.TosAcceptanceHandler',
     'freesound.middleware.BulkChangeLicenseHandler',
     'freesound.middleware.UpdateEmailHandler',
@@ -63,7 +64,15 @@ INSTALLED_APPS = [
     'monitor',
     'raven.contrib.django.raven_compat',
     'django_object_actions',
+    'silk',
 ]
+
+# Silk is the Request/SQL logging platform. We install it but leave it disabled
+# It can be activated in local_settings by changing INTERCEPT_FUNC
+SILKY_AUTHENTICATION = True  # User must login
+SILKY_AUTHORISATION = True  # User must have permissions
+SILKY_PERMISSIONS = lambda user: user.is_superuser
+SILKY_INTERCEPT_FUNC = lambda request: False
 
 CORS_ORIGIN_ALLOW_ALL = True
 

--- a/freesound/urls.py
+++ b/freesound/urls.py
@@ -153,7 +153,10 @@ urlpatterns = [
     url(r'^packsViewSingle', sounds.views.old_pack_link_redirect, name="old-pack-page"),
     url(r'^tagsViewSingle', tags.views.old_tag_link_redirect, name="old-tag-page"),
     url(r'^forum/viewtopic', forum.views.old_topic_link_redirect, name="old-topic-page"),
+
 ]
+
+urlpatterns += [url(r'^silk/', include('silk.urls', namespace='silk'))]
 
 # if you need django to host the admin files...
 from django.conf import settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ boto3==1.7.10
 xlrd==1.1.0
 numpy==1.9.0
 scikits.audiolab==0.11.0
+django-silk==3.0.2


### PR DESCRIPTION
**Description**
Add app to profile request time and sql queries

**Deployment steps**:
1. Install from requirements
2. Run these commands
```
python manage.py migrate
python manage.py collectstatic
```
Because we don't use collectstatic in production we might have to adjust nginx config to allow it to load silk static assets.

3. Update local_settings to set `SILKY_INTERCEPT_FUNC`
