### PR TITLE
Fix syntax of logging message

### DIFF
--- a/general/management/commands/similarity_update.py
+++ b/general/management/commands/similarity_update.py
@@ -69,7 +69,7 @@ class Command(LoggingBaseCommand):
 
         limit = int(options['limit'])
         freesound_extractor_version = options['freesound_extractor_version']
-        console_logger.info(limit, freesound_extractor_version)
+        console_logger.info("limit: %s, version: %s", limit, freesound_extractor_version)
 
         if options['force']:
             to_be_added = Sound.objects.filter(analysis_state='OK', moderation_state='OK').order_by('id')[:limit]


### PR DESCRIPTION
**Description**
Cron was showing an error when running this command. We had updated from `print x, y`, to `logger.info(x, y)`, but the syntax of `logger.info` is that the first argument is a string with `%`-style string formatting and the subsequent arguments are the replacement values.