### PR TITLE
Perform less queries when showing item flag links

### DIFF
--- a/comments/models.py
+++ b/comments/models.py
@@ -19,12 +19,11 @@
 # Authors:
 #     See AUTHORS file.
 #
-
-import sounds
-from django.contrib.auth.models import User
-from django.contrib.contenttypes import fields
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.db.models.signals import post_delete
+
+import sounds
 
 
 class Comment(models.Model):
@@ -33,6 +32,7 @@ class Comment(models.Model):
     comment = models.TextField()
     parent = models.ForeignKey('self', null=True, blank=True, related_name='replies', default=None)
     created = models.DateTimeField(db_index=True, auto_now_add=True)
+    flags = GenericRelation('accounts.UserFlag')
 
     def __unicode__(self):
         return u"%s comment on %s" % (self.user, self.sound)

--- a/forum/models.py
+++ b/forum/models.py
@@ -21,6 +21,7 @@
 #
 
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models, transaction
 from django.db.models import F
 from django.urls import reverse
@@ -35,6 +36,7 @@ import accounts
 import logging
 
 logger = logging.getLogger('web')
+
 
 class Forum(OrderedModel):
 
@@ -173,6 +175,7 @@ class Post(models.Model):
         ("OK", _('OK')),
     )
     moderation_state = models.CharField(db_index=True, max_length=2, choices=MODERATION_STATE_CHOICES, default="OK")
+    flags = GenericRelation('accounts.UserFlag')
 
     class Meta:
         ordering = ('created',)

--- a/messages/models.py
+++ b/messages/models.py
@@ -21,6 +21,7 @@
 #
 
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.utils.encoding import smart_unicode
 
@@ -86,23 +87,24 @@ class Message(models.Model):
 
     user_from = models.ForeignKey(User, related_name='messages_sent')
     user_to = models.ForeignKey(User, related_name='messages_received')
-    
+
     subject = models.CharField(max_length=128)
-    
+
     body = models.ForeignKey(MessageBody)
 
     is_sent = models.BooleanField(default=True, db_index=True)
     is_read = models.BooleanField(default=False, db_index=True)
     is_archived = models.BooleanField(default=False, db_index=True)
-    
+
     created = models.DateTimeField(db_index=True, auto_now_add=True)
-    
+    flags = GenericRelation('accounts.UserFlag')
+
     def get_absolute_url(self):
         return "message", (smart_unicode(self.id),)
 
     def __unicode__(self):
         return u"from: [%s] to: [%s]" % (self.user_from, self.user_to)
-    
+
     class Meta:
         ordering = ('-created',)
 

--- a/messages/views.py
+++ b/messages/views.py
@@ -43,7 +43,7 @@ from utils.pagination import paginate
 def messages_change_state(request):
     if request.method == "POST":
         choice = request.POST.get("choice", False)
-        
+
         # get all message ids in the format `cb_[number]` which have a value of 'on'
         message_ids = []
         for key, val in request.POST.items():
@@ -120,7 +120,7 @@ def new_message(request, username=None, message_id=None):
         form_class = MessageReplyForm
     else:
         form_class = MessageReplyFormWithCaptcha
-    
+
     if request.method == 'POST':
         form = form_class(request.POST)
 
@@ -161,7 +161,7 @@ def new_message(request, username=None, message_id=None):
 
                 if message.user_from != request.user and message.user_to != request.user:
                     raise Http404
-                
+
                 body = message.body.body.replace("\r\n", "\n").replace("\r", "\n")
                 body = ''.join(BeautifulSoup(body).findAll(text=True))
                 body = "\n".join([(">" if line.startswith(">") else "> ") + "\n> ".join(wrap(line.strip(), 60))

--- a/templates/accounts/flag_user.html
+++ b/templates/accounts/flag_user.html
@@ -1,8 +1,4 @@
-
-{% if no_show %}
-    <!-- do noting -->
-{% else %}
-    {% if user_sounds < 1 %}
+{% if show %}
 
     <script type="text/javascript">
 
@@ -32,7 +28,7 @@
             $("#" + id.toString() + "_link").html("");
             $("#" + id.toString() + "_info").html("<span style='color:green'>Spam/Offensive report sent!</span>");
             setTimeout(function() {
-                $("#" + id.toString() + "_info").hide()
+                $("#" + id.toString() + "_info").hide();
                 $("#" + id.toString() + "_link").html("<span style='color:#808080;'>{{ done_text }}</span>");
             }, 2000);
         }
@@ -41,7 +37,7 @@
             $("#" + id.toString() + "_link").html("");
             $("#" + id.toString() + "_info").html("<span style='color:red'>Some error occurred! Try again later...</span>")
             setTimeout(function() {
-                $("#" + id.toString() + "_info").hide()
+                $("#" + id.toString() + "_info").hide();
                 $("#" + id.toString() + "_link").html("<span style='color:#808080;'>Spam/Offensive reporting failed</span>");
             }, 2000);
         }
@@ -64,5 +60,4 @@
         {% endcomment %}
     </span>
 
-    {% endif %}
 {% endif %}

--- a/templates/forum/thread.html
+++ b/templates/forum/thread.html
@@ -69,7 +69,7 @@
         {% endif %}
 
         <div style="float:right; text-align: right; font-size: 10px; margin-right:-30px">
-            {% flag_user "FP" post.author.username post.id "" post.author.profile.num_sounds %}
+            {% flag_user "FP" post post.author %}
         </div>
 
     </li>

--- a/templates/messages/message.html
+++ b/templates/messages/message.html
@@ -23,7 +23,7 @@
 		{{message.body.body|smileys|safe|linebreaks}}
 	</div>
 	<span class="reply_button"><a href="{% url "message-reply" message.id %}">Reply</a></span>
-    <div style="font-size: 11px;font-weight: normal;margin-left: 5px">{% flag_user "PM" message.user_from.username message.id "" message.user_from.profile.num_sounds %}</div>
+    <div style="font-size: 11px;font-weight: normal;margin-left: 5px">{% flag_user "PM" message message.user_from %}</div>
 </div>
 
 {% endblock %}

--- a/templates/sounds/comments.html
+++ b/templates/sounds/comments.html
@@ -32,7 +32,7 @@
     {% for comment in comments %}
     <li>
         <div style="float:right; text-align: right; font-size: 10px">
-            {%  flag_user "SC" comment.user.username comment.id "" comment.user.profile.num_sounds %}
+            {%  flag_user "SC" comment comment.user %}
         </div>
         <img src="{{comment.user.profile.locations.avatar.S.url}}" alt="avatar" class="comment_avatar" />
         <div class="comment_info">

--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -120,7 +120,7 @@
                     {{comment.comment|replace_img|safe|linebreaks}}
 
                     <div style="text-align: right; font-size: 10px; margin-bottom: -8px">
-                        {%  flag_user "SC" comment.user.username comment.id "" comment.user.profile.num_sounds %}
+                        {% flag_user "SC" comment comment.user %}
                     </div>
 
                 </li>


### PR DESCRIPTION
**Issue(s)**
#1344

**Description**
There was a lot of additional complexity in the flag_user template tag that wasn't used. By performing a join in the view and passing in some slightly different objects to the template tag, we can avoid running a query per item (comment, message, post) in order to determine if we
should show a report link.

Some testing still required to determine if this is faster in all cases (it's very slow in the 'all comments' view, this could be improved by trying to perform it only over the currently viewed page instead of all comments)
