### PR TITLE
Make email comparissons of SameUser case insensitive

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -476,10 +476,10 @@ class SameUser(models.Model):
         return transform_unique_email(self.orig_email)
 
     def main_user_changed_email(self):
-        return self.main_user.email != self.main_trans_email
+        return self.main_user.email.lower() != self.main_trans_email.lower()
 
     def secondary_user_changed_email(self):
-        return self.secondary_user.email != self.secondary_trans_email
+        return self.secondary_user.email.lower() != self.secondary_trans_email.lower()
 
 
 def create_user_profile(sender, instance, created, **kwargs):


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1207

**Description**
In the past we made a number of changes to treat emails as case insensitive, however email comparisons in the `SameUser`  model methods were still case sensitive. This PR makes them case insensitive and fixes a but that occurred when an email was supposed to have changed but only the case did. 

I'm not adding a test for this because I think it is quite complicated and it should not happen again because we are now forcing case insensitiveness in emails at the DB level...
