### PR TITLE
Reduce number of sql queries on some pages

### DIFF
--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -33,7 +33,7 @@ class BookmarksTest(TestCase):
         context = resp.context
 
         self.assertEqual(200, resp.status_code)
-        expected_keys = ['bookmark_categories', 'bookmarked_sounds', 'current_page', 'is_owner',
+        expected_keys = ['bookmark_categories', 'current_page', 'is_owner',
                          'n_uncat', 'page', 'paginator', 'user']
         context_keys = context.keys()
         for k in expected_keys:
@@ -67,7 +67,7 @@ class BookmarksTest(TestCase):
         context = resp.context
 
         self.assertEqual(200, resp.status_code)
-        expected_keys = ['bookmark_categories', 'bookmarked_sounds', 'current_page', 'is_owner',
+        expected_keys = ['bookmark_categories', 'current_page', 'is_owner',
                          'n_uncat', 'page', 'paginator', 'user']
         context_keys = context.keys()
         for k in expected_keys:
@@ -84,7 +84,7 @@ class BookmarksTest(TestCase):
         response = self.client.get(reverse('bookmarks-for-user', kwargs={'username': user.username}))
 
         self.assertEqual(200, response.status_code)
-        self.assertEqual(3, len(response.context['bookmarked_sounds']))
+        self.assertEquals(3, len(response.context['page'].object_list))
         self.assertContains(response, 'Your bookmarks')
         self.assertContains(response, 'Uncategorized bookmarks')
         self.assertContains(response, 'BookmarkedSound')
@@ -126,7 +126,7 @@ class BookmarksTest(TestCase):
                                            kwargs={'username': user.username, 'category_id': category.id}))
 
         self.assertEqual(200, response.status_code)
-        self.assertEqual(2, len(response.context['bookmarked_sounds']))
+        self.assertEquals(2, len(response.context['page'].object_list))
         self.assertContains(response, 'Your bookmarks')
         self.assertContains(response, 'Bookmarks in "Category1"')
         self.assertContains(response, 'Uncategorized</a> (1 bookmark)')
@@ -155,8 +155,7 @@ class BookmarksTest(TestCase):
         # The response is a 200
         self.assertEqual(200, response.status_code)
 
-
-        self.assertEqual(2, len(response.context['bookmarked_sounds']))
+        self.assertEquals(2, len(response.context['page'].object_list))
         self.assertContains(response, 'Your bookmarks')
         self.assertContains(response, 'Bookmarks in "Category1"')
         self.assertContains(response, 'Uncategorized</a> (1 bookmark)')

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -22,6 +22,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.db import transaction
+from django.db.models import Count
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
 from django.urls import reverse
@@ -43,12 +44,12 @@ def bookmarks(request, username, category_id=None):
 
     if not category_id:
         category = None
-        bookmarked_sounds = Bookmark.objects.select_related("sound").filter(user=user, category=None)
+        bookmarked_sounds = Bookmark.objects.select_related("sound", "sound__user").filter(user=user, category=None)
     else:
         category = get_object_or_404(BookmarkCategory, id=category_id, user=user)
-        bookmarked_sounds = category.bookmarks.select_related("sound").all()
+        bookmarked_sounds = category.bookmarks.select_related("sound", "sound__user").all()
 
-    bookmark_categories = BookmarkCategory.objects.filter(user=user)
+    bookmark_categories = BookmarkCategory.objects.filter(user=user).annotate(num_bookmarks=Count('bookmarks'))
 
     tvars = {'user': user,
              'is_owner': is_owner,

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -54,7 +54,6 @@ def bookmarks(request, username, category_id=None):
     tvars = {'user': user,
              'is_owner': is_owner,
              'n_uncat': n_uncat,
-             'bookmarked_sounds': bookmarked_sounds,
              'category': category,
              'bookmark_categories': bookmark_categories}
     tvars.update(paginate(request, bookmarked_sounds, 30))

--- a/comments/views.py
+++ b/comments/views.py
@@ -56,7 +56,8 @@ def for_user(request, username):
     """ Display all comments for the sounds of the user """
     user = request.parameter_user
     sounds = Sound.objects.filter(user=user)
-    qs = Comment.objects.filter(sound__in=sounds).select_related("user", "user__profile")
+    qs = Comment.objects.filter(sound__in=sounds).select_related("user", "user__profile",
+                                                                 "sound__user", "sound__user__profile")
     paginator = paginate(request, qs, 30)
     comments = paginator["page"].object_list
     tvars = {
@@ -72,7 +73,8 @@ def for_user(request, username):
 def by_user(request, username):
     """ Display all comments made by the user """
     user = request.parameter_user
-    qs = Comment.objects.filter(user=user).select_related("user", "user__profile")
+    qs = Comment.objects.filter(user=user).select_related("user", "user__profile",
+                                                          "sound__user", "sound__user__profile")
     paginator = paginate(request, qs, 30)
     comments = paginator["page"].object_list
     tvars = {
@@ -86,7 +88,7 @@ def by_user(request, username):
 
 def all(request):
     """ Display all comments """
-    qs = Comment.objects.select_related("user", "user__profile")
+    qs = Comment.objects.select_related("user", "user__profile", "sound__user", "sound__user__profile")
     paginator = paginate(request, qs, 30)
     comments = paginator["page"].object_list
     tvars = {

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -980,7 +980,7 @@ def pack_downloaders(request, username, pack_id):
     pack = get_object_or_404(Pack, id=pack_id)
 
     # Retrieve all users that downloaded a sound
-    qs = PackDownload.objects.filter(pack_id=pack_id)
+    qs = PackDownload.objects.filter(pack_id=pack_id).select_related("user", "user__profile")
     paginator = paginate(request, qs, 32, object_count=pack.num_downloads)
 
     tvars = {'username': username,

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -238,7 +238,10 @@ def front_page(request):
 @redirect_if_old_username_or_404
 def sound(request, username, sound_id):
     try:
-        sound = Sound.objects.select_related("license", "user", "user__profile", "pack").get(id=sound_id, user__username=username)
+        sound = Sound.objects.prefetch_related("tags__tag")\
+            .select_related("license", "user", "user__profile", "pack")\
+            .get(id=sound_id, user__username=username)
+
         user_is_owner = request.user.is_authenticated and \
             (sound.user == request.user or request.user.is_superuser or request.user.is_staff or
              Group.objects.get(name='moderators') in request.user.groups.all())

--- a/templates/bookmarks/bookmarks.html
+++ b/templates/bookmarks/bookmarks.html
@@ -22,7 +22,7 @@
 	<h3>Uncategorized bookmarks</h3>
     {% endif %}
 
-    {% if bookmarked_sounds %}
+    {% if page.object_list %}
 
 	{% show_paginator paginator page current_page request "bookmark" %}
 

--- a/templates/bookmarks/bookmarks.html
+++ b/templates/bookmarks/bookmarks.html
@@ -70,7 +70,7 @@
 		<li><a href="{% url "bookmarks-for-user" user.username %}" {% if not category %}style="font-weight:bold"{% endif %}>Uncategorized</a> ({{n_uncat}} bookmark{{ n_uncat|pluralize }})</li>
 
 	    {% for cat in bookmark_categories %}
-		<li><a href="{% url "bookmarks-for-user-for-category" user.username cat.id %}" {% if category.id == cat.id %}style="font-weight:bold"{% endif %}>{{cat.name}}</a> ({{cat.bookmarks.count}} bookmark{{ cat.bookmarks.count|pluralize }})
+		<li><a href="{% url "bookmarks-for-user-for-category" user.username cat.id %}" {% if category.id == cat.id %}style="font-weight:bold"{% endif %}>{{cat.name}}</a> ({{cat.num_bookmarks}} bookmark{{ cat.num_bookmarks|pluralize }})
 
 		{% if is_owner %}<a href="{% url "delete-bookmark-category" cat.id %}{% if cat.id != category.id %}?next={{request.path}}&page={{current_page}}{% endif %}"><img  style="vertical-align: bottom;" src="{{media_url}}images/cancel.png" width="16" height="16" alt="Delete {{cat.name}} category"/></a>{% endif %}</li>
 


### PR DESCRIPTION
**Issue(s)**
#1344

**Description**
SQL query monitoring was showing that on some pages we were doing a separate sql query for repeated items on some pages. Use select_related/prefetch_related as required to reduce the number of queries.

I'm unsure about the best way to test these. Ideally I would wrap a call to the client in self.assertNumQueries, but these queries vary depending on if the user is logged in, is an admin, has accepted ToS, etc. We could have some constants set that have the number of queries that are called in each of these cases so that we can add them to the expected number, e.g.

```py
expected_num_queries = 6
with self.assertNumQueries(testing.NUM_QUERIES_LOGGED_IN_ADMIN + expected_num_queries):
    self.client.get(....)
```
