### PR TITLE
Search Results Clustering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ freesound/logger.py
 tagrecommendation/TODO.txt
 tagrecommendation/tagrecommendation_settings.py
 similarity/similarity_settings.py
+clustering/clustering_settings.py
 .env
 start_freesound_services.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
 - cp freesound/local_settings.example.py freesound/local_settings.py
 - cp freesound/logger.example.py freesound/logger.py
 - cp similarity/similarity_settings.example.py similarity/similarity_settings.py
+- cp clustering/clustering_settings.example.py clustering/clustering_settings.py
 - cp tagrecommendation/tagrecommendation_settings.example.py tagrecommendation/tagrecommendation_settings.py
 - sed -i 's$/path/to/django/debug.log$debug.log$' freesound/logger.py
 - sed -i 's$^DISPLAY_DEBUG_TOOLBAR.*$DISPLAY_DEBUG_TOOLBAR = False$' freesound/local_settings.py

--- a/clustering/__init__.py
+++ b/clustering/__init__.py
@@ -1,0 +1,17 @@
+from clustering import ClusteringEngine
+
+
+engine = None
+
+default_app_config = 'clustering.apps.ClusteringConfig'
+
+# strings used for communicating the state of the clustering process
+CLUSTERING_RESULT_STATUS_PENDING = "pending"
+CLUSTERING_RESULT_STATUS_FAILED = "failed"
+
+# We only init the clustering engine (which requires specific dependencies) if running process 
+# is configured to be a Celery worker. This function is called when Django starts in the ready 
+# method of the clustering app.
+def init_clustering_engine():
+    global engine
+    engine = ClusteringEngine()

--- a/clustering/apps.py
+++ b/clustering/apps.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+from django.apps import AppConfig
+from . import init_clustering_engine
+
+
+class ClusteringConfig(AppConfig):
+    name = 'clustering'
+    
+    def ready(self):
+        if settings.IS_CELERY_WORKER:
+            init_clustering_engine()

--- a/clustering/clustering.py
+++ b/clustering/clustering.py
@@ -1,0 +1,443 @@
+import os, sys
+from time import time
+import logging
+from django.conf import settings
+
+import clustering_settings as clust_settings
+
+# The following packages are only needed if the running process is configured to be a Celery worker. 
+# We avoid importing them in appservers to avoid having to install unneeded dependencies.
+if settings.IS_CELERY_WORKER:
+    from gaia_wrapper import GaiaWrapperClustering
+    import numpy as np
+    from sklearn import metrics
+    from sklearn.feature_selection import mutual_info_classif
+    import json
+    import networkx as nx
+    from networkx.readwrite import json_graph
+    import community as com
+    from networkx.algorithms.community import k_clique_communities, greedy_modularity_communities
+
+logger = logging.getLogger('clustering')
+
+
+class ClusteringEngine():
+    """Clustering Engine class.
+
+    This class regroups various methods for performing clustering on a set of sounds.
+
+    Instead of directly using the audio feature space for performing the clustering, it creates a 
+    K-Nearest Neighbors Graph that is then partitioned for obtaining the clusters.
+    It relies on Gaia for performing nearest neighbor searches on a multi-dimentional feature space
+    (in gaia_wrapper.py file). The available features used for clustering are listed in the 
+    clustering_settings.py file. It requires building the Gaia dataset index file in advanced.
+
+    It also includes some methods that enable to automaticaly estimate the performance of the clustering
+    method. Moreover, a few unsued alternative methods for performing some intermediate steps are left 
+    here for developement and research purpose.
+    """
+    def __init__(self):
+        self.gaia = GaiaWrapperClustering()
+
+    def _prepare_clustering_result_and_reference_features_for_evaluation(self, classes):
+        """Formats the clustering classes and some reference features in order to then estimate how good is the 
+        clustering performance. Tipically the reference features can be tag-derived features that reflect semantic 
+        characteristics of the content. The reference features are defined in the clustering settings file.
+        
+        Extracts reference features for the sounds given as keys of the classes argument.
+        Prepares classes and extracted features in lists in order to compare them.
+        Removes sounds with missing features.
+
+        Args:
+            classes (Dict{Int: Int}): clustering classes for each sound {<sound_id>: <class_idx>}.
+
+        Returns:
+            Tuple(List[List[Float]], List[Int]): 2-element tuple containing a list of evaluation features 
+                and list of classes (clusters) idx.
+        """
+        sound_ids_list, clusters = zip(*classes.items())
+        reference_features = self.gaia.return_sound_reference_features(sound_ids_list)
+
+        # Remove sounds that are not in the gaia reference dataset
+        idx_to_remove = set([idx for idx, feature in enumerate(reference_features) if feature == None])
+        reference_features_filtered = [f for idx, f in enumerate(reference_features) if idx not in idx_to_remove]
+        clusters_filtered = [c for idx, c in enumerate(clusters) if idx not in idx_to_remove]
+
+        return reference_features_filtered, clusters_filtered
+
+    def _average_mutual_information_reference_features_clusters(self, classes):
+        """Estimates Average Mutual Information between reference features and the given clustering classes.
+
+        Args:
+            classes (Dict{Int: Int}): clustering classes for each sound {<sound_id>: <class_idx>}.
+
+        Returns:
+            Numpy.float: Average Mutual Information.
+        """
+        reference_features, clusters = self._prepare_clustering_result_and_reference_features_for_evaluation(classes)
+        return np.average(mutual_info_classif(reference_features, clusters, discrete_features=True))
+
+    def _silouhette_coeff_reference_features_clusters(self, classes):
+        """Computes mean Silhouette Coefficient score between reference features and the given clustering classes.
+
+        Args:
+            classes (Dict{Int: Int}): clustering classes for each sound {<sound_id>: <class_idx>}.
+
+        Returns:
+            Numpy.float: mean Silhouette Coefficient.
+        """
+        reference_features, clusters = self._prepare_clustering_result_and_reference_features_for_evaluation(classes)
+        return metrics.silhouette_score(reference_features, clusters, metric='euclidean')
+
+    def _calinski_idx_reference_features_clusters(self, classes):
+        """Computes the Calinski and Harabaz score between reference features and the given clustering classes.
+
+        Args:
+            classes (Dict{Int: Int}): clustering classes for each sound {<sound_id>: <class_idx>}.
+
+        Returns:
+            Numpy.float: Calinski and Harabaz score.
+        """
+        reference_features, clusters = self._prepare_clustering_result_and_reference_features_for_evaluation(classes)
+        return metrics.calinski_harabaz_score(reference_features, clusters)
+    
+    def _davies_idx_reference_features_clusters(self, classes):
+        """Computes the Davies-Bouldin score between reference features and the given clustering classes.
+
+        Args:
+            classes (Dict{Int: Int}): clustering classes for each sound {<sound_id>: <class_idx>}.
+
+        Returns:
+            Numpy.float: Davies-Bouldin score.
+        """
+        # This metric is not included in current used sklearn version
+        reference_features, clusters = self._prepare_clustering_result_and_reference_features_for_evaluation(classes)
+        return metrics.davies_bouldin_score(reference_features, clusters)
+
+    def _evaluation_metrics(self, classes):
+        """Computes different scores related to the clustering performance by comparing the resulting clustering classes
+        to the reference features defined in the clustering settings file. The reference features tipically correspond to 
+        tag-derived features that can reflect semantic characteristics of the audio clips.
+
+        Args:
+            classes (Dict{Int: Int}): clustering classes for each sound {<sound_id>: <class_idx>}.
+
+        Returns:
+            Tuple(Numpy.float, Numpy.float, Numpy.float): 3-element tuple containing the Average Mutual Information
+                score, the Silhouette Coefficient and the Calinski and Harabaz score.
+        """
+        # we compute the evaluation metrics only if some reference features are available for evaluation
+        # we return None when they are not available not to break the following part of the code
+        if clust_settings.REFERENCE_FEATURES in clust_settings.AVAILABLE_FEATURES:
+            reference_features, clusters = self._prepare_clustering_result_and_reference_features_for_evaluation(classes)
+            ami = np.average(mutual_info_classif(reference_features, clusters, discrete_features=True))
+            ss = metrics.silhouette_score(reference_features, clusters, metric='euclidean')
+            ci = metrics.calinski_harabaz_score(reference_features, clusters)
+            return ami, ss, ci
+        else:
+            return None, None, None
+
+    def _ratio_intra_community_edges(self, graph, communities):
+        """Computes the ratio of the number of intra-community (cluster) edges to the total number of edges in the cluster.
+
+        This may be useful for estimating how distinctive each cluster is against the other clusters.
+
+        Args:
+            graph (nx.Graph): NetworkX graph representation of sounds.
+            communities (List[List[Int]]): List storing Lists containing the Sound ids that are in each community (cluster).
+
+        Returns:
+            List[Float]: ratio value for each cluster.
+        """
+        # Assess individual communities quality
+        community_num_nodes = [len(community) for community in communities]
+        # counts the number of edges inside a community
+        intra_community_edges = [graph.subgraph(block).size() for block in communities]
+        # counts the number of edges from nodes in a community to nodes inside or outside the same community
+        total_community_edges = [sum([graph.degree(node_id) for node_id in community])-intra_community_edges[i] 
+                                                            for i, community in enumerate(communities)]
+        # ratio (high value -> good cluster)
+        ratio_intra_community_edges = [round(a/float(b), 2) for a,b in zip(intra_community_edges, total_community_edges)]
+
+        return ratio_intra_community_edges
+
+    def _point_centralities(self, graph, communities):
+        """Computes graph centrality of each node in the given communities (clusters) of the given graph.
+
+        This may be useful for selecting representative examples of a cluster. A sound that is central in his cluster may be
+        represent what a cluster contains the most.
+
+        Args:
+            graph (nx.Graph): NetworkX graph representation of sounds.
+            communities (List[List[Int]]): List storing Lists containing the Sound ids that are in each community (cluster).
+
+        Returns:
+            Dict{Int: Float}: Dict containing the community centrality value for each sound 
+                ({<sound_id>: <community_centrality>}).
+        """
+        # 
+        subgraphs = [graph.subgraph(community) for community in communities]
+        communities_centralities = [nx.algorithms.centrality.degree_centrality(subgraph) for subgraph in subgraphs]
+
+        # merge and normalize in each community
+        node_community_centralities = {k: v/max(d.values()) for d in communities_centralities for k, v in d.items()}
+
+        return node_community_centralities
+    
+    def _save_results_to_file(self, query_params, features, graph_json, sound_ids, modularity, 
+                              num_communities, ratio_intra_community_edges, ami, ss, ci, communities):
+        """Saves a json file to disk containing the clustering results information listed below.
+
+        This is used when developing the clustering method. The results and the evaluation metrics are made accessible 
+        for post-analysis.
+        
+        Args:
+            query_params (str): string representing the query parameters submited by the user to the search engine.
+            features (str): name of the features used for clustering. 
+            graph_json: (dict) NetworkX graph representation of sounds data in node-link format that is suitable for JSON 
+                serialization.
+            sound_ids (List[Int]): list of the sound ids.
+            modularity (float): modularity of the graph partition.
+            num_communities (Int): number of communities (clusters).
+            ratio_intra_community_edges (List[Float]): intra-community edges ratio.
+            ami (Numpy.float): Average Mutual Information score.
+            ss (Numpy.float): Silhouette Coefficient score.
+            ci (Numpy.float): Calinski and Harabaz Index score.
+            communities (List[List[Int]]): List storing Lists containing the Sound ids that are in each community (cluster).
+        """
+        if clust_settings.SAVE_RESULTS_FOLDER:
+            result = {
+                'query_params' : query_params,
+                'sound_ids': sound_ids,
+                'num_clusters': num_communities,
+                'graph': graph_json,
+                'features': features,
+                'modularity': modularity,
+                'ratio_intra_community_edges': ratio_intra_community_edges,
+                'average_mutual_information': ami,
+                'silouhette_coeff': ss,
+                'calinski_harabaz_score': ci,
+                'communities': communities
+            }
+            json.dump(result, open('{}/{}.json'.format(clust_settings.SAVE_RESULTS_FOLDER, query_params[0]), 'w'))
+
+    def create_knn_graph(self, sound_ids_list, features=clust_settings.DEFAULT_FEATURES):
+        """Creates a K-Nearest Neighbors Graph representation of the given sounds.
+
+        Args:
+            sound_ids_list (List[str]): list of sound ids.
+            features (str): name of the features to be used for nearest neighbors computation. 
+                Available features are listed in the clustering settings file.
+
+        Returns:
+            (nx.Graph): NetworkX graph representation of sounds.
+        """
+        # Create k nearest neighbors graph        
+        graph = nx.Graph()
+        graph.add_nodes_from(sound_ids_list)
+        k = int(np.ceil(np.log2(len(sound_ids_list))))
+
+        for sound_id in sound_ids_list:
+            try:
+                nearest_neighbors = self.gaia.search_nearest_neighbors(sound_id, k, sound_ids_list, features=features)
+                # edges += [(sound_id, i[0]) for i in nearest_neighbors if i[1]<20]
+                graph.add_edges_from([(sound_id, i[0]) for i in nearest_neighbors if i[1]<20])
+                # graph.add_weighted_edges_from([(sound_id, i[0], 1/i[1]) for i in nearest_neighbors if i[1]<10])
+            except ValueError:  # node does not exist in Gaia dataset
+                graph.remove_node(sound_id)
+
+        # Remove isolated nodes
+        graph.remove_nodes_from(list(nx.isolates(graph)))
+
+        return graph
+
+    def create_common_nn_graph(self, sound_ids_list, features=clust_settings.DEFAULT_FEATURES):
+        """Creates a Common Nearest Neighbors Graph representation of the given sounds.
+
+        Args:
+            sound_ids_list (List[str]): list of sound ids.
+            features (str): name of the features to be used for nearest neighbors computation. 
+                Available features are listed in the clustering settings file.
+
+        Returns:
+            (nx.Graph): NetworkX graph representation of sounds.
+        """
+        # first create a knn graph
+        knn_graph = self.create_knn_graph(sound_ids_list, features=features)
+
+        # create the common nn graph
+        graph = nx.Graph()
+        graph.add_nodes_from(knn_graph.nodes)
+
+        for i, node_i in enumerate(knn_graph.nodes):
+            for j, node_j in enumerate(knn_graph.nodes):
+                if j > i:
+                    num_common_neighbors = len(set(knn_graph.neighbors(node_i)).intersection(knn_graph.neighbors(node_j)))
+                    if num_common_neighbors > 0:
+                        graph.add_edge(node_i, node_j, weight=num_common_neighbors)
+
+        # keep only k most weighted edges
+        k = int(np.ceil(np.log2(len(graph.nodes))))
+        for node in graph.nodes:
+            ordered_neighbors = sorted(list(graph[node].iteritems()), key=lambda x: x[1]['weight'], reverse=True)
+            try:
+                neighbors_to_remove = zip(*ordered_neighbors[k:])[0]
+                graph.remove_edges_from(zip([node]*len(neighbors_to_remove), neighbors_to_remove))
+            except IndexError:
+                pass
+
+        # Remove isolated nodes
+        graph.remove_nodes_from(list(nx.isolates(graph)))
+
+        return graph
+
+    def cluster_graph(self, graph):
+        """Applies community detection in the given graph.
+
+        Uses the Louvain method to extract communities from the given graph.
+
+        Args:
+            graph (nx.Graph): NetworkX graph representation of sounds.
+
+        Returns:
+            Tuple(Dict{Int: Int}, int, List[List[Int]], float): 4-element tuple containing the clustering classes for each sound 
+                {<sound_id>: <class_idx>}, the number of communities (clusters), the sound ids in the communities and
+                the modularity of the graph partition.
+        
+        """ 
+        # Community detection in the graph
+        classes = com.best_partition(graph)
+        num_communities = max(classes.values()) + 1
+        communities = [[key for key, value in classes.iteritems() if value==i] for i in range(num_communities)]
+
+        # overall quality (modularity of the partition)
+        modularity = com.modularity(classes, graph)
+
+        return classes, num_communities, communities, modularity
+
+    def cluster_graph_overlap(sefl, graph, k=5):
+        """Applies overlapping community detection in the given graph.
+
+        Uses the percolation method for finding the k-clique communities in the given graph.
+        This method returns 4 elements to follow the same structure as cluster_graph().
+        However the modularity of an overlapping partition cannot be defined, we return None instead.
+
+        Args:
+            graph (nx.Graph): NetworkX graph representation of sounds.
+
+        Returns:
+            Tuple(Dict{Int: Int}, int, List[List[Int]], None): 4-element tuple containing the clustering classes for each sound 
+                {<sound_id>: <class_idx>}, the number of communities (clusters), the sound ids in the communities and
+                None.
+        """ 
+        communities = [list(community) for community in k_clique_communities(graph, k)]
+        # communities = [list(community) for community in greedy_modularity_communities(graph)]
+        greedy_modularity_communities
+        num_communities = len(communities)
+        classes = {sound_id: cluster_id for cluster_id, cluster in enumerate(communities) for sound_id in cluster}
+
+        return  classes, num_communities, communities, None
+
+    def remove_lowest_quality_cluster(self, graph, classes, communities, ratio_intra_community_edges):
+        """Removes the lowest quality cluster in the given graph.
+
+        Discards the cluster that has the lowest ratio of the number of intra-community edges. Removes the related values 
+        of the removed cluster from the given clustering information.
+
+        Args:
+            graph (nx.Graph): NetworkX graph representation of sounds.
+            classes (Dict{Int: Int}): clustering classes for each sound {<sound_id>: <class_idx>}.
+            communities (List[List[Int]]): List storing Lists containing the Sound ids that are in each community (cluster).
+            ratio_intra_community_edges (List[Float]): intra-community edges ratio.
+
+        Returns:
+            Tuple(nx.Graph, Dict{Int: Int}, List[List[Int]], List[float]): 4-element tuple containing the graph representation 
+            of the sounds, the clustering classes for each sound {<sound_id>: <class_idx>}, the sound ids in the communities 
+            and the ratio of intra-community edges in each cluster.
+        """
+        # if two clusters or less, we do not remove any
+        if len(communities) <= 2:
+            return graph, classes, communities, ratio_intra_community_edges
+        min_ratio_idx = np.argmin(ratio_intra_community_edges)
+        sounds_to_remove = communities[min_ratio_idx]
+        graph.remove_nodes_from(sounds_to_remove)
+        del communities[min_ratio_idx]
+        for snd in sounds_to_remove:
+            del classes[snd]
+        del ratio_intra_community_edges[min_ratio_idx]
+        for idx in range(min_ratio_idx, max(classes.values())):
+            for snd in communities[idx]:
+                classes[snd] -= 1
+        return graph, classes, communities, ratio_intra_community_edges
+
+    def cluster_points(self, query_params, features, sound_ids):
+        """Applies clustering on the requested sounds using the given features name.
+
+        Args:
+            query_params (str): string representing the query parameters submited by the user to the search engine.
+            features (str): name of the features used for clustering the sounds.
+            sound_ids (str): string containing comma-separated sound ids.
+        
+        Returns:
+            Dict: contains the resulting clustering classes and the graph in node-link format suitable for JSON serialization.
+        """
+        start_time = time()
+        sound_ids_list = [str(fs_id) for fs_id in sound_ids.split(',')]
+        logger.info('Request clustering of {} points: {} ... from the query "{}"'
+                .format(len(sound_ids_list), ', '.join(sound_ids_list[:20]), json.dumps(query_params)))
+
+        graph = self.create_knn_graph(sound_ids_list, features=features)
+        # graph = self.create_common_nn_graph(sound_ids_list, features=features)
+
+        if len(graph.nodes) == 0:  # the graph does not contain any node
+            return {'error': False, 'result': None, 'graph': None}
+
+        classes, num_communities, communities, modularity = self.cluster_graph(graph)
+        # classes, num_communities, communities, modularity = self.cluster_graph_overlap(graph)
+        ratio_intra_community_edges = self._ratio_intra_community_edges(graph, communities)
+
+        # graph, classes, communities, ratio_intra_community_edges = self.remove_lowest_quality_cluster(
+        #         graph, classes, communities, ratio_intra_community_edges)
+
+        node_community_centralities = self._point_centralities(graph, communities)
+
+        # Add cluster and centralities info to graph
+        nx.set_node_attributes(graph, classes, 'group')
+        nx.set_node_attributes(graph, node_community_centralities, 'group_centrality')
+
+        # Evaluation metrics vs reference features
+        ami, ss, ci = self._evaluation_metrics(classes)
+
+        end_time = time()
+        logger.info('Clustering done! It took {} seconds. '
+                    'Modularity: {}, '
+                    'Average ratio_intra_community_edges: {}, '
+                    'Average Mutual Information with reference: {}, '
+                    'Silouhette Coefficient with reference: {}, '
+                    'Calinski Index with reference: {}, '
+                    'Davies Index with reference: {}'
+                    .format(end_time-start_time, modularity, np.mean(ratio_intra_community_edges), ami, ss, ci, None))
+
+        # Export graph as json
+        graph_json = json_graph.node_link_data(graph)
+
+        # self._save_results_to_file(query_params, features, graph_json, sound_ids, modularity, 
+        #                            num_communities, ratio_intra_community_edges, ami, ss, ci, communities)
+
+        return {'error': False, 'result': communities, 'graph': graph_json}
+
+    def k_nearest_neighbors(self, sound_id, k):
+        """Performs a K-Nearest Neighbors search on the sound given as input.
+
+        This is currently not used, but could be useful for instance for the get similar sounds feature.
+
+        Args: 
+            sound_id (str): Sound id as query.
+            k (str): number of nearest neighbors to get.
+
+        Returns:
+            str: string containing the comma-separated ids of the nearest neighbors sounds.
+        """
+        logger.info('Request k nearest neighbors of point {}'.format(sound_id))
+        results = self.gaia.search_nearest_neighbors(sound_id, int(k))
+        return json.dumps(results)

--- a/clustering/clustering_settings.example.py
+++ b/clustering/clustering_settings.example.py
@@ -1,0 +1,42 @@
+# Directory where the Gaia dataset index files are located.
+INDEX_DIR = '/home/xavierfav/Documents/dev/search-result-clustering/'
+
+# Configuration of the features used for clustering or evaluation.
+# We define here for each features the Gaia dataset index file, the descriptor name within the dataset 
+# and the metric used for similarity computation.
+# The minimum requirement is to have one available set of features and set it as the default features
+# used for clustering (see variable bellow).
+AVAILABLE_FEATURES = {
+    # AudioSet Features (feature vector of the frame of max energy)
+    'AUDIOSET_FEATURES': {
+        'DATASET_FILE': 'FS_AS_embeddings_mean_max_min_nrg_normalized',
+        'GAIA_DESCRIPTOR_NAMES': 'AS_embeddings_ppc_max_energy',
+        'GAIA_METRIC': 'euclidean'
+    },
+    # tag-based features used as reference features (Bag of Words - LDA)
+    'TAG_DERIVED_FEATURES': None,
+}
+
+# Default features used for clustering
+DEFAULT_FEATURES = 'AUDIOSET_FEATURES'
+
+# Key of AVAILABLE_FEATURES used for evaluating the clustering results
+# Typically tag-derived features
+REFERENCE_FEATURES = None
+
+# Maximum number of results to cluster
+MAX_RESULTS_FOR_CLUSTERING = 1000
+
+# Cache settings
+# One day timeout for keeping clustering results. The cache timer is reset when the clustering is 
+# requested so that popular queries that are performed once a day minimum will always stay in cache
+# and won't be recomputed.
+CLUSTERING_CACHE_TIME = 24*60*60*1
+# One minute timeout for keeping the pending state. When a clustering is being performed async in a 
+# Celery worker, we consider the clustering as pending for only 1 minute. This may be useful if a 
+# worker task got stuck. There should be a settings in celery to stop a worker task if it is running 
+# for too long.
+CLUSTERING_PENDING_CACHE_TIME = 60*1
+
+# Folder for saving the clustering results with evaluation (dev/debug/research purpose)
+SAVE_RESULTS_FOLDER = None

--- a/clustering/gaia_wrapper.py
+++ b/clustering/gaia_wrapper.py
@@ -1,0 +1,113 @@
+import logging
+import os
+import sys
+import time
+import yaml
+from django.conf import settings
+
+from gaia2 import DataSet, View, DistanceFunctionFactory
+
+import clustering_settings as clust_settings
+
+
+logger = logging.getLogger('clustering')
+
+
+class GaiaWrapperClustering:
+    """Gaia wrapper for the clustering engine.
+
+    This class contains helper methods to interface with Gaia.
+    When creating the instance object, Gaia datasets corresponding to the features configured in the clustering 
+    settings file will be loaded.
+    """
+    def __init__(self):
+        self.index_path = clust_settings.INDEX_DIR
+        self.__load_datasets()
+
+    def __get_dataset_path(self, ds_name):
+        return os.path.join(clust_settings.INDEX_DIR, ds_name + '.db')
+
+    def __load_dataset(self, features, gaia_index, gaia_descriptor_names, gaia_metric):
+        """Loads a Gaia dataset, view and metric for a specific feature and config.
+        
+        Args: 
+            features (str): name of the features to be used for clustering. 
+                Available features are listed in the clustering settings file
+            gaia_index (str): Name of the Gaia dataset index file.
+            gaia_descriptor_names (str or List[str]): Name(s) of the descriptor field to use within the Gaia dataset. 
+            gaia_metric (str): Name of the metric to use for nearest neighbors search.
+        """
+        gaia_dataset = DataSet()
+        gaia_dataset.load(self.__get_dataset_path(gaia_index))
+        gaia_view = View(gaia_dataset)
+        gaia_metric = DistanceFunctionFactory.create(gaia_metric, gaia_dataset.layout(), 
+            {'descriptorNames': gaia_descriptor_names})
+
+        setattr(self, '{}_dataset'.format(features), gaia_dataset)
+        setattr(self, '{}_view'.format(features), gaia_view)
+        setattr(self, '{}_metric'.format(features), gaia_metric)
+
+    def __load_datasets(self):
+        """Loads all the Gaia datasets corresponding to the features that are configured in the clustering settings.
+        """
+        logger.info('Loading datasets for each features used in clustering')
+        for feature_string, feature_config in clust_settings.AVAILABLE_FEATURES.items():
+            if feature_config:
+                self.__load_dataset(feature_string, feature_config['DATASET_FILE'], 
+                                    feature_config['GAIA_DESCRIPTOR_NAMES'], feature_config['GAIA_METRIC'])
+                logger.info('{} dataset loaded'.format(feature_string))
+
+    def search_nearest_neighbors(self, sound_id, k, in_sound_ids=[], features=clust_settings.DEFAULT_FEATURES):
+        """Find the k nearest neighbours of a target sound within a given subset of sounds and set of features
+
+        Args:
+            sound_id (str): id of the sound query.
+            k (int): number of nearest neighbors to retrieve.
+            in_sound_ids (List[str]): ids of the subset of sounds within the one we perform the Nearest Neighbors search.
+            features (str): name of the features to be used for nearest neighbors computation. 
+                Available features are listed in the clustering settings file
+
+        Returns:
+            List[str]: ids of the retrieved sounds.
+        """
+        if in_sound_ids:
+            filter = 'WHERE point.id IN ("' + '", "'.join(in_sound_ids) + '")'
+        else:
+            filter = None
+        try:
+            gaia_view = getattr(self, '{}_view'.format(features))
+            gaia_metric = getattr(self, '{}_metric'.format(features))
+            nearest_neighbors = gaia_view.nnSearch(sound_id, gaia_metric, filter).get(k)[1:]
+
+            if not nearest_neighbors:
+                logger.info("No nearest neighbors found for point with id '{}'".format(sound_id))
+
+            return nearest_neighbors
+
+        # probably be more specific here...
+        except Exception as e:
+            logger.info(e)
+            return []
+
+    def return_sound_reference_features(self, sound_ids):
+        """Returns the reference features for the given sounds that are used for evaluating the clustering performance.
+
+        The reference features defined in the clustering settings file.
+        They tipically consists of features derived from the sounds' tags.
+
+        Args:
+            sound_ids (List[str]): list containing the ids of the sounds we want the features.
+
+        Returns:
+            List[List[Float]]: list containing the reference features of the requested sounds.
+        """
+        reference_features = []
+        gaia_dataset = getattr(self, '{}_dataset'.format(clust_settings.REFERENCE_FEATURES))
+        gaia_descriptor_names = clust_settings.AVAILABLE_FEATURES[clust_settings.REFERENCE_FEATURES]['GAIA_DESCRIPTOR_NAMES']
+        for sound_id in sound_ids:
+            try:
+                reference_features.append(gaia_dataset.point(sound_id).value(gaia_descriptor_names))
+            except Exception as e:
+                logger.info(e)
+                reference_features.append(None)
+        return reference_features

--- a/clustering/interface.py
+++ b/clustering/interface.py
@@ -1,0 +1,89 @@
+import copy
+import traceback, logging
+from django.conf import settings
+from django.core.cache import cache
+from utils.encryption import create_hash
+from utils.search.search_general import search_prepare_query, perform_solr_query, \
+    search_prepare_parameters
+
+from tasks import cluster_sounds
+from clustering_settings import MAX_RESULTS_FOR_CLUSTERING, CLUSTERING_CACHE_TIME, DEFAULT_FEATURES
+from . import CLUSTERING_RESULT_STATUS_PENDING, CLUSTERING_RESULT_STATUS_FAILED
+
+
+def get_sound_ids_from_solr_query(query_params):
+    """Performs Solr query and returns results as a list of sound ids.
+
+    This method performs a single query to Solr with a very big page size argument so all results are 
+    returned at once. A very big page size will make the clustering take a lot of time to be performed.
+    The number of results to retrieve is defined in the clustering settings file as MAX_RESULTS_FOR_CLUSTERING.
+
+    Args:
+        query_params (dict): contains the query parameters to replicate the user query.
+    
+    Returns
+        List[int]: list containing the ids of the retrieved sounds.
+    """
+    current_page = 1
+    query_params.update({'sounds_per_page': MAX_RESULTS_FOR_CLUSTERING})
+    query = search_prepare_query(**query_params)
+    non_grouped_number_of_results, facets, paginator, page, docs = perform_solr_query(query, current_page)
+    resultids = [d.get("id") for d in docs]
+    return resultids
+
+
+def cluster_sound_results(request, features=DEFAULT_FEATURES):
+    """Performs clustering on the search results of the given search request with the requested features.
+
+    This is the main entry to the clustering method. It will either get the clustering results from cache, 
+    or compute it (and store it in cache). When needed, the clustering will be performed async by a celery 
+    worker. 
+
+    Args:
+        request (HttpRequest): request associated with the search query submited by the user.
+        features (str): name of the features to be used for clustering. The available features are defined in the 
+            clustering settings file.
+
+    Returns:
+        Dict: contains either the state of the clustering ('pending' or 'failed') or the resulting clustering classes 
+            and the graph in node-link format suitable for JSON serialization.
+    """
+    query_params, _, _ = search_prepare_parameters(request)
+
+    cache_key = 'cluster-results-{search_query}-{filter_query}-{sort}-{tag_weight}-{username_weight}-{id_weight}-' \
+                '{description_weight}-{pack_tokenized_weight}-{original_filename_weight}-{grouping}'.format(**query_params)
+
+    cache_key += '-{}'.format(features)
+    cache_key = cache_key.replace(' ', '')
+
+    cache_key_hashed = hash_cache_key(cache_key)
+
+    # check if result is in cache
+    result = cache.get(cache_key_hashed)
+
+    if result and result not in (CLUSTERING_RESULT_STATUS_PENDING, CLUSTERING_RESULT_STATUS_FAILED):
+        # reset the value in cache so that it presists
+        cache.set(cache_key_hashed, result, CLUSTERING_CACHE_TIME)
+        result.update({'finished': True, 'error': False})
+
+        return result
+
+    elif result == CLUSTERING_RESULT_STATUS_PENDING:
+        return {'finished': False, 'error': False}
+
+    elif result == CLUSTERING_RESULT_STATUS_FAILED:
+        return {'finished': False, 'error': True}
+
+    else:
+        # if not in cache, query solr and perform clustering
+        sound_ids = get_sound_ids_from_solr_query(query_params)
+        sound_ids_string = ','.join([str(sound_id) for sound_id in sound_ids])
+
+        # launch clustering with celery async task
+        cluster_sounds.delay(cache_key_hashed, sound_ids_string, features)
+
+        return {'finished': False, 'error': False}
+
+
+def hash_cache_key(key):
+    return create_hash(key, add_secret=False, limit=32)

--- a/clustering/tasks.py
+++ b/clustering/tasks.py
@@ -1,0 +1,25 @@
+from django.core.cache import cache
+from celery.decorators import task
+
+from clustering_settings import CLUSTERING_CACHE_TIME, CLUSTERING_PENDING_CACHE_TIME
+from . import CLUSTERING_RESULT_STATUS_PENDING, CLUSTERING_RESULT_STATUS_FAILED
+
+
+@task(name="cluster_sounds")
+def cluster_sounds(cache_key_hashed, sound_ids, features):
+    # this import would be better outside the function, but did not work
+    from . import engine
+
+    # store pending state in cache
+    cache.set(cache_key_hashed, CLUSTERING_RESULT_STATUS_PENDING, CLUSTERING_PENDING_CACHE_TIME)
+
+    try:
+        # perform clustering
+        result = engine.cluster_points(cache_key_hashed, features, sound_ids)
+
+        # store result in cache
+        cache.set(cache_key_hashed, result, CLUSTERING_CACHE_TIME)
+
+    except Exception as e:  
+        # delete pending state if exception raised during clustering
+        cache.set(cache_key_hashed, CLUSTERING_RESULT_STATUS_FAILED, CLUSTERING_PENDING_CACHE_TIME)

--- a/freesound/__init__.py
+++ b/freesound/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ['celery_app']

--- a/freesound/celery.py
+++ b/freesound/celery.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+import os
+from celery import Celery
+from django.conf import settings
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'freesound.settings')
+
+app = Celery('freesound')
+
+# Using a string here means the worker don't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load tasks from only the clustering app.
+app.autodiscover_tasks('clustering', related_name='tasks')
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     'bookmarks',
     'forum',
     'search',
+    'clustering',
     'django_extensions',
     'tickets',
     'gunicorn',
@@ -568,6 +569,18 @@ TEMPLATES = [
 # parameter for the url of all.css and freesound.js files, so me make sure client browsers update these
 # files when we do a deploy (the url changes)
 LAST_RESTART_DATE = datetime.datetime.now().strftime("%d%m")
+
+
+# Search Result Clustering Environment variables
+# '1' indicates that a process is running as a celery worker.
+# We get it from environment variable to avoid the need of a specific settings file for celery workers.
+# We enable the imports of clustering dependencies only in celery workers.
+IS_CELERY_WORKER = os.getenv('ENV_CELERY_WORKER', None) == "1"
+
+# Determines whether to use or not the clustering feature.
+# Set to False by default (to be overwritten in local_settings.py)
+# When activated, Enables to do js calls & html clustering facets rendering
+ENABLE_SEARCH_RESULTS_CLUSTERING = False
 
 
 # -------------------------------------------------------------------------------

--- a/freesound/urls.py
+++ b/freesound/urls.py
@@ -104,6 +104,9 @@ urlpatterns = [
 
     url(r'^contact/', support.views.contact, name="contact"),
     url(r'^search/$', search.views.search, name='sounds-search'),
+    url(r'^cluster/$', search.views.clustering_facet, name='clustering-facet'),
+    url(r'^clustering/$', search.views.cluster_visualisation, name='cluster-visualisation'),
+    url(r'^clustered_graph/$', search.views.clustered_graph, name='return-clustered-graph'),
 
     url(r'', include('ratings.urls')),
     url(r'^comments/', include('comments.urls')),

--- a/media/js/webAudioApiForDesigners.js
+++ b/media/js/webAudioApiForDesigners.js
@@ -1,0 +1,219 @@
+// Browser detection required (guess which browsers are at faul =P)
+var isSafari = navigator.userAgent.indexOf("Safari") != -1;
+var isIe = navigator.userAgent.indexOf("MSIE") != -1;
+var isFireFox = navigator.userAgent.indexOf("Firefox") != -1; // not this one ^^
+
+// We need to check if this system has the webAudioContext defined.  
+// As of right now chrome will, but firefox won't because they just started implimenting
+if (typeof(webkitAudioContext) == "undefined" && typeof(mozAudioContext) == "undefined") {
+  window.webkitAudioContext = function(){throw "Web Audio API not supported in this browser";};
+}
+
+function initializeNewWebAudioContext() {
+  return initializeNewWebAudioContext(false);
+}
+
+// You can initialize with the parameter true to actually enable the audio fallback on
+// IE.  This is not recommended and is subject to change if a later version of this framework is written
+function initializeNewWebAudioContext(enableIe) {
+  var context; // this is our web audio context, our way of
+               // controlling and keeping track all of our sounds.  
+  try {
+	if (typeof(mozAudioContext) != "undefined") {
+		context = new mozAudioContext();
+    }
+	else{
+		context = new webkitAudioContext();
+    }
+  }
+  catch(e) {
+    // alert('Web Audio API is not supported in this browser.  HTML 5 Audio Elements will be used instead.');
+    if (isIe && !enableIe){
+      disableSoundFallback();
+    }
+      
+    context = new fallbackAudioContext();
+  }
+  return context;
+}
+
+
+
+// this is useful for IE...
+function disableSoundFallback(){
+  if(isIe){
+    alert("Relevant audio is being disabled for your browser, probably because your browser (IE) is not capable of playing back sound at a reasonable latency.  \n\nEven though you are using Microsoft Windows as an Operating system, you are still able to access the web the way the rest of the world can by downloading an alternative browser.  \n\nConsider web searching for:  Opera, Firefox or Chrome.");
+  }
+  
+  fallbackAudioContext.prototype.playSound = function(strBufferName){return;}
+}
+
+// this is a very strange function which asks that you name
+// the buffer that you plan to store the sound data in...  
+// It's almost meta, but still javascript
+// 
+// The function is complicated by Safari which is a default browser on an OS that
+// has legitamate power, yet doesn't support .ogg for audio.  
+webkitAudioContext.prototype.loadSound = function (url, strNameOfSoundBufferVariable) {
+  var request;
+  if (url instanceof Array){
+    url = webkitAudioContext.orderUrl(url);
+    this.prepareRequest(url[0], strNameOfSoundBufferVariable);
+    for (var i = 1; i < url.length; i++){
+      this.prepareFallbackRequestForSafari(url[i], strNameOfSoundBufferVariable);
+    }
+  }
+  else{
+    this.prepareRequest(url, strNameOfSoundBufferVariable);
+  }
+}
+
+
+// private
+// This method ensures that the .ogg is set to the primary audioContext.buffers[] slot and 
+// not the audioContext.fallbackBuffers[] slot
+webkitAudioContext.orderUrl = function (url) {
+  if (url[0].indexOf(".mp3") == -1){
+    return url;
+  }
+  return [url[1], url[0]];  // reverse order of url.  
+}
+
+
+// Private, plz don't call this directly as that it might change over time
+webkitAudioContext.prototype.prepareRequest = function(url, strNameOfSoundBufferVariable) {
+  var context = this;
+  var request = new XMLHttpRequest();
+  request.open('GET', url, true);
+  request.responseType = 'arraybuffer';
+  
+  // Decode asynchronously
+  request.onload = function() {
+    context.decodeAudioData(request.response, function(buffer) {
+      context.buffers[strNameOfSoundBufferVariable] = buffer; // when finished, put the PCM audio data in the buffer we named
+    }, onError);
+  }
+  request.send();
+}
+
+// Private... Safari...
+// the more I right code for this, the more I hate corporations...
+webkitAudioContext.prototype.prepareFallbackRequestForSafari = function(url, strNameOfSoundBufferVariable) {
+  var context = this;
+  var request = new XMLHttpRequest();
+  request.open('GET', url, true);
+  request.responseType = 'arraybuffer';
+  
+  // Decode asynchronously
+  request.onload = function() {
+    context.decodeAudioData(request.response, function(buffer) {
+      context.fallbackBuffers[strNameOfSoundBufferVariable] = buffer; // when finished, put the PCM audio data in the buffer we named
+    }, onError);
+  }
+  request.send();
+}
+
+
+// I almost want to mark this method as private because it's so rediculous that Apple would
+// try to kill .ogg format.  Their decision is reckless and harmful to the web.  
+webkitAudioContext.prototype.loadFallbackSound = function (url, strNameOfSoundBufferVariable) {
+  var context = this;
+  var request = new XMLHttpRequest();
+  request.open('GET', url, true);
+  request.responseType = 'arraybuffer';
+
+  // Decode asynchronously
+  request.onload = function() {
+    context.decodeAudioData(request.response, function(buffer) {
+      context.fallbackBuffers[strNameOfSoundBufferVariable] = buffer;
+    }, onError);
+    
+  }
+  request.send();
+}
+
+
+
+function onError() {
+  alert("something suboptimal happened while attempting to decode some audioData.  \nYou're probably using Safari, and Apple has some kind of a shady plan going on to stop the .ogg format from easing the development burden on the web.  Perhaps setting a fallback audio file (an mp3) will function properly after this first attempt to decode audio will work.");
+}
+
+webkitAudioContext.prototype.playSound = function(strBuffer) {
+  var context = this;
+  buffer = this.buffers[strBuffer];            // get the audio buffer by it's name
+  if (navigator.vendor.indexOf("Apple") != -1){
+    buffer = this.fallbackBuffers[strBuffer];  // use the fallbackBuffer if the user is trying to support Safari
+  }
+  
+  var source = context.createBufferSource(); // creates a sound source
+  source.buffer = buffer;                    // Give the Source some PCM data to be played
+  source.connect(context.destination);       // connect the audio source the speakers
+  source.start();                          // play the audio source zero seconds from now
+}
+
+
+
+// We need a place to store our audio buffers.  
+// May as well pin them here, directly to the context
+webkitAudioContext.prototype.buffers = {};
+
+// Specially for Safari, use this workaround to create a good experience for 
+// users who wound up using Safari today.  
+webkitAudioContext.prototype.fallbackBuffers = {};
+
+// The fallback context is used on browsers that don't use webkitAudioContext.
+// In the case of a fallback, html5 audio will be used instead
+function fallbackAudioContext() {
+  this.buffers = {};
+}
+
+function fallbackAudioEntity(url) {
+  this.audioElement = new Audio(url);  // Place the audio element here
+  //this.audioElement = document.createElement('audio');   // oh my god... Safari 5 doesn't even support Audio tags in the first place...
+  //this.audioElement.setAttribute('src', url);
+  
+  this.tracks = {};  // .play() multiple audio elements simultaniously in this tracks collection.  It's gc friendly
+  this.audioBufferIndex = 0;  // these help us keep track of the new Audio() elements we create so
+  this.maxSoundsAtOnce = 32;  // they garbage collect a tiny bit easier
+}
+
+fallbackAudioEntity.prototype.playNew = function() {
+  var i = this.audioBufferIndex;
+  
+  if (typeof(this.tracks[i]) != 'undefined' && !isFireFox)
+    this.tracks[i].src = '';  // minimize memory usage... and smoothness too???
+  this.tracks[i] = this.audioElement.cloneNode(true);
+  if (isIe) { this.tracks[i].src = 'audio/beep.mp3'; } //  lol, IE9s performance is ridiculous, what a waste of time
+  this.tracks[i].play();
+  
+  // this stuff is done to prevent "memory leaking" in browsers, which causes a 
+  // stall when it does it's garbage collection after spawning off too many Audio objects
+  this.audioBufferIndex++;
+  if (this.audioBufferIndex >= this.maxSoundsAtOnce)
+    this.audioBufferIndex = 0;
+
+  return this.tracks[i];
+}
+
+fallbackAudioContext.prototype.loadSound = function(url, strNameOfSoundBufferVariable) {
+  if (url instanceof Array){
+    url = webkitAudioContext.orderUrl(url);
+    if (isSafari || isIe){
+      url[0] = url[1];  // make the mp3 the one chosen... since this isn't firefox...
+    }
+    
+    this.buffers[strNameOfSoundBufferVariable] = new fallbackAudioEntity(url[0]);
+  }
+  else{
+    this.buffers[strNameOfSoundBufferVariable] = new fallbackAudioEntity(url);
+  }
+}
+
+// this was needed due to Safari.  
+fallbackAudioContext.prototype.loadFallbackSound = function(url, strNameOfSoundBufferVariable) {
+  return;
+}
+
+fallbackAudioContext.prototype.playSound = function(strBufferName){
+  return this.buffers[strBufferName].playNew();
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,6 @@ xlrd==1.1.0
 numpy==1.9.0
 scikits.audiolab==0.11.0
 django-silk==3.0.2
+celery==4.1.1
+redis==3.2.0
+django-redis==4.10.0

--- a/requirements_clustering.txt
+++ b/requirements_clustering.txt
@@ -1,0 +1,5 @@
+numpy==1.14.1
+networkx==2.2
+python-louvain==0.13
+scikit-learn==0.19.1
+scipy==0.18.1

--- a/search/tests.py
+++ b/search/tests.py
@@ -23,6 +23,7 @@ from django.urls import reverse
 from sounds.models import Sound
 from search.views import search_process_filter
 from utils.search.solr import SolrResponseInterpreter, SolrResponseInterpreterPaginator
+from utils.test_helpers import create_user_and_sounds
 import mock
 import copy
 
@@ -81,6 +82,70 @@ solr_select_returned_data = {
         'status': 0
     }
 }
+
+
+def return_successful_clustering_results(sound_id_1, sound_id_2, sound_id_3, sound_id_4):
+    return {
+        'graph': {
+            'directed': False,
+            'graph': {
+
+            },
+            'nodes': [
+                {
+                    'group_centrality': 0.5,
+                    'group': 0,
+                    'id': sound_id_1
+                },
+                {
+                    'group_centrality': 1,
+                    'group': 0,
+                    'id': sound_id_2
+                },
+                {
+                    'group_centrality': 0.5,
+                    'group': 1,
+                    'id': sound_id_3
+                },
+                {
+                    'group_centrality': 1,
+                    'group': 1,
+                    'id': sound_id_4
+                },
+            ],
+            'links': [
+                {
+                    'source': sound_id_1,
+                    'target': sound_id_2
+                },
+                {
+                    'source': sound_id_1,
+                    'target': sound_id_3
+                },
+                {
+                    'source': sound_id_3,
+                    'target': sound_id_4
+                },
+            ],
+            'multigraph': False
+        },
+        'finished': True,
+        'result': [
+            [
+                sound_id_1,
+                sound_id_2
+            ],
+            [
+                sound_id_3,
+                sound_id_4
+            ],
+        ],
+        'error':False
+    }
+
+pending_clustering_results = {'finished': False, 'error': False}
+
+failed_clustering_results = {'finished': False, 'error': True}
 
 
 class SearchPageTests(TestCase):
@@ -162,3 +227,48 @@ class SearchProcessFilter(TestCase):
 
 
 
+class SearchResultClustering(TestCase):
+
+    fixtures = ['licenses']
+
+    def setUp(self):
+        create_user_and_sounds(num_sounds=4, tags='tag1, tag2, tag3')
+        sound_ids = list(Sound.objects.values_list('id', flat=True))
+
+        self.successful_clustering_results = return_successful_clustering_results(*map(str, sound_ids))
+        self.pending_clustering_results = pending_clustering_results
+        self.failed_clustering_results = failed_clustering_results
+
+    @mock.patch('search.views.cluster_sound_results')
+    def test_successful_search_result_clustering_view(self, cluster_sound_results):
+        cluster_sound_results.return_value = self.successful_clustering_results
+        resp = self.client.get(reverse('clustering-facet'))
+
+        # 200 status code & use of clustering facets template
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, 'search/clustering_facet.html')
+
+        # check cluster's content
+        # 2 sounds per clusters
+        # 3 most used tags in the cluster 'tag1 tag2 tag3'
+        # context variable cluster_id_num_results: [(<cluster_id>, <num_sounds>, <tags>), ...]
+        self.assertEqual(resp.context['cluster_id_num_results'], 
+            [(0, 2, u'tag1 tag2 tag3'), (1, 2, u'tag1 tag2 tag3')])
+
+    @mock.patch('search.views.cluster_sound_results')
+    def test_pending_search_result_clustering_view(self, cluster_sound_results):
+        cluster_sound_results.return_value = self.pending_clustering_results
+        resp = self.client.get(reverse('clustering-facet'))
+
+        # 200 status code & JSON response content
+        self.assertEqual(resp.status_code, 200)
+        self.assertJSONEqual(resp.content, {'status': 'pending'})
+
+    @mock.patch('search.views.cluster_sound_results')
+    def test_failed_search_result_clustering_view(self, cluster_sound_results):
+        cluster_sound_results.return_value = self.failed_clustering_results
+        resp = self.client.get(reverse('clustering-facet'))
+
+        # 200 status code & JSON response content
+        self.assertEqual(resp.status_code, 200)
+        self.assertJSONEqual(resp.content, {'status': 'failed'})

--- a/search/views.py
+++ b/search/views.py
@@ -1,3 +1,4 @@
+
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -21,275 +22,77 @@
 import datetime
 import json
 import logging
+from collections import defaultdict
 
 import re
 from django.conf import settings
+from django.shortcuts import render, redirect, reverse
 from django.shortcuts import get_object_or_404
+from django.http import JsonResponse
 
-import forms
 import sounds
 import forum
-from utils.frontend_handling import render
+from utils.search.search_general import search_prepare_sort, search_process_filter, \
+    search_prepare_query, perform_solr_query, search_prepare_parameters, split_filter_query
 from utils.logging_filters import get_client_ip
 from utils.search.solr import Solr, SolrQuery, SolrResponseInterpreter, \
     SolrResponseInterpreterPaginator, SolrException
+from clustering.interface import cluster_sound_results
+from clustering.clustering_settings import DEFAULT_FEATURES
 
 logger = logging.getLogger("search")
 
 
-def search_prepare_sort(sort, options):
-    """ for ordering by rating order by rating, then by number of ratings """
-    if sort in [x[1] for x in options]:
-        if sort == "avg_rating desc":
-            sort = [sort, "num_ratings desc"]
-        elif  sort == "avg_rating asc":
-            sort = [sort, "num_ratings asc"]
-        else:
-            sort = [sort]
-    else:
-        sort = [forms.SEARCH_DEFAULT_SORT]
-    return sort
-
-
-def search_process_filter(filter_query):
-    # Process the filter to replace humnan-readable Audio Commons descriptor names for the dynamic field names used in
-    # Solr (e.g. ac_tonality -> ac_tonality_s, ac_tempo -> ac_tempo_i). The dynamic field names we define in Solr
-    # schema are '*_b' (for bool), '*_d' (for float), '*_i' (for integer) and '*_s' (for string). At indexing time
-    # we append these suffixes to the ac descirptor names so Solr can treat the types properly. Now we automatically
-    # append the suffices to the filter names so users do not need to deal with that.
-    for name, t in settings.AUDIOCOMMONS_INCLUDED_DESCRIPTOR_NAMES_TYPES:
-        filter_query = filter_query.replace('ac_{0}:'.format(name), 'ac_{0}{1}:'
-                                            .format(name, settings.SOLR_DYNAMIC_FIELDS_SUFFIX_MAP[t]))
-    return filter_query
-
-
-def search_prepare_query(search_query,
-                         filter_query,
-                         sort,
-                         current_page,
-                         sounds_per_page,
-                         id_weight=settings.DEFAULT_SEARCH_WEIGHTS['id'],
-                         tag_weight=settings.DEFAULT_SEARCH_WEIGHTS['tag'],
-                         description_weight=settings.DEFAULT_SEARCH_WEIGHTS['description'],
-                         username_weight=settings.DEFAULT_SEARCH_WEIGHTS['username'],
-                         pack_tokenized_weight=settings.DEFAULT_SEARCH_WEIGHTS['pack_tokenized'],
-                         original_filename_weight=settings.DEFAULT_SEARCH_WEIGHTS['original_filename'],
-                         grouping=False,
-                         include_facets=True,
-                         grouping_pack_limit=1,
-                         offset=None):
-    query = SolrQuery()
-
-    # Set field weights and scoring function
-    field_weights = []
-    if id_weight != 0:
-        field_weights.append(("id", id_weight))
-    if tag_weight != 0:
-        field_weights.append(("tag", tag_weight))
-    if description_weight != 0:
-        field_weights.append(("description", description_weight))
-    if username_weight != 0:
-        field_weights.append(("username", username_weight))
-    if pack_tokenized_weight != 0:
-        field_weights.append(("pack_tokenized", pack_tokenized_weight))
-    if original_filename_weight != 0:
-        field_weights.append(("original_filename", original_filename_weight))
-    query.set_dismax_query(search_query,
-                           query_fields=field_weights,)
-
-    # Set start and rows parameters (offset and size)
-    if not offset:
-        start = (current_page - 1) * sounds_per_page
-    else:
-        start = offset
-
-    # Process filter
-    filter_query = search_process_filter(filter_query)
-
-    # Set all options
-    query.set_query_options(start=start, rows=sounds_per_page, field_list=["id"], filter_query=filter_query, sort=sort)
-
-    # Specify query factes
-    if include_facets:
-        query.add_facet_fields("samplerate", "grouping_pack", "username", "tag", "bitrate", "bitdepth", "type", "channels", "license")
-        query.set_facet_options_default(limit=5, sort=True, mincount=1, count_missing=False)
-        query.set_facet_options("type", limit=len(sounds.models.Sound.SOUND_TYPE_CHOICES))
-        query.set_facet_options("tag", limit=30)
-        query.set_facet_options("username", limit=30)
-        query.set_facet_options("grouping_pack", limit=10)
-        query.set_facet_options("license", limit=10)
-
-    # Add groups
-    if grouping:
-        query.set_group_field(group_field="grouping_pack")
-        query.set_group_options(
-            group_func=None,
-            group_query=None,
-            group_rows=10,
-            group_start=0,
-            group_limit=grouping_pack_limit,  # This is the number of documents that will be returned for each group. By default only 1 is returned.
-            group_offset=0,
-            group_sort=None,
-            group_sort_ingroup=None,
-            group_format='grouped',
-            group_main=False,
-            group_num_groups=True,
-            group_cache_percent=0)
-    return query
-
-
-def perform_solr_query(q, current_page):
-    """
-    This util function performs the query to Solr and returns needed parameters to continue with the view.
-    The main reason to have this util function is to facilitate mocking in unit tests for this view.
-    """
-    solr = Solr(settings.SOLR_URL)
-    results = SolrResponseInterpreter(solr.select(unicode(q)))
-    paginator = SolrResponseInterpreterPaginator(results, settings.SOUNDS_PER_PAGE)
-    page = paginator.page(current_page)
-    return results.non_grouped_number_of_matches, results.facets, paginator, page, results.docs
-
-
 def search(request):
-    search_query = request.GET.get("q", "")
-    filter_query = request.GET.get("f", "")
-    filter_query_link_more_when_grouping_packs = filter_query.replace(' ','+')
+    query_params, advanced_search_params_dict, extra_vars = search_prepare_parameters(request)
 
-    # Generate array with information of filters
-    filter_query_split = []
-    if filter_query != "":
-        for filter_str in re.findall(r'[\w-]+:\"[^\"]+', filter_query):
-            valid_filter = True
-            filter_str = filter_str + '"'
-            filter_display = filter_str.replace('"', '')
-            filter_name = filter_str.split(":")[0]
-            if filter_name != "duration" and filter_name != "is_geotagged":
-                if filter_name == "grouping_pack":
-                    val = filter_display.split(":")[1]
-                    # If pack does not contain "_" then it's not a valid pack filter
-                    if "_" in val:
-                        filter_display = "pack:"+ val.split("_")[1]
-                    else:
-                        valid_filter = False
+    # get the url query params for later sending it to the clustering engine
+    url_query_params_string = request.META['QUERY_STRING']
 
-                if valid_filter:
-                    filter = {
-                        'name': filter_display,
-                        'remove_url': filter_query.replace(filter_str, ''),
-                    }
-                    filter_query_split.append(filter)
+    # get sound ids of the requested cluster when applying a clustering facet
+    # the list of ids is used to create a Solr query with filter by ids in search_prepare_query()
+    cluster_id = request.GET.get('cluster_id')
+    if cluster_id:
+        in_ids = _get_ids_in_cluster(request, cluster_id)
+    else:
+        in_ids = []
+    query_params.update({'in_ids': in_ids})
 
-    try:
-        current_page = int(request.GET.get("page", 1))
-    except ValueError:
-        current_page = 1
-    sort = request.GET.get("s", None)
-    sort_options = forms.SEARCH_SORT_OPTIONS_WEB
-    grouping = request.GET.get("g", "1")  # Group by default
-
-    # If the query is filtered by pack, do not collapse sounds of the same pack (makes no sense)
-    # If the query is through AJAX (for sources remix editing), do not collapse
-    if "pack" in filter_query or request.GET.get("ajax", "") == "1":
-        grouping = ""
-
-    # Set default values
-    id_weight = settings.DEFAULT_SEARCH_WEIGHTS['id']
-    tag_weight = settings.DEFAULT_SEARCH_WEIGHTS['tag']
-    description_weight = settings.DEFAULT_SEARCH_WEIGHTS['description']
-    username_weight = settings.DEFAULT_SEARCH_WEIGHTS['username']
-    pack_tokenized_weight = settings.DEFAULT_SEARCH_WEIGHTS['pack_tokenized']
-    original_filename_weight = settings.DEFAULT_SEARCH_WEIGHTS['original_filename']
-
-    # Parse advanced search options
-    advanced = request.GET.get("advanced", "")
-    advanced_search_params_dict = {}
-
-    # if advanced search
-    if advanced == "1":
-        a_tag = request.GET.get("a_tag", "")
-        a_filename = request.GET.get("a_filename", "")
-        a_description = request.GET.get("a_description", "")
-        a_packname = request.GET.get("a_packname", "")
-        a_soundid = request.GET.get("a_soundid", "")
-        a_username = request.GET.get("a_username", "")
-        advanced_search_params_dict.update({  # These are stored in a dict to facilitate logging and passing to template
-            'a_tag': a_tag,
-            'a_filename': a_filename,
-            'a_description': a_description,
-            'a_packname': a_packname,
-            'a_soundid': a_soundid,
-            'a_username': a_username,
-        })
-
-        # If none is selected use all (so other filter can be appleid)
-        if a_tag or a_filename or a_description or a_packname or a_soundid or a_username != "" :
-
-            # Initialize all weights to 0
-            id_weight = 0
-            tag_weight = 0
-            description_weight = 0
-            username_weight = 0
-            pack_tokenized_weight = 0
-            original_filename_weight = 0
-
-            # Set the weights of selected checkboxes
-            if a_soundid != "":
-                id_weight = settings.DEFAULT_SEARCH_WEIGHTS['id']
-            if a_tag != "":
-                tag_weight = settings.DEFAULT_SEARCH_WEIGHTS['tag']
-            if a_description != "":
-                description_weight = settings.DEFAULT_SEARCH_WEIGHTS['description']
-            if a_username != "":
-                username_weight = settings.DEFAULT_SEARCH_WEIGHTS['username']
-            if a_packname != "":
-                pack_tokenized_weight = settings.DEFAULT_SEARCH_WEIGHTS['pack_tokenized']
-            if a_filename != "":
-                original_filename_weight = settings.DEFAULT_SEARCH_WEIGHTS['original_filename']
-
-    sort = search_prepare_sort(sort, forms.SEARCH_SORT_OPTIONS_WEB)
-
-    logger.info(u'Search (%s)' % json.dumps({
-        'ip': get_client_ip(request),
-        'query': search_query,
-        'filter': filter_query,
-        'username': request.user.username,
-        'page': current_page,
-        'sort': sort[0],
-        'group_by_pack': grouping,
-        'advanced': json.dumps(advanced_search_params_dict) if advanced == "1" else ""
-    }))
-
-    query = search_prepare_query(search_query,
-                                 filter_query,
-                                 sort,
-                                 current_page,
-                                 settings.SOUNDS_PER_PAGE,
-                                 id_weight,
-                                 tag_weight,
-                                 description_weight,
-                                 username_weight,
-                                 pack_tokenized_weight,
-                                 original_filename_weight,
-                                 grouping=grouping
-                                 )
+    filter_query_split = split_filter_query(query_params['filter_query'], cluster_id)
 
     tvars = {
         'error_text': None,
-        'filter_query': filter_query,
+        'filter_query': query_params['filter_query'],
         'filter_query_split': filter_query_split,
-        'search_query': search_query,
-        'grouping': grouping,
-        'advanced': advanced,
-        'sort': sort,
-        'sort_options': sort_options,
-        'filter_query_link_more_when_grouping_packs': filter_query_link_more_when_grouping_packs,
-        'current_page': current_page,
+        'search_query': query_params['search_query'],
+        'grouping': query_params['grouping'],
+        'advanced': extra_vars['advanced'],
+        'sort': query_params['sort'],
+        'sort_unformatted': extra_vars['sort_unformatted'],
+        'sort_options': extra_vars['sort_options'],
+        'filter_query_link_more_when_grouping_packs': extra_vars['filter_query_link_more_when_grouping_packs'],
+        'current_page': query_params['current_page'],
+        'url_query_params_string': url_query_params_string,
     }
-    if advanced == "1":
-        tvars.update(advanced_search_params_dict)
+    
+    tvars.update(advanced_search_params_dict)
+
+    logger.info(u'Search (%s)' % json.dumps({
+        'ip': get_client_ip(request),
+        'query': query_params['search_query'],
+        'filter': query_params['filter_query'],
+        'username': request.user.username,
+        'page': query_params['current_page'],
+        'sort': query_params['sort'][0],
+        'group_by_pack': query_params['grouping'],
+        'advanced': json.dumps(advanced_search_params_dict) if extra_vars['advanced'] == "1" else ""
+    }))
+
+    query = search_prepare_query(**query_params)
 
     try:
-        non_grouped_number_of_results, facets, paginator, page, docs = perform_solr_query(query, current_page)
+        non_grouped_number_of_results, facets, paginator, page, docs = perform_solr_query(query, 
+                                                                                          query_params['current_page'])
         resultids = [d.get("id") for d in docs]
         resultsounds = sounds.models.Sound.objects.bulk_query_id(resultids)
         allsounds = {}
@@ -302,7 +105,7 @@ def search(request):
         docs = [doc for doc in docs if doc["id"] in allsounds]
         for d in docs:
             d["sound"] = allsounds[d["id"]]
-
+        
         tvars.update({
             'paginator': paginator,
             'page': page,
@@ -318,10 +121,107 @@ def search(request):
         logger.error('Could probably not connect to Solr - %s' % e)
         tvars.update({'error_text': 'The search server could not be reached, please try again later.'})
 
+    # enables AJAX clustering call & html clustering facets rendering
+    if settings.ENABLE_SEARCH_RESULTS_CLUSTERING:
+        tvars.update({'clustering_on': True})
+
     if request.GET.get("ajax", "") != "1":
         return render(request, 'search/search.html', tvars)
     else:
         return render(request, 'search/search_ajax.html', tvars)
+
+
+def _get_ids_in_cluster(request, requested_cluster_id):
+    """Get the sound ids in the requested cluster. Used for applying a filter by id when using a cluster facet.
+    """
+    try:
+        requested_cluster_id = int(requested_cluster_id) - 1
+    
+        # results are cached in clustering_utilities, available features are defined in the clustering settings file.
+        result = cluster_sound_results(request, features=DEFAULT_FEATURES)
+        results = result['result']
+
+        sounds_from_requested_cluster = results[int(requested_cluster_id)]
+
+    except ValueError:
+        return []
+    except IndexError:
+        return []
+
+    return sounds_from_requested_cluster
+
+
+def clustering_facet(request):
+    """Triggers the computation of the clustering, returns the state of processing or the clustering facet.
+    """
+    # pass the url query params for later sending it to the clustering engine
+    url_query_params_string = request.META['QUERY_STRING']
+    # remove existing cluster facet filter from the params since the returned cluster facets will include 
+    # their correspondinng cluster_id query parameter (done in the template)
+    url_query_params_string = re.sub(r"(&cluster_id=[0-9]*)", "", url_query_params_string)
+
+    result = cluster_sound_results(request, features=DEFAULT_FEATURES)
+
+    # check if computation is finished. If not, send computation state.
+    if result['finished']:
+        if result['result'] is not None:
+            results = result['result']
+            num_clusters = num_clusters = len(results) + 1
+        else:
+             return JsonResponse({'status': 'failed'}, safe=False)
+    elif result['error']:
+        return JsonResponse({'status': 'failed'}, safe=False)
+    else:
+        return JsonResponse({'status': 'pending'}, safe=False)
+
+    num_sounds_per_cluster = [len(cluster) for cluster in results]
+    classes = {sound_id: cluster_id for cluster_id, cluster in enumerate(results) for sound_id in cluster}
+
+    # label clusters using most occuring tags
+    sound_instances = sounds.models.Sound.objects.bulk_query_id(map(int, classes.keys()))
+    sound_tags = {sound.id: sound.get_sound_tags() for sound in sound_instances}
+    cluster_tags = defaultdict(list)
+    query_terms = {t.lower() for t in request.GET.get('q', '').split(' ')}
+    for sound_id, tags in sound_tags.iteritems():
+        cluster_tags[classes[str(sound_id)]] += [t.lower() for t in tags if t.lower() not in query_terms]
+    cluster_tags_with_count = {k: sorted([(t, tags.count(t)) for t in set(tags)], 
+                                         key=lambda x: x[1], reverse=True)
+                               for k, tags in cluster_tags.iteritems()}
+    cluster_most_occuring_tags = [' '.join(zip(*tags[:3])[0]) for tags in cluster_tags_with_count.values() if len(tags)>2]  # dict values sorted?!
+
+    return render(request, 'search/clustering_facet.html', {
+            'results': classes,
+            'url_query_params_string': url_query_params_string,
+            'cluster_id_num_results': zip(range(num_clusters), num_sounds_per_cluster, cluster_most_occuring_tags),
+    })
+
+
+def cluster_visualisation(request):
+    url_query_params_string = request.META['QUERY_STRING']
+    return render(request, 'search/clustered_graph.html', {
+            'url_query_params_string': url_query_params_string,
+    })
+
+
+def clustered_graph(request):
+    """Returns the clustered sound graph representation of the search results.
+    """
+    result = cluster_sound_results(request, features=DEFAULT_FEATURES)
+    graph = result['graph']
+
+    results = sounds.models.Sound.objects.bulk_query_id([int(node['id']) for node in graph['nodes']])
+    preview_urls_name_tags_by_id = {s.id:(s.get_preview_abs_url()[21:],
+                                          s.original_filename,
+                                          ' '.join(s.get_sound_tags()),
+                                          s.get_absolute_url()) for s in results}
+
+    for node in graph['nodes']:
+        node['url'] = preview_urls_name_tags_by_id[int(node['id'])][0]
+        node['name'] = preview_urls_name_tags_by_id[int(node['id'])][1]
+        node['tags'] = preview_urls_name_tags_by_id[int(node['id'])][2]
+        node['sound_page_url'] = preview_urls_name_tags_by_id[int(node['id'])][3]
+
+    return JsonResponse(json.dumps(graph), safe=False)
 
 
 def search_forum(request):

--- a/templates/search/clustered_graph.html
+++ b/templates/search/clustered_graph.html
@@ -1,0 +1,347 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Force-Directed Layout</title>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="//d3js.org/d3.v3.min.js"></script>
+    <script type="text/javascript" src="{{media_url}}js/webAudioApiForDesigners.js"></script>
+    <style type="text/css">
+        .node {
+            stroke: rgb(255, 255, 255);
+            stroke-width: 1.5px;
+            cursor: pointer;
+        }
+
+        .link {
+            stroke: rgb(99, 99, 99);
+            opacity: 0.1;
+            /* stroke-width: 1px; */
+        }
+
+        h1 {
+            font-size: 20px;
+            margin: 10px 0;
+            font-weight: normal;
+        }
+
+        h2 {
+            font-size: 18px;
+            margin: 5px 0;
+            font-weight: normal;
+        }
+
+        h3 {
+            font-size: 10px;
+            margin: 5px 0;
+            font-weight: normal;
+        }
+
+        header {
+            padding: 20px;
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
+
+        body {
+            background-color: rgba(128, 128, 128, 0.1);
+        }
+    </style>
+</head>
+
+<body>
+    <header>
+        <h1>Sound file name</h1>
+        <h2>Click on a node to display info</h2>
+        <h3></h3>
+    </header>
+    <div id="chart"></div>
+    <script type="text/javascript">
+        var BASE_NODE_SIZE = 5,
+            BASE_NODE_SIZE_ONHOVER = 8,
+            RATIO_NODE_SIZE_CENTRALITY = 5,
+            ON_OVER_NODE_SIZE = 12;
+        FORCE_CHARGE = -100;
+        FORCE_LINK_DISTANCE = 20;
+
+        var width = window.innerWidth - 30,
+            height = window.innerHeight - 30;
+
+        var fill = d3.scale.category20();
+
+        // https://github.com/wbkd/d3-extended
+        d3.selection.prototype.moveToFront = function () {
+            return this.each(function () {
+                this.parentNode.appendChild(this);
+            });
+        };
+
+        var force = d3.layout.force()
+            .charge(FORCE_CHARGE)
+            .linkDistance(FORCE_LINK_DISTANCE)
+            .linkStrength(function (d) {
+                if (d.weight) {
+                    return 3 * d.weight;
+                } else {
+                    return 1;
+                }
+            })
+            .size([width, height])
+            .gravity(0.4)
+            .alpha(0.8)
+            .theta(0.8)
+            .friction(0.9);
+
+        var zoom = d3.behavior.zoom()
+            .scaleExtent([0.3, 2])
+            .on("zoom", zoomed);
+
+        var svg = d3.select("body").append("svg")
+            .attr("viewBox", "0 0 " + width + " " + height)
+            .attr("preserveAspectRatio", "xMinYMid")
+            .append("g")
+            .call(zoom)
+            .append("g");
+
+        //big black box surrounding everything that we can zoom on 
+        var rect = svg.append("g")
+            .attr("class", "rect")
+            .append("rect")
+            .style("fill", "white")
+            .style("opacity", 0)
+            .attr("width", width)
+            .attr("height", height)
+            .style("pointer-events", "all")
+
+        var vis = svg.append("g")
+            .attr("width", width)
+            .attr("height", height)
+            .append("g")
+
+        // request clustered graph
+        $.get("{% url 'return-clustered-graph' %}"+"?{{url_query_params_string | safe}}", {
+        }).then(res => JSON.parse(res)).then(graph => {
+            console.log(graph)
+            var init_graph = JSON.parse(JSON.stringify(graph));
+
+            var nodeById = d3.map();
+
+            graph.nodes.forEach(function (node) {
+                nodeById.set(node.id, node);
+            });
+
+            graph.links.forEach(function (link) {
+                link.source = nodeById.get(link.source);
+                link.target = nodeById.get(link.target);
+            });
+
+            // Force layout
+            force
+                .nodes(graph.nodes)
+                .links(graph.links)
+                .start();
+
+            var link = vis.selectAll(".link")
+                .data(graph.links)
+                .enter().append("line")
+                .attr("class", "link")
+                .style("stroke-width", function (d) {
+                    return d.weight;
+                });
+
+            var node = vis.selectAll(".node")
+                .data(graph.nodes)
+                .enter().append("circle")
+                .attr("class", "node")
+                .attr("r", function (d) {
+                    return size_node(d.group_centrality);
+                })
+                .style("fill", function (d) {
+                    return fill(d.group);
+                })
+                .on('click', connectedNodes);
+            // .call(force.drag);
+
+            svg.selectAll(".node")
+                .on("mouseenter", function (d) {
+                    // load and play sound
+                    context.loadSound(d.url, '0');
+                    playingSound = context.playSound('0');
+
+                    // make node bigger
+                    d3.select(this)
+                        .transition()
+                        .attr("r", function (d) {
+                            return size_node_on_hover(d.group_centrality);
+                        })
+
+                    d3.select(this).moveToFront();
+                })
+                .on("mouseleave", function () {
+                    // stop playing sound
+                    if (playingSound) {
+                        playingSound.pause();
+                    }
+
+                    // make node smaller
+                    d3.select(this)
+                        .transition()
+                        .attr("r", function (d) {
+                            return size_node(d.group_centrality);
+                        })
+                });
+
+            force.on("tick", function () {
+                    link.attr("x1", function (d) {
+                            return d.source.x;
+                        })
+                        .attr("y1", function (d) {
+                            return d.source.y;
+                        })
+                        .attr("x2", function (d) {
+                            return d.target.x;
+                        })
+                        .attr("y2", function (d) {
+                            return d.target.y;
+                        });
+
+                    node.attr("cx", function (d) {
+                            return d.x;
+                        })
+                        .attr("cy", function (d) {
+                            return d.y;
+                        });
+                    node.each(collide(0.3));
+                })
+                // .on('end', function () {
+                //     (function (console) {
+                //         console.save = function (data, filename) {
+
+                //             if (!data) {
+                //                 console.error('Console.save: No data')
+                //                 return;
+                //             }
+
+                //             if (!filename) filename = 'console.json'
+
+                //             if (typeof data === "object") {
+                //                 data = JSON.stringify(data, undefined, 4)
+                //             }
+
+                //             var blob = new Blob([data], {
+                //                     type: 'text/json'
+                //                 }),
+                //                 e = document.createEvent('MouseEvents'),
+                //                 a = document.createElement('a')
+
+                //             a.download = filename
+                //             a.href = window.URL.createObjectURL(blob)
+                //             a.dataset.downloadurl = ['text/json', a.download, a.href].join(':')
+                //             e.initMouseEvent('click', true, false, window, 0, 0, 0, 0, 0, false,
+                //                 false, false, false, 0, null)
+                //             a.dispatchEvent(e)
+                //         }
+                //     })(console)
+                    
+                //     init_graph.nodes = graph.nodes;
+                //     console.save(init_graph, 'graph.json')
+                // });
+
+            // Hilight nodes on click
+            //Toggle stores whether the highlighting is on
+            var toggle = 0;
+            //Create an array logging what is connected to what
+            var linkedByIndex = {};
+            for (i = 0; i < graph.nodes.length; i++) {
+                linkedByIndex[i + "," + i] = 1;
+            };
+            graph.links.forEach(function (d) {
+                linkedByIndex[d.source.index + "," + d.target.index] = 1;
+            });
+            //This function looks up whether a pair are neighbours
+            function neighboring(a, b) {
+                return linkedByIndex[a.index + "," + b.index];
+            }
+
+            function connectedNodes() {
+                if (toggle == 0) {
+                    //Reduce the opacity of all but the neighbouring nodes
+                    d = d3.select(this).node().__data__;
+                    link.style("opacity", function (o) {
+                        return d.index == o.source.index | d.index == o.target.index ? 1 : 0.05;
+                    });
+                    node.style("opacity", function (o) {
+                        return neighboring(d, o) | neighboring(o, d) ? 1 : 0.15;
+                    });
+
+                    // show sound info
+                    d3.select("h1").html(d.name + '   centrality: ' + d.group_centrality);
+                    d3.select("h2").html(d.tags);
+                    d3.select("h3").html('<a href="' + d.sound_page_url + '">' + d.sound_page_url + '</a>');
+
+                    toggle = 1;
+                } else {
+                    //Put them back to opacity=1
+                    node.style("opacity", 1);
+                    link.style("opacity", 0.1);
+                    toggle = 0;
+
+                    // remove sound info
+                    d3.select("h1").html('Sound file name');
+                    d3.select("h2").html('Click on a node to display info');
+                    d3.select("h3").html('');
+                }
+            }
+
+            // Collide for forbiding overlap of nodes
+            var padding = 1;
+
+            function collide(alpha) {
+                var quadtree = d3.geom.quadtree(graph.nodes);
+                return function (d) {
+                    var rb = 2 * size_node(d.group_centrality),
+                        nx1 = d.x - rb,
+                        nx2 = d.x + rb,
+                        ny1 = d.y - rb,
+                        ny2 = d.y + rb;
+                    quadtree.visit(function (quad, x1, y1, x2, y2) {
+                        if (quad.point && (quad.point !== d)) {
+                            var x = d.x - quad.point.x,
+                                y = d.y - quad.point.y,
+                                l = Math.sqrt(x * x + y * y);
+                            if (l < rb) {
+                                l = (l - rb) / l * alpha;
+                                d.x -= x *= l;
+                                d.y -= y *= l;
+                                quad.point.x += x;
+                                quad.point.y += y;
+                            }
+                        }
+                        return x1 > nx2 || x2 < nx1 || y1 > ny2 || y2 < ny1;
+                    });
+                };
+            }
+        });
+
+        function size_node(c) {
+            return c * RATIO_NODE_SIZE_CENTRALITY + BASE_NODE_SIZE;
+        }
+
+        function size_node_on_hover(c) {
+            return c * RATIO_NODE_SIZE_CENTRALITY + BASE_NODE_SIZE_ONHOVER;
+        }
+
+        // Zoom        
+        function zoomed() {
+            vis.attr("transform", "translate(" + d3.event.translate + ")scale(" + d3.event.scale + ")");
+        }
+
+        // Web Audio API
+        var context = initializeNewWebAudioContext();
+        var playingSound; // keep track of playing sound to stop it
+    </script>
+</body>
+
+</html>

--- a/templates/search/clustering_facet.html
+++ b/templates/search/clustering_facet.html
@@ -1,0 +1,8 @@
+<ul>
+    {% for cluster_id, num_results, tags in cluster_id_num_results %}
+        <li class="facet_item">
+            <a href="{% url 'sounds-search' %}?{{url_query_params_string | safe}}&cluster_id={{cluster_id|add:1}}">Cluster #{{cluster_id|add:1}}
+            </a> ({{tags}}, {{num_results}})
+        </li>
+    {% endfor %}
+</ul>

--- a/templates/search/facet.html
+++ b/templates/search/facet.html
@@ -1,10 +1,10 @@
 {% ifequal type "list" %}
  <ul>
-     {% for f in facet %}<li class="facet_item"><a href=".?g={{grouping}}&q={{search_query}}&f={{f.params}}">{{f.display_name}}</a> ({{f.count}})</li>{% endfor %}
+     {% for f in facet %}<li class="facet_item"><a href=".?g={{grouping}}&q={{search_query}}&f={{f.params}}&s={{sort_unformatted}}">{{f.display_name}}</a> ({{f.count}})</li>{% endfor %}
 </ul>
 {% endifequal %}
 {% ifequal type "cloud" %}
 <p class="search-tagcloud">
-    {% for f in facet %}<span class="facet_item" style="font-size:{{f.size}}em"><a href=".?g={{grouping}}&q={{search_query}}&f={{f.params}}">{{f.display_name}}</a></span> {% endfor %}
+    {% for f in facet %}<span class="facet_item" style="font-size:{{f.size}}em"><a href=".?g={{grouping}}&q={{search_query}}&f={{f.params}}&s={{sort_unformatted}}">{{f.display_name}}</a></span> {% endfor %}
 </p>
 {% endifequal %}

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -36,7 +36,7 @@
 <p id="filter_query_display">
 
 {% for filter in filter_query_split %}
-    <a href=".?g={{grouping}}&q={{search_query}}&f={{ filter.remove_url }}" title="remove this filter">{{ filter.name }}</a>
+    <a href=".?g={{grouping}}&q={{search_query}}&f={{ filter.remove_url }}&s={{sort_unformatted}}" title="remove this filter">{{ filter.name }}</a>
 {% endfor %}
 
 </p>
@@ -76,6 +76,11 @@
         		descriptions[j].innerHTML = descriptions[j].innerHTML.replace(re,"<b>"+term+"</b>");
         	}
         }
+
+        // Ajax request clustering
+        {% if clustering_on %}
+            request_clustering();
+        {% endif %}
 
     });
 
@@ -201,6 +206,25 @@
         $("#filter_query").val(cleaned);
     }
 
+    // function for requesting clustering
+    function request_clustering()
+    {
+        $.get({% url 'clustering-facet' %} + '?{{ url_query_params_string | safe }}', 
+                {}, 
+                function( data ) {
+                    if (data.status === 'pending') {
+                        setTimeout(() => {
+                            request_clustering();
+                        }, 500);
+                    } else if (data.status === 'failed') {
+                        // clustering failed
+                        $('#clusters-div').replaceWith(""); // TODO: remove clusters facet container
+                    } else {
+                        $('#clusters-div').replaceWith(data);
+                    }
+        });
+    }
+
 </script>
 
 {% if error_text %}
@@ -208,6 +232,18 @@
 {% else %}
     {% if facets %}
     <div id="sidebar" style="float:right">
+
+        {% if clustering_on %}
+            <h3>clusters 
+                <a href="{% url 'cluster-visualisation' %}?{{ url_query_params_string | safe }}">
+                    <img src='{{media_url}}images/eye-open.png' width="30px"/>
+                </a>
+            </h3>
+            <div id='clusters-div'>...
+                <br><br>
+            </div>
+        {% endif %}
+
         {% if facets.license and facets.license|length > 1 %}
             <h3>licenses</h3>
             {% display_facet "license" facets.license "list" %}

--- a/utils/search/search_general.py
+++ b/utils/search/search_general.py
@@ -22,17 +22,354 @@ import logging
 import math
 import random
 import socket
+import json
 
+import re
 from django.conf import settings
 
 import sounds
+from search import forms
 from search.forms import SEARCH_SORT_OPTIONS_WEB
-from search.views import search_prepare_sort, search_prepare_query
-from utils.search.solr import Solr, SolrQuery, SolrResponseInterpreter, SolrException
+from utils.search.solr import Solr, SolrQuery, SolrResponseInterpreter, SolrException, \
+    SolrResponseInterpreterPaginator
 from utils.text import remove_control_chars
+from utils.logging_filters import get_client_ip
 
 logger = logging.getLogger("search")
 console_logger = logging.getLogger("console")
+
+
+def search_prepare_sort(sort, options):
+    """Creates sort list for ordering by rating.
+
+    Order by rating, then by number of ratings.
+    
+    Args:
+        sort (str): sort url query parameter.
+        options (List[Tuple(str)]): list containing 2-element tuples with the ordering option names
+        and their corresponding fields in the database. 
+
+    Returns:
+        List[str]: list containing the sorting parameters.
+    """
+    if sort in [x[1] for x in options]:
+        if sort == "avg_rating desc":
+            sort = [sort, "num_ratings desc"]
+        elif  sort == "avg_rating asc":
+            sort = [sort, "num_ratings asc"]
+        else:
+            sort = [sort]
+    else:
+        sort = [forms.SEARCH_DEFAULT_SORT]
+    return sort
+
+
+def search_process_filter(filter_query):
+    """Process the filter to replace humnan-readable Audio Commons descriptor names.
+
+    Used for the dynamic field names used in Solr (e.g. ac_tonality -> ac_tonality_s, ac_tempo -> ac_tempo_i).
+    The dynamic field names we define in Solr schema are '*_b' (for bool), '*_d' (for float), '*_i' (for integer) 
+    and '*_s' (for string). At indexing time we append these suffixes to the ac descirptor names so Solr can 
+    treat the types properly. Now we automatically append the suffices to the filter names so users do not 
+    need to deal with that.
+
+    Args:
+        filter_query (str): query filter string.
+
+    Returns:
+        str: processed filter query string.
+    """
+    for name, t in settings.AUDIOCOMMONS_INCLUDED_DESCRIPTOR_NAMES_TYPES:
+        filter_query = filter_query.replace('ac_{0}:'.format(name), 'ac_{0}{1}:'
+                                            .format(name, settings.SOLR_DYNAMIC_FIELDS_SUFFIX_MAP[t]))
+    return filter_query
+
+
+def split_filter_query(filter_query, cluster_id):
+    """Parses and pre-process search filter parameters and returns the filters' information.
+
+    This function is used in the search template to display the filter and the link when removing them.
+    The clustering facet filter is in a separate query parameter. It facilitates to distinguish them from
+    the classical facet filters.
+
+    Args:
+        filter_query (str): query filter string.
+        cluster_id (str): cluster filter string.
+
+    Returns:
+        List[dict]: list of dictionaries containing the filter name and the url when removing the filter.
+    """
+    # Generate array with information of filters
+    filter_query_split = []
+    if filter_query != "":
+        for filter_str in re.findall(r'[\w-]+:\"[^\"]+', filter_query):
+            valid_filter = True
+            filter_str = filter_str + '"'
+            filter_display = filter_str.replace('"', '')
+            filter_name = filter_str.split(":")[0]
+            if filter_name != "duration" and filter_name != "is_geotagged":
+                if filter_name == "grouping_pack":
+                    val = filter_display.split(":")[1]
+                    # If pack does not contain "_" then it's not a valid pack filter
+                    if "_" in val:
+                        filter_display = "pack:"+ val.split("_")[1]
+                    else:
+                        valid_filter = False
+
+                if valid_filter:
+                    filter = {
+                        'name': filter_display,
+                        'remove_url': filter_query.replace(filter_str, ''),
+                    }
+                    filter_query_split.append(filter)
+
+    # add cluster filter information
+    if cluster_id and cluster_id.isdigit():
+        filter_query_split.append({
+            'name': "Cluster #" + cluster_id,
+            'remove_url': filter_query,
+        })
+
+    return filter_query_split
+
+
+def search_prepare_parameters(request):
+    """Parses and pre-process search input parameters from the request object and returns them as a dict.
+
+    From the request object, it constructs all the parameters needed for building the Solr query 
+    object. Additionally, other variables are returned for logging purpose, and for building the search
+    view context variables.
+
+    This functions also make easier the replication of the Solr query from the clustering engine.
+
+    Args:
+        request (HttpRequest): request associated with the search query submited by the user.
+    
+    Returns:
+        Tuple(dict, dict, dict): 3-element tuple containing the query parameters needed for building the Solr 
+        query, the advanced search params to be logged and some extra parameters needed in the search view. 
+    """
+    search_query = request.GET.get("q", "")
+    filter_query = request.GET.get("f", "")
+    cluster_id = request.GET.get('cluster_id', "")
+
+    try:
+        current_page = int(request.GET.get("page", 1))
+    except ValueError:
+        current_page = 1
+    sort_unformatted = request.GET.get("s", None)
+    grouping = request.GET.get("g", "1")  # Group by default
+
+    # If the query is filtered by pack, do not collapse sounds of the same pack (makes no sense)
+    # If the query is through AJAX (for sources remix editing), do not collapse
+    if "pack" in filter_query or request.GET.get("ajax", "") == "1":
+        grouping = ""
+
+    # Set default values
+    id_weight = settings.DEFAULT_SEARCH_WEIGHTS['id']
+    tag_weight = settings.DEFAULT_SEARCH_WEIGHTS['tag']
+    description_weight = settings.DEFAULT_SEARCH_WEIGHTS['description']
+    username_weight = settings.DEFAULT_SEARCH_WEIGHTS['username']
+    pack_tokenized_weight = settings.DEFAULT_SEARCH_WEIGHTS['pack_tokenized']
+    original_filename_weight = settings.DEFAULT_SEARCH_WEIGHTS['original_filename']
+
+    # Parse advanced search options
+    advanced = request.GET.get("advanced", "")
+    advanced_search_params_dict = {}
+
+    if advanced == "1":
+        a_tag = request.GET.get("a_tag", "")
+        a_filename = request.GET.get("a_filename", "")
+        a_description = request.GET.get("a_description", "")
+        a_packname = request.GET.get("a_packname", "")
+        a_soundid = request.GET.get("a_soundid", "")
+        a_username = request.GET.get("a_username", "")
+
+        # These are stored in a dict to facilitate logging and passing to template
+        advanced_search_params_dict.update({
+            'a_tag': a_tag,
+            'a_filename': a_filename,
+            'a_description': a_description,
+            'a_packname': a_packname,
+            'a_soundid': a_soundid,
+            'a_username': a_username,
+        })
+
+        # If none is selected use all (so other filter can be appleid)
+        if a_tag or a_filename or a_description or a_packname or a_soundid or a_username != "" :
+
+            # Initialize all weights to 0
+            id_weight = 0
+            tag_weight = 0
+            description_weight = 0
+            username_weight = 0
+            pack_tokenized_weight = 0
+            original_filename_weight = 0
+
+            # Set the weights of selected checkboxes
+            if a_soundid != "":
+                id_weight = settings.DEFAULT_SEARCH_WEIGHTS['id']
+            if a_tag != "":
+                tag_weight = settings.DEFAULT_SEARCH_WEIGHTS['tag']
+            if a_description != "":
+                description_weight = settings.DEFAULT_SEARCH_WEIGHTS['description']
+            if a_username != "":
+                username_weight = settings.DEFAULT_SEARCH_WEIGHTS['username']
+            if a_packname != "":
+                pack_tokenized_weight = settings.DEFAULT_SEARCH_WEIGHTS['pack_tokenized']
+            if a_filename != "":
+                original_filename_weight = settings.DEFAULT_SEARCH_WEIGHTS['original_filename']
+
+    sort_options = SEARCH_SORT_OPTIONS_WEB
+    sort = search_prepare_sort(sort_unformatted, sort_options)
+
+    query_params = {
+        'search_query': search_query,
+        'filter_query': filter_query,
+        'sort': sort,
+        'current_page': current_page,
+        'sounds_per_page': settings.SOUNDS_PER_PAGE,
+        'id_weight': id_weight,
+        'tag_weight': tag_weight,
+        'description_weight': description_weight,
+        'username_weight': username_weight,
+        'pack_tokenized_weight': pack_tokenized_weight,
+        'original_filename_weight': original_filename_weight,
+        'grouping': grouping,
+    }
+
+    filter_query_link_more_when_grouping_packs = filter_query.replace(' ','+')
+
+    extra_vars = {
+        'filter_query_link_more_when_grouping_packs': filter_query_link_more_when_grouping_packs,
+        'sort_unformatted': sort_unformatted,
+        'advanced': advanced,
+        'sort_options': sort_options,
+    }
+
+    return query_params, advanced_search_params_dict, extra_vars
+
+
+def search_prepare_query(search_query,
+                         filter_query,
+                         sort,
+                         current_page,
+                         sounds_per_page,
+                         id_weight=settings.DEFAULT_SEARCH_WEIGHTS['id'],
+                         tag_weight=settings.DEFAULT_SEARCH_WEIGHTS['tag'],
+                         description_weight=settings.DEFAULT_SEARCH_WEIGHTS['description'],
+                         username_weight=settings.DEFAULT_SEARCH_WEIGHTS['username'],
+                         pack_tokenized_weight=settings.DEFAULT_SEARCH_WEIGHTS['pack_tokenized'],
+                         original_filename_weight=settings.DEFAULT_SEARCH_WEIGHTS['original_filename'],
+                         grouping=False,
+                         include_facets=True,
+                         grouping_pack_limit=1,
+                         offset=None,
+                         in_ids=[]):
+    """Create the Solr query object given the query parameters.
+    
+    Args:
+        search_query (str): query string.
+        filter_query (str): query filter string.
+        sort (str): sort option string.
+        current_page (int): requested page of the results.
+        sounds_per_page (int): number of sounds per page.
+        id_weight (int): id weight for the query.
+        tag_weight (int): tag weight for the query.
+        description_weight (int): description weight for the query.
+        username_weight (int): username weight for the query.
+        pack_tokenized_weight (int): pack weight for the query.
+        original_filename_weight (int): filename weight for the query.
+        grouping (bool): only show one (or more) sounds for each pack.
+        include_facets (bool): include facets or no.
+        grouping_pack_limit (int): number of sounds showed for each pack.
+        offset (int): a numerical offset.
+        in_ids (list): list of sound ids for cluster filter facet.
+
+    Returns: (SolrQuery): the solr query object corresponding to the user submitted query.
+
+    """
+    query = SolrQuery()
+
+    # Set field weights and scoring function
+    field_weights = []
+    for weight, weight_str in [(id_weight, "id"),
+                               (tag_weight, "tag"),
+                               (description_weight, "description"), 
+                               (username_weight, "username"),
+                               (pack_tokenized_weight, "pack_tokenized"),
+                               (original_filename_weight, "original_filename")]:
+        if weight != 0:
+            field_weights.append((weight_str, weight))
+
+    query.set_dismax_query(search_query,
+                           query_fields=field_weights,)
+
+    # Set start and rows parameters (offset and size)
+    if not offset:
+        start = (current_page - 1) * sounds_per_page
+    else:
+        start = offset
+
+    # Process filter
+    filter_query = search_process_filter(filter_query)
+
+    # Process filter for clustering.
+    # When applying a cluster facet filter, the sounds in the clusters already have been filtered by other 
+    # present filter. So there is no need to keep in filter_query all the other filters.
+    # When a cluster filter is applied and the user applies another facet filter, it simply removes the cluster
+    # filter and re-computes the clustering for the new filters (this logic is done with the facet 
+    # remove_url links).
+    if in_ids:
+        filter_query = ''
+        if len(in_ids) == 1:
+            filter_query += 'id:{}'.format(in_ids[0])
+        else:
+            filter_query += 'id:'
+            filter_query += ' OR id:'.join(in_ids)
+
+    # Set all options
+    query.set_query_options(start=start, rows=sounds_per_page, field_list=["id"], filter_query=filter_query, sort=sort)
+
+    # Specify query factes
+    if include_facets:
+        query.add_facet_fields("samplerate", "grouping_pack", "username", "tag", "bitrate", "bitdepth", "type", "channels", "license")
+        query.set_facet_options_default(limit=5, sort=True, mincount=1, count_missing=False)
+        query.set_facet_options("type", limit=len(sounds.models.Sound.SOUND_TYPE_CHOICES))
+        query.set_facet_options("tag", limit=30)
+        query.set_facet_options("username", limit=30)
+        query.set_facet_options("grouping_pack", limit=10)
+        query.set_facet_options("license", limit=10)
+
+    # Add groups
+    if grouping:
+        query.set_group_field(group_field="grouping_pack")
+        query.set_group_options(
+            group_func=None,
+            group_query=None,
+            group_rows=10,
+            group_start=0,
+            group_limit=grouping_pack_limit,  # This is the number of documents that will be returned for each group. By default only 1 is returned.
+            group_offset=0,
+            group_sort=None,
+            group_sort_ingroup=None,
+            group_format='grouped',
+            group_main=False,
+            group_num_groups=True,
+            group_cache_percent=0)
+    return query
+
+
+def perform_solr_query(q, current_page):
+    """
+    This util function performs the query to Solr and returns needed parameters to continue with the view.
+    The main reason to have this util function is to facilitate mocking in unit tests for this view.
+    """
+    solr = Solr(settings.SOLR_URL)
+    results = SolrResponseInterpreter(solr.select(unicode(q)))
+    paginator = SolrResponseInterpreterPaginator(results, settings.SOUNDS_PER_PAGE)
+    page = paginator.page(current_page)
+    return results.non_grouped_number_of_matches, results.facets, paginator, page, results.docs
 
 
 def convert_to_solr_document(sound):

--- a/utils/tests/test_search_general.py
+++ b/utils/tests/test_search_general.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.urls import reverse
+from django.conf import settings
+from utils.search.search_general import search_prepare_parameters, split_filter_query, search_prepare_query
+from search.forms import SEARCH_DEFAULT_SORT, SEARCH_SORT_OPTIONS_WEB
+
+
+class SearchUtilsTest(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_search_prepare_parameters_without_query_params(self):
+        request = self.factory.get(reverse('sounds-search'))
+        query_params, advanced_search_params_dict, extra_vars = search_prepare_parameters(request)
+
+        expected_default_query_params = {
+            'id_weight': settings.DEFAULT_SEARCH_WEIGHTS['id'],
+            'tag_weight': settings.DEFAULT_SEARCH_WEIGHTS['tag'],
+            'description_weight': settings.DEFAULT_SEARCH_WEIGHTS['description'],
+            'username_weight': settings.DEFAULT_SEARCH_WEIGHTS['username'],
+            'pack_tokenized_weight': settings.DEFAULT_SEARCH_WEIGHTS['pack_tokenized'],
+            'original_filename_weight': settings.DEFAULT_SEARCH_WEIGHTS['original_filename'],
+            'sort': [SEARCH_DEFAULT_SORT],
+            'sounds_per_page': settings.SOUNDS_PER_PAGE,
+            'current_page': 1,
+            'grouping': u'1',
+            'filter_query': u'',
+            'search_query': u'',
+        }
+
+        expected_extra_vars = {
+            'advanced': '',
+            'sort_unformatted': None,
+            'filter_query_link_more_when_grouping_packs': '',
+            'sort_options': SEARCH_SORT_OPTIONS_WEB
+        }
+
+        self.assertDictEqual(query_params, expected_default_query_params)
+        self.assertDictEqual(advanced_search_params_dict, {})
+        self.assertDictEqual(extra_vars, expected_extra_vars)
+
+    def test_search_prepare_parameters_with_query_params(self):
+        # "dog" query, search only in tags and descriptions, duration from 1-10 sec, only geotag, sort by duration, no group by pack
+        url_query_str = '?q=dog&f=duration:[1+TO+10]+is_geotagged:1&s=duration+desc&advanced=1&a_tag=1&a_description=1&g='
+        request = self.factory.get(reverse('sounds-search')+url_query_str)
+        query_params, advanced_search_params_dict, extra_vars = search_prepare_parameters(request)
+
+        expected_default_query_params = {
+            'id_weight': 0,
+            'tag_weight': settings.DEFAULT_SEARCH_WEIGHTS['tag'],
+            'description_weight': settings.DEFAULT_SEARCH_WEIGHTS['description'],
+            'username_weight': 0,
+            'pack_tokenized_weight': 0,
+            'original_filename_weight': 0,
+            'sort': [u'duration desc'],
+            'sounds_per_page': settings.SOUNDS_PER_PAGE,
+            'current_page': 1,
+            'grouping': u'',
+            'filter_query': u'duration:[1 TO 10] is_geotagged:1',
+            'search_query': u'dog',
+        }
+
+        expected_extra_vars = {
+            'advanced': u'1',
+            'sort_unformatted': u'duration desc',
+            'filter_query_link_more_when_grouping_packs': u'duration:[1+TO+10]+is_geotagged:1',
+            'sort_options': SEARCH_SORT_OPTIONS_WEB
+        }
+
+        expected_advanced_search_params_dict = {
+            'a_tag': u'1', 
+            'a_username': '', 
+            'a_description': u'1', 
+            'a_packname': '', 
+            'a_filename': '', 
+            'a_soundid': '',
+        }
+
+        self.assertDictEqual(query_params, expected_default_query_params)
+        self.assertDictEqual(advanced_search_params_dict, expected_advanced_search_params_dict)
+        self.assertDictEqual(extra_vars, expected_extra_vars)
+
+    def test_search_prepare_parameters_non_ascii_query(self):
+        # Simple test to check if some non ascii characters are correctly handled by search_prepare_parameters()
+        request = self.factory.get(reverse('sounds-search')+u'?q=Æ æ ¿ É')
+        query_params, advanced_search_params_dict, extra_vars = search_prepare_parameters(request)
+        self.assertEqual(query_params['search_query'], u'\xc6 \xe6 \xbf \xc9')
+
+    def test_split_filter_query_duration_and_facet(self):
+        # We check that the combination of a duration filter and a facet filter (CC Attribution) works correctly.
+        filter_query_string = u'duration:[0 TO 10] license:"Attribution"'
+        filter_query_split = split_filter_query(filter_query_string, '')
+
+        # duraton filter is not a facet, but should stay present when removing a facet.
+        expected_filter_query_split = [
+            {'remove_url': u'duration:[0 TO 10]', 'name': u'license:Attribution'}, 
+        ]
+
+        # we use assertIn because the unicode strings that split_filter_query generates can incorporate 
+        # additional spaces, which is not a problem.
+        self.assertIn(expected_filter_query_split[0]['name'], filter_query_split[0]['name'])
+        self.assertIn(expected_filter_query_split[0]['remove_url'], filter_query_split[0]['remove_url'])
+
+    def test_split_filter_query_cluster_facet(self):
+        # We check that the combination of a duration filter, a facet filter (CC Attribution) and a cluster filter
+        # works correctly.
+        filter_query_string = u'duration:[0 TO 10] license:"Attribution"'
+        filter_query_split = split_filter_query(filter_query_string, '1')
+
+        expected_filter_query_split = [
+            {'remove_url': u'duration:[0 TO 10]', 'name': u'license:Attribution'}, 
+            {'remove_url': u'duration:[0 TO 10] license:"Attribution"', 'name': 'Cluster #1'}
+        ]
+
+        # check that the cluster facet exists
+        filter_query_names = [filter_query_dict['name'] for filter_query_dict in expected_filter_query_split]
+        self.assertIn('Cluster #1', filter_query_names)
+
+        # the order does not matter for the list of facet dicts.
+        # we get the index of the correspondings facets dicts.
+        cc_attribution_facet_dict_idx = filter_query_names.index('license:Attribution')
+        cluster_facet_dict_idx = filter_query_names.index('Cluster #1')
+
+        self.assertIn(expected_filter_query_split[0]['name'], 
+                      filter_query_split[cc_attribution_facet_dict_idx]['name'])
+        self.assertIn(expected_filter_query_split[0]['remove_url'], 
+                      filter_query_split[cc_attribution_facet_dict_idx]['remove_url'])
+
+        self.assertIn(expected_filter_query_split[1]['name'], 
+                      filter_query_split[cluster_facet_dict_idx]['name'])
+        self.assertIn(expected_filter_query_split[1]['remove_url'], 
+                      filter_query_split[cluster_facet_dict_idx]['remove_url'])
+
+    def test_search_prepare_query(self):
+        # we test that some query parameters get correctly setted in the Solr query object.
+        query_params = {
+            'search_query': u'cat',
+            'filter_query': u'duration:[1 TO 10] is_geotagged:1',
+            'sort': [u'duration desc'],
+            'current_page': 1,
+            'sounds_per_page': settings.SOUNDS_PER_PAGE,
+            'id_weight': 10,
+            'tag_weight': 0,
+            'description_weight': 0,
+            'username_weight': 0,
+            'pack_tokenized_weight': 0,
+            'original_filename_weight': 0,
+            'grouping': True,
+            'in_ids': [],
+        }
+
+        query = search_prepare_query(**query_params)
+
+        self.assertEqual(query.params['q'], 'cat')
+        self.assertEqual(query.params['qf'], 'id^10')
+        self.assertEqual(query.params['fq'], 'duration:[1 TO 10] is_geotagged:1')
+        self.assertTrue(query.params['group'])
+        self.assertEqual(query.params['sort'], 'duration desc')
+        self.assertEqual(query.params['rows'], settings.SOUNDS_PER_PAGE)
+
+    def test_search_prepare_query_cluster_filter(self):
+        # we test that a cluster filter removes all other filters and correctly adds filters by id.
+        query_params = {
+            'search_query': u'cat',
+            'filter_query': u'duration:[1 TO 10] is_geotagged:1',
+            'sort': [u'duration desc'],
+            'current_page': 1,
+            'sounds_per_page': settings.SOUNDS_PER_PAGE,
+            'in_ids': ["1", "2", "3"],
+        }
+
+        query = search_prepare_query(**query_params)
+        self.assertEqual(query.params['fq'], "id:1 OR id:2 OR id:3")
+        


### PR DESCRIPTION
**NOTE:** this PR is a new version of https://github.com/MTG/freesound/pull/1370, originally created by @xavierfav. After a couple rounds of reviews, I messed up when merging from the external remote and the original PR included some commits which were already in master, showing wrong files changed. We decided to make a new branch (this time in the Freesound repo itself) and open a new PR to make it easier to continue with the review process. The previous comments of the review are still accessible at the old PR URL.

---

This PR is a Work in Progress. The aim is to iteratively discuss the integration of the search result clustering engine into Freesound.

**Search Result Clustering Functioning**
- A user submits a query to the Freesound collection. 
- The client receives the results and makes AJAX request to trigger the clustering of the top 1000 sounds in the results.
- The client periodically (every 0.5s) asks for the clustering result.
- When the clustering is finished, the result is cached for later uses and some cluster facets appear in the client page, with some tags and the number of sounds in each of them. 
- Clicking on a cluster facet will filter the results in order to retrieve only the sounds belonging to the selected cluster. Removing the filter can be done by clicking on the filter facet under the query definition as it is done with the other facets. The only particularity here is that only one cluster filter can be applied at a time.
- Clicking on an icon next to the cluster facet header will open a page with a 2D visualisation that enable quick exploration of the results.

**Notes**
- I've been moving code from `search/views.py` to `utils/search/general_search.py`, I order to enable the clustering engine to reuse Solr related functions for performing queries to the audio database.
- Celery (+ Redis) is used for performing async clustering.
- Config of cache to use Redis backend (easy to make Celery workers and Django sharing the same cache). This is configured in my `local_settings.py` file.
- I fixed #1269 on the way.

**TODO**
- Review code.
- Fix bug: when a cluster too big (>500 items), the Solr query made when applying the cluster facet produces a too long url (increase header size or switch to POST request).
- Make K-Nearest Neighbors Graph construction faster by parallelizing the NN searches. 
---

**How To**
- Add this to your local settings (change port if you need):
```python
# Redis backend cache
CACHES = {
    "default": {
        "BACKEND": "django_redis.cache.RedisCache",
        "LOCATION": "redis://localhost:6380",
        "OPTIONS": {
            "CLIENT_CLASS": "django_redis.client.DefaultClient"
        },
        "KEY_PREFIX": "example"
    }
}

# CELERY STUFF
CELERY_BROKER_URL = 'redis://localhost:6380'
CELERY_RESULT_BACKEND = 'redis://localhost:6380'
CELERY_ACCEPT_CONTENT = ['application/json']
CELERY_TASK_SERIALIZER = 'json'
CELERY_RESULT_SERIALIZER = 'json'

REDIS_HOST = 'localhost'
REDIS_PORT = 6380

# enable the use of the clustering feature.
ENABLE_SEARCH_RESULTS_CLUSTERING = True
```
- Configure the clustering engine:
`cp clustering/clustering_settings.example.py clustering/clustering_settings.py`
Open the file and set `INDEX_DIR` to the folder path were the Gaia dataset is (shared on [google drive](https://drive.google.com/open?id=1gqy1Jfxd71gBuLlhGFwVxwV7UJZ1nBXq)), and `INDEX_NAME_AS` as the name of the dataset file.
- Start Redis: 
`redis-server --port 6380`
- Start Cekery:
`env ENV_CELERY_WORKER=1 celery -A freesound worker -l info`
- Start Django server:
`python manage.py runserver`
- Start Solr as usual.