### PR TITLE
Redirect to donations page if request is GET for paypal-session

### DIFF
--- a/donations/views.py
+++ b/donations/views.py
@@ -230,6 +230,8 @@ def donation_session_paypal(request):
         else:
             data = {'errors': form.errors}
         return JsonResponse(data)
+    # If request is GET redirect to donations page
+    return HttpResponseRedirect(reverse('donate'))
 
 
 def donate(request):


### PR DESCRIPTION
Users shouldn't get to this page with GET, but if they do it will
raise an error. Therefore, if that happens now we redirect to the
donations page.
