### PR TITLE
Increase Similarity.save timeout to 5 minutes

### DIFF
--- a/similarity/client/__init__.py
+++ b/similarity/client/__init__.py
@@ -139,7 +139,7 @@ class Similarity():
         url = _BASE_URL + _URL_SAVE
         if filename:
             url += '?' + 'filename=' + str(filename)
-        return _result_or_exception(_get_url_as_json(url, timeout=120))
+        return _result_or_exception(_get_url_as_json(url, timeout=60 * 5))
 
     @classmethod
     def save_indexing_server(cls, filename = None):


### PR DESCRIPTION
**Description**
Calling the save method of the Similarity client currently ends up raising a timeout because similarity server takes more than the (previous) timeout of 120 seconds. Because it is not straightforward to make Similarity server save faster, quick solution is to simply increase timeout of the save method, which is the purpose of this commit/PR.
