### PR TITLE
#1348: reduce number of queries before views start

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -742,7 +742,7 @@ def attribution(request):
 
 @redirect_if_old_username_or_404
 def downloaded_sounds(request, username):
-    user = get_object_or_404(User, username__iexact=username)
+    user = request.parameter_user
     qs = Download.objects.filter(user_id=user.id)
     paginator = paginate(request, qs, settings.SOUNDS_PER_PAGE, object_count=user.profile.num_sound_downloads)
     page = paginator["page"]
@@ -757,7 +757,7 @@ def downloaded_sounds(request, username):
 
 @redirect_if_old_username_or_404
 def downloaded_packs(request, username):
-    user = get_object_or_404(User, username__iexact=username)
+    user = request.parameter_user
     qs = PackDownload.objects.filter(user=user.id)
     paginator = paginate(request, qs, settings.PACKS_PER_PAGE, object_count=user.profile.num_pack_downloads)
     page = paginator["page"]
@@ -856,7 +856,7 @@ def accounts(request):
 
 @redirect_if_old_username_or_404
 def account(request, username):
-    user = User.objects.select_related('profile').get(username__iexact=username)
+    user = request.parameter_user
 
     tags = user.profile.get_user_tags() if user.profile else []
     latest_sounds = list(Sound.objects.bulk_sounds_for_user(user.id, settings.SOUNDS_PER_PAGE))

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -179,9 +179,8 @@ def bulk_license_change(request):
             Sound.objects.filter(user=request.user).update(license=selected_license, is_index_dirty=True)
             for sound in Sound.objects.filter(user=request.user).all():
                 SoundLicenseHistory.objects.create(sound=sound, license=selected_license)
-            Profile.objects.filter(user=request.user).update(has_old_license=False)
-            cache.set('has-old-license-%s' % request.user.id,
-                      [False, Sound.objects.filter(user=request.user).exists()], 2592000)
+            request.user.profile.has_old_license = False
+            request.user.profile.save()
             return HttpResponseRedirect(reverse('accounts-home'))
     else:
         form = NewLicenseForm()

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -35,7 +35,7 @@ from utils.username import redirect_if_old_username_or_404
 
 @redirect_if_old_username_or_404
 def bookmarks(request, username, category_id=None):
-    user = get_object_or_404(User, username__iexact=username)
+    user = request.parameter_user
 
     is_owner = request.user.is_authenticated and user == request.user
 

--- a/comments/views.py
+++ b/comments/views.py
@@ -54,7 +54,7 @@ def delete(request, comment_id):
 @redirect_if_old_username_or_404
 def for_user(request, username):
     """ Display all comments for the sounds of the user """
-    user = get_object_or_404(User, username__iexact=username)
+    user = request.parameter_user
     sounds = Sound.objects.filter(user=user)
     qs = Comment.objects.filter(sound__in=sounds).select_related("user", "user__profile")
     paginator = paginate(request, qs, 30)
@@ -71,7 +71,7 @@ def for_user(request, username):
 @redirect_if_old_username_or_404
 def by_user(request, username):
     """ Display all comments made by the user """
-    user = get_object_or_404(User, username__iexact=username)
+    user = request.parameter_user
     qs = Comment.objects.filter(user=user).select_related("user", "user__profile")
     paginator = paginate(request, qs, 30)
     comments = paginator["page"].object_list

--- a/follow/views.py
+++ b/follow/views.py
@@ -36,7 +36,7 @@ from utils.username import redirect_if_old_username_or_404
 
 @redirect_if_old_username_or_404
 def following_users(request, username):
-    user = get_object_or_404(User, username=username)
+    user = request.parameter_user
     is_owner = False
     if request.user.is_authenticated:
         is_owner = request.user == user
@@ -50,7 +50,7 @@ def following_users(request, username):
 
 @redirect_if_old_username_or_404
 def followers(request, username):
-    user = get_object_or_404(User, username=username)
+    user = request.parameter_user
     is_owner = False
     if request.user.is_authenticated:
         is_owner = request.user == user
@@ -64,7 +64,7 @@ def followers(request, username):
 
 @redirect_if_old_username_or_404
 def following_tags(request, username):
-    user = get_object_or_404(User, username=username)
+    user = request.parameter_user
     is_owner = False
     if request.user.is_authenticated:
         is_owner = request.user == user

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -721,7 +721,7 @@ def pack(request, username, pack_id):
 
 @redirect_if_old_username_or_404
 def packs_for_user(request, username):
-    user = get_object_or_404(User, username__iexact=username)
+    user = request.parameter_user
     order = request.GET.get("order", "name")
     if order not in ["name", "-last_updated", "-created", "-num_sounds", "-num_downloads"]:
         order = "name"
@@ -736,7 +736,7 @@ def packs_for_user(request, username):
 
 @redirect_if_old_username_or_404
 def for_user(request, username):
-    sound_user = get_object_or_404(User, username__iexact=username)
+    sound_user = request.parameter_user
     paginator = paginate(request, Sound.public.only('id').filter(user=sound_user), settings.SOUNDS_PER_PAGE)
     sound_ids = [sound_obj.id for sound_obj in paginator['page']]
     user_sounds = Sound.objects.ordered_ids(sound_ids)

--- a/utils/username.py
+++ b/utils/username.py
@@ -23,7 +23,6 @@ from django.contrib.auth.models import User
 from accounts.models import OldUsername
 from django.http import Http404
 from django.shortcuts import redirect
-from django.core.urlresolvers import NoReverseMatch
 from django.urls import reverse
 
 
@@ -43,7 +42,7 @@ def get_user_from_username_or_oldusername(username):
 def get_user_or_404(username):
     # Helper to get the user from an username or raise 404
     user = get_user_from_username_or_oldusername(username)
-    if user == None:
+    if user is None:
         raise Http404
     return user
 
@@ -56,12 +55,13 @@ def redirect_if_old_username_or_404(func):
     internal URL that require users being logged in. This is because there should not be public links pointing to
     internal URLs.
     """
+
     def inner(request, *args, **kwargs):
         new_user = get_user_or_404(kwargs['username'])
         if kwargs['username'] != new_user.username:
             kwargs['username'] = new_user.username
             return redirect(reverse(inner, args=args, kwargs=kwargs), permanent=True)
+        request.parameter_user = new_user
         return func(request, *args, **kwargs)
+
     return inner
-
-


### PR DESCRIPTION
**Issue(s)**
#1348

**Description**
We found that some middlewares and other before-view processes (decorators) are running a high number of queries. Because these happen before every single request, optimising them should have a huge impact in the number of queries that we run.
