### PR TITLE
Handle Zendesk API exceptions and log them

### DIFF
--- a/support/views.py
+++ b/support/views.py
@@ -28,7 +28,7 @@ from django.urls import reverse
 from requests.exceptions import HTTPError
 from zenpy import Zenpy
 from zenpy.lib import api_objects as zendesk_api
-from zenpy.lib.exception import APIException as ZendeskAPIException
+from zenpy.lib.exception import APIException as ZendeskAPIException, ZenpyException
 
 from comments.models import Comment
 from support.forms import ContactForm
@@ -92,7 +92,7 @@ def send_to_zendesk(request_email, subject, message, user=None):
     )
     try:
         zenpy.tickets.create(ticket)
-    except (ZendeskAPIException, HTTPError) as e:
+    except (ZendeskAPIException, HTTPError, ZenpyException) as e:
         web_logger.info('Error creating Zendesk ticket: {}'.format(str(e)))
 
 

--- a/support/views.py
+++ b/support/views.py
@@ -25,6 +25,7 @@ from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.shortcuts import render
 from django.urls import reverse
+from requests.exceptions import HTTPError
 from zenpy import Zenpy
 from zenpy.lib import api_objects as zendesk_api
 from zenpy.lib.exception import APIException as ZendeskAPIException
@@ -91,7 +92,7 @@ def send_to_zendesk(request_email, subject, message, user=None):
     )
     try:
         zenpy.tickets.create(ticket)
-    except ZendeskAPIException as e:
+    except (ZendeskAPIException, HTTPError) as e:
         web_logger.info('Error creating Zendesk ticket: {}'.format(str(e)))
 
 

--- a/support/views.py
+++ b/support/views.py
@@ -18,16 +18,22 @@
 #     See AUTHORS file.
 #
 
+import logging
+
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
-from django.urls import reverse
 from django.shortcuts import render
-from django.conf import settings
-from support.forms import ContactForm
-from utils.mail import send_mail_template_to_support
+from django.urls import reverse
 from zenpy import Zenpy
 from zenpy.lib import api_objects as zendesk_api
+from zenpy.lib.exception import APIException as ZendeskAPIException
+
 from comments.models import Comment
+from support.forms import ContactForm
+from utils.mail import send_mail_template_to_support
+
+web_logger = logging.getLogger('web')
 
 
 def create_zendesk_ticket(request_email, subject, message, user=None):
@@ -83,7 +89,10 @@ def send_to_zendesk(request_email, subject, message, user=None):
         token=settings.ZENDESK_TOKEN,
         subdomain='freesound'
     )
-    zenpy.tickets.create(ticket)
+    try:
+        zenpy.tickets.create(ticket)
+    except ZendeskAPIException as e:
+        web_logger.info('Error creating Zendesk ticket: {}'.format(str(e)))
 
 
 def send_email_to_support(request_email, subject, message, user=None):


### PR DESCRIPTION
**Issue(s)**
https://github.com/mtg/freesound/issues/1463
https://logserver.mtg.upf.edu/organizations/sentry/issues/1730/ (Sentry)
https://logserver.mtg.upf.edu/organizations/sentry/issues/1739/ (Sentry)

**Description**
Sometimes when trying to create a support ticket in Zendesk using the Zendesk API, an exception is raised (from Zendesk). The case we observed so far happens when we try to create many tickets in a short amount of time. This can happen if someone is trying to abuse the contact form, and Zendesk blocks this activity. This does not have any major impact on our contact form because, apparently, Zendesk API works normally after this suspension which is probably temporary or based on IP or something. In this PR we add a try/except to catch this exception and log the error accordingly.

**Deployment**
After this PR is merged and deployed, we should add a "counter" for such errors somewhere in graylog, so we see them if they happen.
