### PR TITLE
Fix bug in sound moderation with is_explicit flags

### DIFF
--- a/tickets/forms.py
+++ b/tickets/forms.py
@@ -74,9 +74,9 @@ MODERATION_CHOICES = [(x, x) for x in
 IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY = "K"
 IS_EXPLICIT_ADD_FLAG_KEY = "A"
 IS_EXPLICIT_REMOVE_FLAG_KEY = "R"
-IS_EXPLICIT_FLAG_CHOICES = ((IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY, "Keep user preference"),
-                            (IS_EXPLICIT_ADD_FLAG_KEY, "Add \"is explicit\" flag"),
-                            (IS_EXPLICIT_REMOVE_FLAG_KEY, "Remove \"is explicit\" flag"))
+IS_EXPLICIT_FLAG_CHOICES = ((IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY, 'Keep user preference'),
+                            (IS_EXPLICIT_ADD_FLAG_KEY, 'Add "is explicit" flag'),
+                            (IS_EXPLICIT_REMOVE_FLAG_KEY, 'Remove "is explicit" flag'))
 
 
 class SoundModerationForm(forms.Form):

--- a/tickets/forms.py
+++ b/tickets/forms.py
@@ -89,9 +89,10 @@ class SoundModerationForm(forms.Form):
                              error_messages={'required': 'No sound selected...'})
     
     is_explicit = forms.ChoiceField(choices=IS_EXPLICIT_FLAG_CHOICES,
-                                    initial=IS_EXPLICIT_FLAG_CHOICES[0][0],
+                                    initial=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY,
                                     required=True, 
                                     label=mark_safe("<i>Is explicit</i> flag"))
+
 
 class ModerationMessageForm(forms.Form):
     message = HtmlCleaningCharField(widget=forms.Textarea,

--- a/tickets/forms.py
+++ b/tickets/forms.py
@@ -22,6 +22,7 @@ from django import forms
 from django.conf import settings
 from utils.forms import CaptchaWidget
 from utils.forms import HtmlCleaningCharField
+from django.utils.safestring import mark_safe
 
 
 class ModeratorMessageForm(forms.Form):
@@ -70,6 +71,13 @@ MODERATION_CHOICES = [(x, x) for x in
                        'Return',
                        'Whitelist']]
 
+IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY = "K"
+IS_EXPLICIT_ADD_FLAG_KEY = "A"
+IS_EXPLICIT_REMOVE_FLAG_KEY = "R"
+IS_EXPLICIT_FLAG_CHOICES = ((IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY, "Keep user preference"),
+                            (IS_EXPLICIT_ADD_FLAG_KEY, "Add \"is explicit\" flag"),
+                            (IS_EXPLICIT_REMOVE_FLAG_KEY, "Remove \"is explicit\" flag"))
+
 
 class SoundModerationForm(forms.Form):
     action = forms.ChoiceField(choices=MODERATION_CHOICES,
@@ -79,8 +87,11 @@ class SoundModerationForm(forms.Form):
 
     ticket = forms.CharField(widget=forms.widgets.HiddenInput,
                              error_messages={'required': 'No sound selected...'})
-    is_explicit = forms.BooleanField(required=False, label='Sound(s) contain explicit content')
-
+    
+    is_explicit = forms.ChoiceField(choices=IS_EXPLICIT_FLAG_CHOICES,
+                                    initial=IS_EXPLICIT_FLAG_CHOICES[0][0],
+                                    required=True, 
+                                    label=mark_safe("<i>Is explicit</i> flag"))
 
 class ModerationMessageForm(forms.Form):
     message = HtmlCleaningCharField(widget=forms.Textarea,

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -227,7 +227,7 @@ class TicketTestsIsExplicitFlagFromQueue(TicketTests):
         TicketTests.setUp(self)
         self.ticket = self._create_assigned_ticket()
 
-    def _perform_action(self, action, is_explicit_flag_key=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY):
+    def _perform_action(self, action, is_explicit_flag_key):
         return self.client.post(reverse('tickets-moderation-assigned', args=[self.test_moderator.id]), {
             'action': action, 'message': u'', 'ticket': self.ticket.id, 'is_explicit': is_explicit_flag_key})
 
@@ -237,7 +237,7 @@ class TicketTestsIsExplicitFlagFromQueue(TicketTests):
         """
         self.ticket.sound.is_explicit = True
         self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY)
+        self._perform_action(u'Approve', IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY)
         self.ticket.sound.refresh_from_db()
         self.assertEqual(self.ticket.sound.is_explicit, True)
 
@@ -247,7 +247,7 @@ class TicketTestsIsExplicitFlagFromQueue(TicketTests):
         """
         self.ticket.sound.is_explicit = False
         self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY)
+        self._perform_action(u'Approve', IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY)
         self.ticket.sound.refresh_from_db()
         self.assertEqual(self.ticket.sound.is_explicit, False)
 
@@ -257,7 +257,7 @@ class TicketTestsIsExplicitFlagFromQueue(TicketTests):
         """
         self.ticket.sound.is_explicit = True
         self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_ADD_FLAG_KEY)
+        self._perform_action(u'Approve', IS_EXPLICIT_ADD_FLAG_KEY)
         self.ticket.sound.refresh_from_db()
         self.assertTrue(self.ticket.sound.is_explicit)
 
@@ -267,7 +267,7 @@ class TicketTestsIsExplicitFlagFromQueue(TicketTests):
         """
         self.ticket.sound.is_explicit = False
         self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_ADD_FLAG_KEY)
+        self._perform_action(u'Approve', IS_EXPLICIT_ADD_FLAG_KEY)
         self.ticket.sound.refresh_from_db()
         self.assertTrue(self.ticket.sound.is_explicit)
 
@@ -277,7 +277,7 @@ class TicketTestsIsExplicitFlagFromQueue(TicketTests):
         """
         self.ticket.sound.is_explicit = False
         self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_REMOVE_FLAG_KEY)
+        self._perform_action(u'Approve', IS_EXPLICIT_REMOVE_FLAG_KEY)
         self.ticket.sound.refresh_from_db()
         self.assertFalse(self.ticket.sound.is_explicit)
 
@@ -287,6 +287,6 @@ class TicketTestsIsExplicitFlagFromQueue(TicketTests):
         """
         self.ticket.sound.is_explicit = True
         self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_REMOVE_FLAG_KEY)
+        self._perform_action(u'Approve', IS_EXPLICIT_REMOVE_FLAG_KEY)
         self.ticket.sound.refresh_from_db()
         self.assertFalse(self.ticket.sound.is_explicit)

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -154,9 +154,10 @@ class TicketTestsFromQueue(TicketTests):
         TicketTests.setUp(self)
         self.ticket = self._create_assigned_ticket()
 
-    def _perform_action(self, action, is_explicit_flag_key=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY):
+    def _perform_action(self, action):
         return self.client.post(reverse('tickets-moderation-assigned', args=[self.test_moderator.id]), {
-            'action': action, 'message': u'', 'ticket': self.ticket.id, 'is_explicit': is_explicit_flag_key})
+            'action': action, 'message': u'', 'ticket': self.ticket.id,
+            'is_explicit': IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY})
 
     @mock.patch('sounds.models.delete_sound_from_solr')
     def test_delete_ticket_from_queue(self, delete_sound_solr):
@@ -200,62 +201,6 @@ class TicketTestsFromQueue(TicketTests):
         self.assertEqual(resp.status_code, 200)
         self._assert_ticket_and_sound_fields(TICKET_STATUS_DEFERRED, self.test_moderator, 'PE')
 
-    def test_keep_is_explicit_preference_for_explicit_sound(self):
-        """Test that when approving a sound marked as 'is_explicit' it continues to be marked as such the moderator
-        chooses to preserve author's preference on the flag
-        """
-        self.ticket.sound.is_explicit = True
-        self.ticket.sound.save()
-        resp = self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY)
-        self.assertEqual(resp.status_code, 200)
-        self._assert_ticket_and_sound_fields(TICKET_STATUS_CLOSED, self.test_moderator, 'OK')
-        self.assertEqual(self.ticket.sound.is_explicit, True)
-
-    def test_keep_is_explicit_preference_for_non_explicit_sound(self):
-        """Test that when approving a sound not marked as 'is_explicit', the flag does not get added if the moderator
-        chooses to preserve author's preference on the flag
-        """
-        self.ticket.sound.is_explicit = False
-        self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY)
-        self.assertEqual(self.ticket.sound.is_explicit, False)
-
-    def test_add_is_explicit_flag_for_explicit_sound(self):
-        """Test that when apporving a sound it's 'is_explicit' flag is set to True if the moderator chooses to add
-        the explicit flag
-        """
-        self.ticket.sound.is_explicit = True
-        self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_ADD_FLAG_KEY)
-        self.assertTrue(self.ticket.sound.is_explicit)
-
-    def test_add_is_explicit_flag_for_non_explicit_sound(self):
-        """Test that when apporving a sound it's 'is_explicit' flag is set to True if the moderator chooses to add
-        the explicit flag, even if the sound was originally marked as non explicit
-        """
-        self.ticket.sound.is_explicit = False
-        self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_ADD_FLAG_KEY)
-        self.assertTrue(self.ticket.sound.is_explicit)
-
-    def test_remove_is_explicit_flag_for_non_explicit_sound(self):
-        """Test that when apporving a sound it's 'is_explicit' flag is set to False if the moderator chooses to remove
-        the explicit flag
-        """
-        self.ticket.sound.is_explicit = False
-        self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_REMOVE_FLAG_KEY)
-        self.assertFalse(self.ticket.sound.is_explicit)
-
-    def test_remove_is_explicit_flag_for_explicit_sound(self):
-        """Test that when apporving a sound it's 'is_explicit' flag is set to False if the moderator chooses to remove
-        the explicit flag, even if the sound was originally marked as explicit
-        """
-        self.ticket.sound.is_explicit = True
-        self.ticket.sound.save()
-        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_REMOVE_FLAG_KEY)
-        self.assertFalse(self.ticket.sound.is_explicit)
-
 
 class TicketTestsFromTicketViewOwn(TicketTestsFromQueue):
     """Ticket state changes in a response to actions from ticket inspection page for own ticket"""
@@ -273,3 +218,75 @@ class TicketTestsFromTicketViewNew(TicketTestsFromQueue):
     def _perform_action(self, action):
         return self.client.post(reverse('tickets-ticket', args=[self.ticket.key]), {
             'ss-action': action})
+
+
+class TicketTestsIsExplicitFlagFromQueue(TicketTests):
+    """Test that the is_explicit flag of moderated sounds changes in accordance to moderator's choices"""
+
+    def setUp(self):
+        TicketTests.setUp(self)
+        self.ticket = self._create_assigned_ticket()
+
+    def _perform_action(self, action, is_explicit_flag_key=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY):
+        return self.client.post(reverse('tickets-moderation-assigned', args=[self.test_moderator.id]), {
+            'action': action, 'message': u'', 'ticket': self.ticket.id, 'is_explicit': is_explicit_flag_key})
+
+    def test_keep_is_explicit_preference_for_explicit_sound(self):
+        """Test that when approving a sound marked as 'is_explicit' it continues to be marked as such the moderator
+        chooses to preserve author's preference on the flag
+        """
+        self.ticket.sound.is_explicit = True
+        self.ticket.sound.save()
+        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY)
+        self.ticket.sound.refresh_from_db()
+        self.assertEqual(self.ticket.sound.is_explicit, True)
+
+    def test_keep_is_explicit_preference_for_non_explicit_sound(self):
+        """Test that when approving a sound not marked as 'is_explicit', the flag does not get added if the moderator
+        chooses to preserve author's preference on the flag
+        """
+        self.ticket.sound.is_explicit = False
+        self.ticket.sound.save()
+        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY)
+        self.ticket.sound.refresh_from_db()
+        self.assertEqual(self.ticket.sound.is_explicit, False)
+
+    def test_add_is_explicit_flag_for_explicit_sound(self):
+        """Test that when apporving a sound it's 'is_explicit' flag is set to True if the moderator chooses to add
+        the explicit flag
+        """
+        self.ticket.sound.is_explicit = True
+        self.ticket.sound.save()
+        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_ADD_FLAG_KEY)
+        self.ticket.sound.refresh_from_db()
+        self.assertTrue(self.ticket.sound.is_explicit)
+
+    def test_add_is_explicit_flag_for_non_explicit_sound(self):
+        """Test that when apporving a sound it's 'is_explicit' flag is set to True if the moderator chooses to add
+        the explicit flag, even if the sound was originally marked as non explicit
+        """
+        self.ticket.sound.is_explicit = False
+        self.ticket.sound.save()
+        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_ADD_FLAG_KEY)
+        self.ticket.sound.refresh_from_db()
+        self.assertTrue(self.ticket.sound.is_explicit)
+
+    def test_remove_is_explicit_flag_for_non_explicit_sound(self):
+        """Test that when apporving a sound it's 'is_explicit' flag is set to False if the moderator chooses to remove
+        the explicit flag
+        """
+        self.ticket.sound.is_explicit = False
+        self.ticket.sound.save()
+        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_REMOVE_FLAG_KEY)
+        self.ticket.sound.refresh_from_db()
+        self.assertFalse(self.ticket.sound.is_explicit)
+
+    def test_remove_is_explicit_flag_for_explicit_sound(self):
+        """Test that when apporving a sound it's 'is_explicit' flag is set to False if the moderator chooses to remove
+        the explicit flag, even if the sound was originally marked as explicit
+        """
+        self.ticket.sound.is_explicit = True
+        self.ticket.sound.save()
+        self._perform_action(u'Approve', is_explicit_flag_key=IS_EXPLICIT_REMOVE_FLAG_KEY)
+        self.ticket.sound.refresh_from_db()
+        self.assertFalse(self.ticket.sound.is_explicit)

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -392,6 +392,7 @@ def moderation_assigned(request, user_id):
         msg_form = ModerationMessageForm(request.POST)
 
         if mod_sound_form.is_valid() and msg_form.is_valid():
+
             ticket_ids = mod_sound_form.cleaned_data.get("ticket", '').split('|')
             tickets = Ticket.objects.filter(id__in=ticket_ids)
             msg = msg_form.cleaned_data.get("message", False)
@@ -416,8 +417,8 @@ def moderation_assigned(request, user_id):
                 elif is_explicit_choice_key == IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY:
                     # Don't update the 'is_explicit' field and leave it as the user originally set it
                     pass
-
                 Sound.objects.filter(ticket__in=tickets).update(**sounds_update_params)
+
                 if msg:
                     notification = Ticket.NOTIFICATION_APPROVED_BUT
                 else:

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -414,9 +414,10 @@ def moderation_assigned(request, user_id):
                     sounds_update_params['is_explicit'] = True
                 elif is_explicit_choice_key == IS_EXPLICIT_REMOVE_FLAG_KEY:
                     sounds_update_params['is_explicit'] = False
-                elif is_explicit_choice_key == IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY:
-                    # Don't update the 'is_explicit' field and leave it as the user originally set it
-                    pass
+
+                # Otherwise is_explicit_choice_key = IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY, don't update the
+                # 'is_explicit' field and leave it as the user originally set it
+
                 Sound.objects.filter(ticket__in=tickets).update(**sounds_update_params)
 
                 if msg:


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1367

**Description**
Fixed bug in sound moderation which caused the "is explicit" information introduced by users to be overwritten by moderators choices even if moderators introduced no preference. 

After this fix the moderators will have the options to 1) keep user preference about "is explicit" flag (default), 2) add the flag to all selected sounds, 3) remove the flag from all selected sounds.

I have manually tested the fixed feature with several sounds and it works good. Also added unit tests.
