### PR TITLE
Don't use control chars in APIv2 browser-version docs memacahe keys

### DIFF
--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -46,6 +46,7 @@ from apiv2.exceptions import RequiresHttpsException, UnauthorizedException, Serv
 from examples import examples
 from search.views import search_prepare_query
 from similarity.client import SimilarityException
+from utils.encryption import create_hash
 from utils.logging_filters import get_client_ip
 from utils.search.solr import Solr, SolrException, SolrResponseInterpreter
 from utils.similarity_utilities import api_search as similarity_api_search
@@ -74,7 +75,8 @@ class FsClientIdGenerator(BaseHashGenerator):
 def get_view_description(cls, html=False):
     description = ''
     if getattr(cls, 'get_description', None):
-        cache_key = cls.get_view_name()
+        cache_key = create_hash(cls.get_view_name(), add_secret=False, limit=32)
+        print cache_key
         cached_description = cache.get(cache_key)
         if not cached_description:
             description = cls.get_description()

--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -76,7 +76,6 @@ def get_view_description(cls, html=False):
     description = ''
     if getattr(cls, 'get_description', None):
         cache_key = create_hash(cls.get_view_name(), add_secret=False, limit=32)
-        print cache_key
         cached_description = cache.get(cache_key)
         if not cached_description:
             description = cls.get_description()


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1422

**Description**
I suspect a recent upgrade in memacache made the browsable API to fail because it tries to save and load data from cache using invalid cache keys. This is quite urgent to fix because it means browsable API does not work at al right now :)