### PR TITLE
Mapbox API version update

### DIFF
--- a/media/js/maps-mapbox.js
+++ b/media/js/maps-mapbox.js
@@ -1,5 +1,6 @@
 var FREESOUND_SATELLITE_STYLE_ID = 'cjgxefqkb00142roas6kmqneq';
 var FREESOUND_STREETS_STYLE_ID = 'cjkmk0h7p79z32spe9j735hrd';
+var MIN_INPUT_CHARACTERS_FOR_GEOCODER =  3; // From mapbox docs: "Minimum number of characters to enter before [geocoder] results are shown"
 
 function setMaxZoomCenter(lat, lng, zoom) {
     window.map.flyTo({'center': [lng, lat], 'zoom': zoom - 1});  // Subtract 1 for compatibility with gmaps zoom levels
@@ -101,7 +102,7 @@ function make_sounds_map(geotags_url, map_element_id, on_built_callback, on_boun
             map.touchZoomRotate.disableRotation();
             map.addControl(new mapboxgl.NavigationControl({ showCompass: false }));
             if (show_search === true){
-                map.addControl(new MapboxGeocoder({ accessToken: mapboxgl.accessToken }), 'top-left');
+                map.addControl(new MapboxGeocoder({ accessToken: mapboxgl.accessToken, minLength: MIN_INPUT_CHARACTERS_FOR_GEOCODER}), 'top-left');
             }
             window.map = map; // Used to have a global reference to the map
 
@@ -326,7 +327,7 @@ function make_geotag_edit_map(map_element_id, arrow_url, on_bounds_changed_callb
     map.dragRotate.disable();
     map.touchZoomRotate.disableRotation();
     map.addControl(new mapboxgl.NavigationControl({ showCompass: false }));
-    map.addControl(new MapboxGeocoder({ accessToken: mapboxgl.accessToken }), 'top-left');
+    map.addControl(new MapboxGeocoder({ accessToken: mapboxgl.accessToken, minLength: MIN_INPUT_CHARACTERS_FOR_GEOCODER }), 'top-left');
 
     map.toggleStyle = function() {
         toggleMapStyle(map, map_element_id);

--- a/templates/templatetags/maps_js_scripts.html
+++ b/templates/templatetags/maps_js_scripts.html
@@ -1,7 +1,7 @@
-<script src='https://api.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.js'></script>
-<link href='https://api.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.css' rel='stylesheet' />
-<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.2.0/mapbox-gl-geocoder.min.js'></script>
-<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.2.0/mapbox-gl-geocoder.css' type='text/css' />
+<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.js'></script>
+<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.css' rel='stylesheet' />
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.4.1/mapbox-gl-geocoder.min.js'></script>
+<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.4.1/mapbox-gl-geocoder.css' type='text/css' />
 <script type="text/javascript" src="{{ media_url }}/js/maps-mapbox.js?v={{ last_restart_date }}"></script>
 <script type="text/javascript">
     mapboxgl.accessToken = '{{ mapbox_access_token }}';


### PR DESCRIPTION
**Description**
Mapbox is introducing changes in the pricing which require an update of the versions of the APIs used. I've reviewed the release notes and there don't seem to be any breaking changes from the version we used to the most up to date. This PR updates the JS file we load from mapbox. I did some testing locally and it all seems to load and work well.

This PR also includes a small modification in the geocoder behaviour to reduce the number of API requests we make by not triggering a request if user has inputted less that 3 characters.

**Deployment steps**:
Keep an eye on map load counts and the new pricing ;)