### PR TITLE
Clear EmailBoucne objects even if changing email from admin

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -31,7 +31,6 @@ from django.contrib.auth.models import User
 from django.core.paginator import Paginator
 from django.utils.functional import cached_property
 from django.db import connection
-from django.core.cache import cache
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -39,7 +38,7 @@ from django_object_actions import DjangoObjectActions
 from django.contrib.auth.forms import UserChangeForm
 from django.forms import ValidationError
 
-from accounts.models import Profile, UserFlag, EmailPreferenceType, OldUsername
+from accounts.models import Profile, UserFlag, EmailPreferenceType, OldUsername, EmailBounce
 
 
 FULL_DELETE_USER_ACTION_NAME = 'full_delete_user'
@@ -241,16 +240,25 @@ class FreesoundUserAdmin(DjangoObjectActions, UserAdmin):
 
     change_actions = ('full_delete', 'delete_include_sounds', 'delete_preserve_sounds', )
 
+admin.site.unregister(User)
+admin.site.register(User, FreesoundUserAdmin)
+
 
 class OldUsernameAdmin(admin.ModelAdmin):
     search_fields = ('=username', )
     raw_id_fields = ('user', )
     list_display = ('user', 'username')
 
+admin.site.register(OldUsername, OldUsernameAdmin)
 
-admin.site.unregister(User)
-admin.site.register(User, FreesoundUserAdmin)
+
+class EmailBounceAdmin(admin.ModelAdmin):
+    search_fields = ('=user__username',)
+    list_display = ('user', )
+
+admin.site.register(EmailBounce, EmailBounceAdmin)
+
 
 admin.site.register(EmailPreferenceType)
 
-admin.site.register(OldUsername, OldUsernameAdmin)
+

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -495,10 +495,19 @@ post_save.connect(create_user_profile, sender=User)
 
 def presave_user(sender, instance, **kwargs):
     try:
-        old_username = User.objects.get(pk=instance.id).username
+        old_user_object = User.objects.get(pk=instance.id)
+
+        # Check if username has changed and, if so, create a OldUsername object (if does not exist)
+        old_username = old_user_object.username
         if old_username.lower() != instance.username.lower():
             # We use .get_or_create below to avoid having 2 OldUsername objects with the same user/username pair
             OldUsername.objects.get_or_create(user=instance, username=old_username)
+
+        # Check if email has change and, if so, remove existing EmailBounce objects associated to the user (if any)
+        old_email = old_user_object.email
+        if old_email != instance.email:
+            EmailBounce.objects.filter(user=instance).delete()
+
     except User.DoesNotExist:
         pass
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1152,8 +1152,8 @@ def email_reset_complete(request, uidb36=None, token=None):
     # Remove temporal mail change information from the DB
     ResetEmailRequest.objects.get(user=user).delete()
 
-    # Clear saved email bounces for old email
-    EmailBounce.objects.filter(user=user).delete()
+    # NOTE: no need to clear existing EmailBounce objects associated to this user here because it is done in
+    # a User deletion pre_save hook if we detect that email has changed
 
     # Send email to the old address notifying about the change
     tvars = {'old_email': old_email, 'user': user}


### PR DESCRIPTION
**Issue(s)**
Fixes https://github.com/MTG/freesound/issues/1323

**Description**
This PR changes the way in which `EmailBounce` objects are cleared so that it works both when users change their email through the email reset form and when an admin changes user's email though the admin page. Now `EmailBounce` objects are cleared in a `User` `pre_save` hook.