### PR TITLE
Correctly pluralize "comment" when there is more than 1

### DIFF
--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -128,7 +128,7 @@
             </ul>
 
             <div id="comments_pagination">
-                {% show_paginator paginator page current_page request "comments" %}
+                {% show_paginator paginator page current_page request "comment" %}
             </div>
         {%  else %}
             <p><br>This sound has not been commented on yet, be the first to comment!</p>


### PR DESCRIPTION
**Issue(s)**
Reported at https://twitter.com/freesounddev/status/1308782566548353025

**Description**
This is the only instance of the pager that had this argument as a plural instead of singular.
