### PR TITLE
Don't perform extra queries when showing random sounds of packs (#1360)

### DIFF
--- a/sounds/models.py
+++ b/sounds/models.py
@@ -1134,13 +1134,9 @@ class Pack(SocialModel):
             self.last_updated = sounds[0].created
         self.save()
 
-    def get_random_sound_from_pack(self):
-        pack_sounds = Sound.objects.filter(pack=self.id, processing_state="OK", moderation_state="OK").order_by('?')[0:1]
-        return pack_sounds[0]
-
     def get_random_sounds_from_pack(self):
-        pack_sounds = Sound.objects.filter(pack=self.id, processing_state="OK", moderation_state="OK").order_by('?')[0:3]
-        return pack_sounds[0:min(3,len(pack_sounds))]
+        """Get 3 random sounds from this pack"""
+        return Sound.public.filter(pack=self.id).order_by('?')[:3]
 
     def get_pack_tags(self, max_tags=50):
         pack_tags = get_pack_tags(self)

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -699,12 +699,12 @@ def pack(request, username, pack_id):
     if pack.is_deleted:
         return render(request, 'sounds/deleted_pack.html')
 
-    qs = Sound.objects.only('id').filter(pack=pack, moderation_state='OK', processing_state='OK')
+    qs = Sound.public.only('id').filter(pack=pack)
     paginator = paginate(request, qs, settings.SOUNDS_PER_PAGE)
     sound_ids = [sound_obj.id for sound_obj in paginator['page']]
     pack_sounds = Sound.objects.ordered_ids(sound_ids)
 
-    num_sounds_ok = len(qs)
+    num_sounds_ok = paginator['paginator'].count
     if num_sounds_ok == 0 and pack.num_sounds != 0:
         messages.add_message(request, messages.INFO, 'The sounds of this pack have <b>not been moderated</b> yet.')
     else:

--- a/templates/sounds/display_pack.html
+++ b/templates/sounds/display_pack.html
@@ -30,27 +30,11 @@
 <div class="sounds_in_pack">
 {% with pack.get_random_sounds_from_pack as sounds %}
     <span class="text">Some random samples from the pack:</span><br>
-    <div class="sound">
-    {% with sounds.0 as sound %}
-        {% if sound %}
-            {% include "sounds/player_medium.html" %}
-        {% endif %}
-    {% endwith %}
-    </div>
-    <div class="sound">
-    {% with sounds.1 as sound %}
-        {% if sound %}
-            {% include "sounds/player_medium.html" %}
-        {% endif %}
-    {% endwith %}
-    </div>
-    <div class="sound">
-    {% with sounds.2 as sound %}
-        {% if sound %}
-            {% include "sounds/player_medium.html" %}
-        {% endif %}
-    {% endwith %}
-    </div>
+    {% for sound in sounds %}
+        <div class="sound">
+        {% include "sounds/player_medium.html" %}
+        </div>
+    {% endfor %}
 {% endwith %}
 </div>
 </div>


### PR DESCRIPTION
**Issue(s)**
#1360

**Description**
The template was causing a new queryset to be evaluated for each of the
3 random sounds in a pack (with the possiblity that all 3 sounds could
randomly be the same sound!).
Use the queryset count from the paginator to reduce the number of
queries on a pack page.
Use Sound.public in a few places to make code easier to read.
