### PR TITLE
Handle bug with unexisting sound when creating DeletedSound object

### DIFF
--- a/sounds/models.py
+++ b/sounds/models.py
@@ -1213,7 +1213,15 @@ def on_delete_sound(sender, instance, **kwargs):
         # Note: we do not store information about individual downloads and ratings, we only
         # store count and average (for ratings). We do not store at all information about bookmarks.
 
-        data = Sound.objects.filter(pk=instance.pk).values()[0]
+        try:
+            data = Sound.objects.filter(pk=instance.pk).values()[0]
+        except IndexError:
+            # The sound being deleted can't be found on the database. This might happen if a sound is being deleted
+            # multiple times concurrently, and in one "thread" the sound object has already been deleted when reaching
+            # this part of the code. If that happens, return form this function without creating the DeletedSound
+            # object nor doing any of the other steps as this will have been already carried out.
+            return
+
         pack = None
         if instance.pack:
             pack = Pack.objects.filter(pk=instance.pack.pk).values()[0]


### PR DESCRIPTION
**Issue(s)**
https://github.com/mtg/freesound/issues/1131

**Description**
This PR provides a solution for a bug that happens when trying to create a `DeletedSound` object for a `Sound` that no longer exists. This happens rarely, but we registered some of these errors in Sentry. Our hypothesis is that this happens if a sound is being deleted concurrently multiple times, and in one of the processes the `Sound` object has already been deleted when running the `on_delete_sound` signal code. The proposed solution adds a `try/except` in the `on_delete_sound` signal code so that if the sound no longer exists in the DB, it is assumed that the delete process has already been carried out and the function returns without performing any changes nor creating any `DeletedSound` object.

I'm not adding a test for this because I'm not sure how to test this error caused by concurrency. However, the creation of `DeletedSound` objects is already being tested so this PR should not break existing functionality.

