### PR TITLE
Use the database replica to read large tables when generating stats

### DIFF
--- a/environment
+++ b/environment
@@ -1,1 +1,2 @@
 DJANGO_DATABASE_URL=postgres://freesound@db/freesound
+DJANGO_RO_REPLICA_DATABASE_URL=postgres://freesound@db/freesound

--- a/freesound/local_settings.example.py
+++ b/freesound/local_settings.example.py
@@ -5,6 +5,9 @@ import os
 DEBUG = True
 DISPLAY_DEBUG_TOOLBAR = True
 
+# Use a database replica when reading some large tables
+USE_REPLICA_FOR_READS = True
+
 # Data path of the mounted data volume in docker
 DATA_PATH = '/freesound-data/'
 

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -15,7 +15,8 @@ DISPLAY_DEBUG_TOOLBAR = False
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', '___this_is_a_secret_key_that_should_not_be_used___')
 
 default_url = 'postgres://postgres@db/postgres'
-DATABASES = {'default': dj_database_url.config('DJANGO_DATABASE_URL', default=default_url)}
+DATABASES = {'default': dj_database_url.config('DJANGO_DATABASE_URL', default=default_url),
+             'ro_replica': dj_database_url.config('DJANGO_RO_REPLICA_DATABASE_URL', default=default_url)}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
@@ -85,7 +86,7 @@ CORS_ORIGIN_ALLOW_ALL = True
 AUTHENTICATION_BACKENDS = ('accounts.modelbackend.CustomModelBackend',)
 
 # This was the default serializer in django 1.6. Now we keep using it because
-# we saw some erros when running tests, in the future we should change to the
+# we saw some errors when running tests, in the future we should change to the
 # new one.
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
@@ -271,6 +272,11 @@ LOG_DOWNLOADS = False
 # Followers notifications
 MAX_EMAILS_PER_COMMAND_RUN = 1000
 NOTIFICATION_TIMEDELTA_PERIOD = datetime.timedelta(days=7)
+
+# Database replicas
+# In order to reduce load on the primary database, we can use a replica for some queries that we
+# know take a lot of resources. Configure the 'ro_replica' database and turn on this flag
+USE_REPLICA_FOR_READS = True
 
 
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Now that we have a database replica, we want to use it for some queries. Stats generation is one of the operations that historically has caused the database server to get slower, so use it for some queries.

I'm not sure about the best way to do the queries in this command. I've chosen a few of the larger tables, and manually selected the replica with the `.using()` method on a queryset.
I didn't do it with all models - what do we think here? Should we only use it for the large tables, or consistently use it on _all_ objects? The replica database will always be completely up-to-date.

Alternatively, we could use a [database router](https://docs.djangoproject.com/en/3.0/topics/db/multi-db/#using-routers) and somehow indicate that we want to use the replica for all read queries. This could be as simple as this command setting an environment variable, and us having a router that checks this environment variable and uses the replica database for all read queries.

Feedback welcome...

**Deployment steps**:
Needs local_settings in production to configure the `ro_replica` database