### PR TITLE
Download list of all downloaded sounds

### DIFF
--- a/accounts/tests/test_views.py
+++ b/accounts/tests/test_views.py
@@ -26,7 +26,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from accounts.models import OldUsername
-from sounds.models import SoundOfTheDay
+from sounds.models import SoundOfTheDay, Download, PackDownload
 from utils.test_helpers import create_user_and_sounds
 
 
@@ -35,15 +35,19 @@ class SimpleUserTest(TestCase):
     fixtures = ['licenses']
 
     def setUp(self):
-        user, _, sounds = create_user_and_sounds()
+        user, packs, sounds = create_user_and_sounds(num_packs=1)
         self.user = user
         self.sound = sounds[0]
+        self.pack = packs[0]
         self.sound.moderation_state = "OK"
         self.sound.processing_state = "OK"
         self.sound.analysis_state = "OK"
         self.sound.similarity_state = "OK"
         self.sound.save()
         SoundOfTheDay.objects.create(sound=self.sound, date_display=datetime.date.today())
+        Download.objects.create(user=self.user, sound=self.sound, license=self.sound.license,
+                                created=self.sound.created)
+        PackDownload.objects.create(user=self.user, pack=self.pack, created=self.pack.created)
 
     def test_account_response_ok(self):
         # 200 response on account access
@@ -103,6 +107,25 @@ class SimpleUserTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         resp = self.client.get(reverse('user-following-tags', kwargs={'username': self.user.username}))
         self.assertEqual(resp.status_code, 200)
+
+    def test_download_attribution_csv(self):
+        self.client.force_login(self.user)
+        # 200 response on download attribution as csv
+        resp = self.client.get(reverse('accounts-download-attribution') + '?dl=csv')
+        self.assertEqual(resp.status_code, 200)
+        # response content as expected
+        self.assertEqual(resp.content, 'Download Type,File Name,User,License\r\n'
+                         + 'P,Test pack 0,testuser,Test pack 0\r\n'
+                         + 'S,Test sound 0,testuser,Sampling+\r\n')
+
+    def test_download_attribution_txt(self):
+        self.client.force_login(self.user)
+        # 200 response on download attribution as txt
+        resp = self.client.get(reverse('accounts-download-attribution') + '?dl=txt')
+        self.assertEqual(resp.status_code, 200)
+        # response content as expected
+        self.assertEqual(resp.content, 'P: Test pack 0 by testuser | License: Test pack 0\n'
+                         + 'S: Test sound 0 by testuser | License: Sampling+\n')
 
     @mock.patch('gearman.GearmanClient.submit_job')
     def test_sounds_response_ok(self, submit_job):

--- a/accounts/tests/test_views.py
+++ b/accounts/tests/test_views.py
@@ -115,8 +115,8 @@ class SimpleUserTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         # response content as expected
         self.assertEqual(resp.content, 'Download Type,File Name,User,License\r\n'
-                         + 'P,Test pack 0,testuser,Test pack 0\r\n'
-                         + 'S,Test sound 0,testuser,Sampling+\r\n')
+                         + 'P,%s,%s,%s\r\n' % (self.pack, self.user.username, self.pack)
+                         + 'S,%s,%s,%s\r\n' % (self.sound.original_filename, self.user.username, self.sound.license))
 
     def test_download_attribution_txt(self):
         self.client.force_login(self.user)
@@ -124,8 +124,9 @@ class SimpleUserTest(TestCase):
         resp = self.client.get(reverse('accounts-download-attribution') + '?dl=txt')
         self.assertEqual(resp.status_code, 200)
         # response content as expected
-        self.assertEqual(resp.content, 'P: Test pack 0 by testuser | License: Test pack 0\n'
-                         + 'S: Test sound 0 by testuser | License: Sampling+\n')
+        self.assertEqual(resp.content, 'P: %s by %s | License: %s\n' % (self.pack, self.user.username, self.pack)
+                         + 'S: %s by %s | License: %s\n'
+                         % (self.sound.original_filename, self.user.username, self.sound.license))
 
     @mock.patch('gearman.GearmanClient.submit_job')
     def test_sounds_response_ok(self, submit_job):

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -57,6 +57,7 @@ urlpatterns = [
     url(r'^delete/$', accounts.delete, name="accounts-delete"),
     url(r'^pending/$', accounts.pending, name="accounts-pending"),
     url(r'^attribution/$', accounts.attribution, name="accounts-attribution"),
+    url(r'^download-attribution/$', accounts.download_attribution, name="accounts-download-attribution"),
     url(r'^stream/$', follow.stream, name='stream'),
 
     url(r'^upload/$', accounts.upload, name="accounts-upload", kwargs=dict(no_flash=True)),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -710,18 +710,17 @@ def describe_sounds(request):
 
 @login_required
 def attribution(request):
-
     qs_sounds = Download.objects.annotate(download_type=Value("sound", CharField()))\
         .values('download_type', 'sound_id', 'sound__user__username', 'sound__original_filename',
                 'license__name', 'sound__license__name', 'created').filter(user=request.user)
     qs_packs = PackDownload.objects.annotate(download_type=Value("pack", CharField()))\
         .values('download_type', 'pack_id', 'pack__user__username', 'pack__name', 'pack__name',
                 'pack__name', 'created').filter(user=request.user)
-    # NOTE: in the query above we duplicate 'pack__name' so that qs_packs has same num columns than qs_sounds. This is
+    # NOTE: in the query above we duplciate 'pack__name' so that qs_packs has same num columns than qs_sounds. This is
     # a requirement for doing QuerySet.union below. Also as a result of using QuerySet.union, the names of the columns
     # (keys in each dictionary element) are unified and taken from the main query set. This means that after the union,
     # queryset entries corresponding to PackDownload will have corresponding field names from entries corresponding to
-    # Download. Therefore to access the pack_id (which is the second value in the list), you'll need to do
+    # Download. Therefre to access the pack_id (which is the second value in the list), you'll need to do
     # item['sound_id'] instead of item ['pack_id']. See the template of this view for an example of this.
     qs = qs_sounds.union(qs_packs).order_by('-created')
 
@@ -732,7 +731,6 @@ def attribution(request):
 
 @login_required
 def download_attribution(request):
-
     content = {"csv": {"style": "csv", "pattern": "%s,%s,%s,%s\n"},
                "txt": {"style": "plain", "pattern": "%s: %s by %s | License: %s\n"}}
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -710,23 +710,48 @@ def describe_sounds(request):
 
 @login_required
 def attribution(request):
+
+    def render_line(style, download_type, filename, username, license):
+        if style == "csv":
+            return ",".join([download_type, filename, username, license]) + "\n"
+        elif style == "txt":
+            return "%s: %s by %s | License: %s" % (download_type[0].upper(), filename, username, license) + "\n"
+        else:
+            return ""
+
     qs_sounds = Download.objects.annotate(download_type=Value("sound", CharField()))\
         .values('download_type', 'sound_id', 'sound__user__username', 'sound__original_filename',
                 'license__name', 'sound__license__name', 'created').filter(user=request.user)
     qs_packs = PackDownload.objects.annotate(download_type=Value("pack", CharField()))\
         .values('download_type', 'pack_id', 'pack__user__username', 'pack__name', 'pack__name',
                 'pack__name', 'created').filter(user=request.user)
-    # NOTE: in the query above we duplciate 'pack__name' so that qs_packs has same num columns than qs_sounds. This is
+    # NOTE: in the query above we duplicate 'pack__name' so that qs_packs has same num columns than qs_sounds. This is
     # a requirement for doing QuerySet.union below. Also as a result of using QuerySet.union, the names of the columns
     # (keys in each dictionary element) are unified and taken from the main query set. This means that after the union,
     # queryset entries corresponding to PackDownload will have corresponding field names from entries corresponding to
-    # Download. Therefre to access the pack_id (which is the second value in the list), you'll need to do
+    # Download. Therefore to access the pack_id (which is the second value in the list), you'll need to do
     # item['sound_id'] instead of item ['pack_id']. See the template of this view for an example of this.
     qs = qs_sounds.union(qs_packs).order_by('-created')
 
-    tvars = {'format': request.GET.get("format", "regular")}
-    tvars.update(paginate(request, qs, 40))
-    return render(request, 'accounts/attribution.html', tvars)
+    download = request.GET.get("dl", "")
+    if download in ["csv", "txt"]:
+        content = {"csv": "csv", "txt": "plain"}
+        response = HttpResponse(content_type='text/%s' % content[download])
+        response['Content-Disposition'] = 'attachment; filename="attribution.%s"' % download
+        output = []
+        if download == "csv":
+            output.append('Download Type,File Name,User,License\n')
+        for row in qs:
+            output.append(render_line(download, row["download_type"], row["sound__original_filename"],
+                                      row["sound__user__username"],
+                                      row["license__name"] or row["sound__license__name"]))
+        response.writelines(output)
+        response.close()
+        return response
+    else:
+        tvars = {'format': request.GET.get("format", "regular")}
+        tvars.update(paginate(request, qs, 40))
+        return render(request, 'accounts/attribution.html', tvars)
 
 
 @redirect_if_old_username_or_404

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -25,6 +25,8 @@ import logging
 import os
 import tempfile
 import uuid
+import cStringIO
+import csv
 
 import gearman
 from django.conf import settings
@@ -731,31 +733,36 @@ def attribution(request):
 
 @login_required
 def download_attribution(request):
-    content = {"csv": {"style": "csv", "pattern": "%s,%s,%s,%s\n"},
-               "txt": {"style": "plain", "pattern": "%s: %s by %s | License: %s\n"}}
+    content = {'csv': 'csv', 'txt': 'plain'}
 
-    qs_sounds = Download.objects.annotate(download_type=Value("sound", CharField()))\
+    qs_sounds = Download.objects.annotate(download_type=Value('sound', CharField()))\
         .values('download_type', 'sound_id', 'sound__user__username', 'sound__original_filename',
                 'license__name', 'sound__license__name', 'created').filter(user=request.user)
-    qs_packs = PackDownload.objects.annotate(download_type=Value("pack", CharField()))\
+    qs_packs = PackDownload.objects.annotate(download_type=Value('pack', CharField()))\
         .values('download_type', 'pack_id', 'pack__user__username', 'pack__name', 'pack__name',
                 'pack__name', 'created').filter(user=request.user)
     # NOTE: see the above view, attribution.
     qs = qs_sounds.union(qs_packs).order_by('-created')
 
-    download = request.GET.get("dl", "")
-    if download in ["csv", "txt"]:
-        response = HttpResponse(content_type='text/%s' % content[download]["style"])
-        response['Content-Disposition'] = 'attachment; filename="attribution.%s"' % download
-        output = []
-        if download == "csv":
-            output.append('Download Type,File Name,User,License\n')
-        for row in qs:
-            output.append(content[download]["pattern"] % (row["download_type"][0].upper(),
-                                                          row["sound__original_filename"],
-                                                          row["sound__user__username"],
-                                                          row["license__name"] or row["sound__license__name"]))
-        response.writelines(output)
+    download = request.GET.get('dl', '')
+    if download in ['csv', 'txt']:
+        now = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+        filename = '%s_%s_attribution.%s' % (request.user, now, download)
+        response = HttpResponse(content_type='text/%s' % content[download])
+        response['Content-Disposition'] = 'attachment; filename="%s"' % filename
+        output = cStringIO.StringIO()
+        if download == 'csv':
+            output.write('Download Type,File Name,User,License\r\n')
+            csv_writer = csv.writer(output, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+            for row in qs:
+                csv_writer.writerow([row['download_type'][0].upper(), row['sound__original_filename'],
+                                    row['sound__user__username'], row['license__name'] or row['sound__license__name']])
+        elif download == 'txt':
+            for row in qs:
+                output.write("%s: %s by %s | License: %s\n" % (row['download_type'][0].upper(),
+                             row['sound__original_filename'], row['sound__user__username'],
+                             row['license__name'] or row['sound__license__name']))
+        response.writelines(output.getvalue())
         response.close()
         return response
     else:

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -763,7 +763,6 @@ def download_attribution(request):
                              row['sound__original_filename'], row['sound__user__username'],
                              row['license__name'] or row['sound__license__name']))
         response.writelines(output.getvalue())
-        response.close()
         return response
     else:
         return HttpResponseRedirect(reverse('accounts-attribution'))

--- a/templates/accounts/attribution.html
+++ b/templates/accounts/attribution.html
@@ -12,7 +12,7 @@
 <p>
 	This is the list of files you have downloaded. When you use freesound samples (under the "attribution" or "attribution non-commercial license"), you have to <a href="{% url "wiki-page" "faq" %}#how-do-i-creditattribute">credit the original creator of the sound</a> in your work. This list makes it a little bit easier to do so. "S" means sound, "P" means pack.<br/>
 	There are 3 flavors of this list: <a href="?format=regular">regular</a>, <a href="?format=html">html</a> or <a href="?format=plaintext">plain text</a>.
-    <br/>You can also download the complete list as <a href="?dl=csv">csv</a> or <a href="?dl=txt">plain text</a>.
+    <br/>You can also download the complete list as <a href="{% url "accounts-download-attribution" %}?dl=csv">csv</a> or <a href="{% url "accounts-download-attribution" %}?dl=txt">plain text</a>.
 </p>
 
 <div class="attribution_objects">

--- a/templates/accounts/attribution.html
+++ b/templates/accounts/attribution.html
@@ -12,6 +12,7 @@
 <p>
 	This is the list of files you have downloaded. When you use freesound samples (under the "attribution" or "attribution non-commercial license"), you have to <a href="{% url "wiki-page" "faq" %}#how-do-i-creditattribute">credit the original creator of the sound</a> in your work. This list makes it a little bit easier to do so. "S" means sound, "P" means pack.<br/>
 	There are 3 flavors of this list: <a href="?format=regular">regular</a>, <a href="?format=html">html</a> or <a href="?format=plaintext">plain text</a>.
+    <br/>You can also download the complete list as <a href="?dl=csv">csv</a> or <a href="?dl=txt">plain text</a>.
 </p>
 
 <div class="attribution_objects">


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1451

**Description**
This PR provides users a way to download a list of all the sounds they've downloaded, as csv or plain text.
It's accessible via new links in the attribution page, pointing to a new dedicated view, `download_attribution`.
The new view has the same object selection as the `attribution` one it derives from, and serves the whole list without pagination as a downloadable file (direct write into the response with the appropriate headers), in the format specified via the `dl` query parameter. The currently handled values for the parameter are `txt` and `csv`.

