### PR TITLE
Fix server error changing email in admin

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -151,6 +151,15 @@ class AdminUserForm(UserChangeForm):
         raise ValidationError("This username is already taken or has been in used in the past by this or some other "
                               "user.")
 
+    def clean_email(self):
+        # Check that email is not being used by another user (case insensitive)
+        email = self.cleaned_data["email"]
+        try:
+            User.objects.exclude(pk=self.instance.id).get(email__iexact=email)
+        except User.DoesNotExist:
+            return email
+        raise ValidationError("This email is already being used by another user.")
+
 
 class FreesoundUserAdmin(DjangoObjectActions, UserAdmin):
     search_fields = ('=username', '=email')

--- a/accounts/tests/test_user.py
+++ b/accounts/tests/test_user.py
@@ -735,6 +735,40 @@ class ChangeUsernameTest(TestCase):
         self.assertEqual(OldUsername.objects.filter(username='userA', user=userA).count(), 0)
 
 
+class ChangeEmailViaAdminTestCase(TestCase):
+
+    def test_change_email_form_admin(self):
+        User.objects.create_user('superuser', password='testpass', is_superuser=True, is_staff=True)
+        self.client.login(username='superuser', password='testpass')
+
+        # Create user and get admin change url
+        userA = User.objects.create_user('userA', email='userA@freesound.org', password='testpass')
+        admin_change_url = reverse('admin:auth_user_change', args=[userA.id])
+
+
+        # Try to change email to some other (unused email)
+        new_email = 'aNewEmail@freesound.org'
+        post_data = {'username': userA.username,
+                     'email': new_email,
+                     'date_joined_0': "2015-10-06", 'date_joined_1': "16:42:00"}  # date_joined required
+        resp = self.client.post(admin_change_url, data=post_data)
+        self.assertRedirects(resp, reverse('admin:auth_user_changelist'))  # Successful edit redirects to users list
+        userA.refresh_from_db()
+        self.assertEqual(userA.email, new_email)
+
+        # Now create another user with a different email, and try to change userA email to the email of the new user
+        userB = User.objects.create_user('userB', email='userBA@freesound.org', password='testpass')
+        post_data = {'username': userA.username,
+                     'email': userB.email,
+                     'date_joined_0': "2015-10-06", 'date_joined_1': "16:42:00"}  # date_joined required
+        resp = self.client.post(admin_change_url, data=post_data)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(bool(resp.context['adminform'].errors), True)  # Error in email field
+        self.assertIn('This email is already being used by another user', str(resp.context['adminform'].errors))
+        userA.refresh_from_db()
+        self.assertEqual(userA.email, new_email)  # Email has not been changed
+
+
 class UsernameValidatorTest(TestCase):
     """ Makes sure that username validation works as intended """
 


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1394

**Description**
This PR adds an email validator in the custom admin form to check if the selected email is being used by another account in Freesound and, if so, raise a `ValidationError` instead of triggering a server error when trying to set new email and violating unique/case-insensitive DB constraint.

