### PR TITLE
Use create_directories util method to always create without failing

### DIFF
--- a/accounts/tests/test_upload.py
+++ b/accounts/tests/test_upload.py
@@ -30,7 +30,7 @@ from django.urls import reverse
 
 from sounds.models import License, Sound, Pack, BulkUploadProgress
 from tags.models import Tag
-from utils.filesystem import File
+from utils.filesystem import File, create_directories
 from utils.test_helpers import create_test_files, override_uploads_path_with_temp_directory, \
     override_csv_path_with_temp_directory
 
@@ -66,7 +66,7 @@ class UserUploadAndDescribeSounds(TestCase):
         user = User.objects.create_user("testuser", password="testpass")
         self.client.login(username='testuser', password='testpass')
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        os.mkdir(user_upload_path)
+        create_directories(user_upload_path)
         create_test_files(filenames, user_upload_path)
 
         # Check that files are displayed in the template
@@ -112,7 +112,7 @@ class UserUploadAndDescribeSounds(TestCase):
         user = User.objects.create_user("testuser", password="testpass")
         self.client.login(username='testuser', password='testpass')
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        os.mkdir(user_upload_path)
+        create_directories(user_upload_path)
         create_test_files(filenames, user_upload_path)
 
         # Set license and pack data in session

--- a/similarity/gaia_wrapper.py
+++ b/similarity/gaia_wrapper.py
@@ -28,6 +28,7 @@ from gaia2 import DataSet, transform, DistanceFunctionFactory, View, Point, Vari
 from similarity_server_utils import generate_structured_dict_from_layout, get_nested_dictionary_value, \
     get_nested_descriptor_names, set_nested_dictionary_value, parse_filter_list
 import similarity_settings as sim_settings
+from utils.filesystem import create_directories
 
 logger = logging.getLogger('similarity')
 
@@ -63,8 +64,7 @@ class GaiaWrapper:
         therefore this function does not prepare or normalize loaded datasets.
         """
 
-        if not os.path.exists(sim_settings.INDEX_DIR):
-            os.makedirs(sim_settings.INDEX_DIR)
+        create_directories(sim_settings.INDEX_DIR, exist_ok=True)
 
         # load original dataset
         if os.path.exists(self.original_dataset_path):

--- a/sounds/management.py
+++ b/sounds/management.py
@@ -24,6 +24,8 @@ from django.db.models.signals import post_syncdb
 from django.dispatch import receiver
 from django.conf import settings
 
+from utils.filesystem import create_directories
+
 
 @receiver(post_syncdb)
 def create_locations(sender, **kwargs):
@@ -35,11 +37,6 @@ def create_locations(sender, **kwargs):
                    settings.DISPLAYS_PATH,
                    settings.FILE_UPLOAD_TEMP_DIR]:
         if not os.path.isdir(folder):
-            try:
-                os.mkdir(folder)
-                print ("Successfullly created the folder: '%s'" % folder)
-            except Exception as e:
-                print ("Problem creating this folder: '%s', %s"
-                    % (folder, e))
+            create_directories(folder, exist_ok=True)
         else:
             print ("Folder: '%s' already exists" % folder)

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -42,6 +42,7 @@ from sounds.models import Download, PackDownload, PackDownloadSound, SoundAnalys
 from sounds.models import Pack, Sound, License, DeletedSound
 from utils.cache import get_template_cache_key
 from utils.encryption import encrypt
+from utils.filesystem import create_directories
 from utils.test_helpers import create_user_and_sounds, override_analysis_path_with_temp_directory
 
 
@@ -1037,7 +1038,7 @@ class SoundAnalysisModel(TestCase):
         # Now create an analysis object which stores output in a JSON file. Again check that get_analysis works.
         analysis_filename = '%i_testextractor_out.json'
         sound_analysis_folder = os.path.join(settings.ANALYSIS_PATH, str(sound.id / 1000))
-        os.mkdir(sound_analysis_folder)
+        create_directories(sound_analysis_folder)
         json.dump(analysis_data, open(os.path.join(sound_analysis_folder, analysis_filename), 'w'))
         sa2 = SoundAnalysis.objects.create(sound=sound, extractor="TestExtractor2", analysis_filename=analysis_filename)
         self.assertEqual(sound.analyses.all().count(), 2)

--- a/utils/filesystem.py
+++ b/utils/filesystem.py
@@ -66,7 +66,7 @@ def generate_tree(path):
             counter += 1
             files[file_object.id] = file_object
             parent.children.append(file_object)
-            
+
     return lookups[path], files
 
 
@@ -110,20 +110,6 @@ def create_directories(path, exist_ok=True):
     except OSError as exc:
         # Ignore exception if directory already existing
         if exist_ok and exc.errno != errno.EEXIST:
-            raise
-
-
-def remove_directory(path):
-    """
-    Removes the directory at the specified path and all of its contents (including files and other direcotries).
-    No exception is raised if no direcotry exists at the given path.
-    :param str path: path of the direcotry to delete
-    """
-    try:
-        shutil.rmtree(path)
-    except OSError as e:
-        # Ignore exception if directory does not exist
-        if e.errno != errno.ENOENT:
             raise
 
 

--- a/utils/mirror_files.py
+++ b/utils/mirror_files.py
@@ -3,8 +3,7 @@ import os
 import shutil
 import logging
 import errno
-from utils.filesystem import remove_directory_if_empty
-
+from utils.filesystem import remove_directory_if_empty, create_directories
 
 web_logger = logging.getLogger('web')
 
@@ -13,14 +12,7 @@ def copy_files(source_destination_tuples):
     for source_path, destination_path in source_destination_tuples:
         if settings.LOG_START_AND_END_COPYING_FILES:
             web_logger.error('Started copying file %s to %s' % (source_path, destination_path))
-        try:
-            path = os.path.dirname(destination_path)
-            os.makedirs(path)
-        except OSError as e:  # I.e. path already exists
-            if e.errno == errno.EEXIST and os.path.isdir(path):
-                pass
-            else:
-                raise
+        create_directories(os.path.dirname(destination_path), exist_ok=True)
         try:
             shutil.copy2(source_path, destination_path)
             if settings.LOG_START_AND_END_COPYING_FILES:

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -35,7 +35,7 @@ from gearman.errors import ServerUnavailable
 from geotags.models import GeoTag
 from utils.audioprocessing import get_sound_type
 from utils.cache import invalidate_template_cache
-from utils.filesystem import md5file, remove_directory_if_empty
+from utils.filesystem import md5file, remove_directory_if_empty, create_directories
 from utils.mirror_files import copy_sound_to_mirror_locations, remove_empty_user_directory_from_mirror_locations, \
     remove_uploaded_file_from_mirror_locations
 from utils.text import slugify, remove_control_chars
@@ -60,7 +60,7 @@ class CantMoveException(Exception):
 def _remove_user_uploads_folder_if_empty(user):
     """
     Check if the user uploads folder is empty and removes it.
-    Removes user uploads folder in the "local" disk and in mirrored disks too. 
+    Removes user uploads folder in the "local" disk and in mirrored disks too.
     """
     user_uploads_dir = user.profile.locations()['uploads_dir']
     remove_directory_if_empty(user_uploads_dir)
@@ -141,10 +141,7 @@ def create_sound(user,
     sound.base_filename_slug = "%d__%s__%s" % (sound.id, slugify(sound.user.username), slugify(orig))
     new_original_path = sound.locations("path")
     if sound.original_path != new_original_path:
-        try:
-            os.makedirs(os.path.dirname(new_original_path))
-        except OSError:
-            pass
+        create_directories(os.path.dirname(new_original_path), exist_ok=True)
         try:
             shutil.move(sound.original_path, new_original_path)
 
@@ -521,8 +518,7 @@ def bulk_describe_from_csv(csv_file_path, delete_already_existing=False, force_i
 
         # Move sounds to the user upload directory (if sounds are not already there)
         user_uploads_directory = user.profile.locations()['uploads_dir']
-        if not os.path.exists(user_uploads_directory):
-            os.mkdir(user_uploads_directory)
+        create_directories(user_uploads_directory, exist_ok=True)
         src_path = os.path.join(sounds_base_dir, line_cleaned['audio_filename'])
         dest_path = os.path.join(user_uploads_directory, os.path.basename(line_cleaned['audio_filename']))
         if src_path != dest_path:

--- a/utils/tests/tests.py
+++ b/utils/tests/tests.py
@@ -35,6 +35,7 @@ from sounds.models import Sound, Pack, License, Download
 from utils.audioprocessing.freesound_audio_analysis import FreesoundAudioAnalyzer
 from utils.audioprocessing.freesound_audio_processing import FreesoundAudioProcessor
 from utils.audioprocessing.processing import AudioProcessingException
+from utils.filesystem import create_directories
 from utils.sound_upload import get_csv_lines, validate_input_csv_file, bulk_describe_from_csv, create_sound, \
     NoAudioException, AlreadyExistsException
 from utils.tags import clean_and_split_tags
@@ -69,7 +70,7 @@ class UtilsTest(TestCase):
         filenames = ['file1.wav', 'file2.wav']
         user = User.objects.create_user("testuser", password="testpass")
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        os.mkdir(user_upload_path)
+        create_directories(user_upload_path)
         create_test_files(filenames, user_upload_path)
         shutil.copyfile(user_upload_path + filenames[0], user_upload_path + "copy.wav")
         license = License.objects.all()[0]
@@ -271,12 +272,12 @@ class BulkDescribeUtils(TestCase):
         # Create user uploads folder and test audio files
         user = User.objects.create_user("testuser", password="testpass")
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        os.mkdir(user_upload_path)
+        create_directories(user_upload_path)
         create_test_files(['file1.wav', 'file2.wav', 'file3.wav', 'file4.wav', 'file5.wav'], user_upload_path)
 
         # Create CSV files folder with descriptions
         csv_file_base_path = settings.CSV_PATH + '/%i/' % user.id
-        os.mkdir(csv_file_base_path)
+        create_directories(csv_file_base_path)
 
         # Test CSV with all lines and metadata ok
         csv_file_path = self.create_file_with_lines('test_descriptions.csv', [
@@ -389,7 +390,6 @@ class BulkDescribeUtils(TestCase):
         self.assertTrue('username' in lines_validated[0]['line_errors'])  # User does not exist
         self.assertTrue('columns' in lines_validated[1]['line_errors'])  # Invalid number of columns
 
-
     @override_uploads_path_with_temp_directory
     @override_csv_path_with_temp_directory
     def test_bulk_describe_from_csv(self):
@@ -397,12 +397,12 @@ class BulkDescribeUtils(TestCase):
         # Create user uploads folder and test audio files
         user = User.objects.create_user("testuser", password="testpass")
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        os.mkdir(user_upload_path)
+        create_directories(user_upload_path)
         create_test_files(['file1.wav', 'file2.wav', 'file3.wav', 'file4.wav', 'file5.wav'], user_upload_path)
 
         # Create CSV files folder with descriptions
         csv_file_base_path = settings.CSV_PATH + '/%i/' % user.id
-        os.mkdir(csv_file_base_path)
+        create_directories(csv_file_base_path)
 
         # Create Test CSV with some lines ok and some wrong lines
         csv_file_path = self.create_file_with_lines('test_descriptions.csv', [


### PR DESCRIPTION
**Issue(s)**
Fixes #1440 

**Description**
We had many places where we were creating directories with different methods, and reporting different log messages depending on if the operation failed or succeeded.
Use the standard `create_directories` method that we already had, instead of using os.mkdir or os.makedirs.

**Deployment steps**:
Should be nothing specific
