### PR TITLE
Fix ascii decoding error in paginator

### DIFF
--- a/general/templatetags/paginator.py
+++ b/general/templatetags/paginator.py
@@ -49,7 +49,8 @@ def show_paginator(context, paginator, page, current_page, request, anchor="", n
     # although paginator objects are 0-based, we use 1-based paging
     page_numbers = [n for n in range(min_page_num, max_page_num) if n > 0 and n <= paginator.num_pages]
 
-    params = urllib.urlencode([(key, value.encode('utf-8')) for (key, value) in request.GET.items() if key.lower() != u"page"])
+    params = urllib.urlencode([(key.encode('utf-8'), value.encode('utf-8')) for (key, value) in request.GET.items()
+                               if key.lower() != u"page"])
 
     if params == "":
         url = request.path + u"?page="

--- a/general/tests.py
+++ b/general/tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -19,10 +21,14 @@
 #
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+from django.urls import reverse
 
 from forum.models import Thread, Post, Forum
+from general.templatetags.paginator import show_paginator
 from ratings.models import SoundRating
+from sounds.models import Sound
+from utils.pagination import paginate
 from utils.test_helpers import create_user_and_sounds
 
 
@@ -123,3 +129,24 @@ class ReportCountStatusesManagementCommandTestCase(TestCase):
         self.assertEqual(sound.avg_rating, 4)
         self.assertEqual(sound.num_comments, 1)
         self.assertEqual(sound.num_downloads, 0)
+
+
+class PaginatorTestCase(TestCase):
+
+    def test_url_with_non_ascii_characters(self):
+        """Paginator objects are passed a request object which includes a list of request GET parameters and values.
+        The paginator uses this object to get parameters like the current page that is requested, and also to construct
+        pagination links which contain all the same GET parameters as the initial request so that whatever things
+        are determined there, will be preserved when moving to the next page. To do that the paginator iterates over
+        all GET parameters and values. This test checks that if non-ascii characters are passed as GET parameter names
+        or values, paginator does not break.
+        """
+        context = {'media_url': 'fake URL'}
+        text_with_non_ascii = u'�textèé'
+        dummy_request = RequestFactory().get(reverse('sounds'), {
+            text_with_non_ascii: '1',
+            'param_name': text_with_non_ascii,
+            'param2_name': 'ok_value',
+        })
+        paginator = paginate(dummy_request, Sound.objects.all(), 10)
+        show_paginator(context, paginator['paginator'], paginator['page'], paginator['current_page'], dummy_request)

--- a/templates/sounds/tags.html
+++ b/templates/sounds/tags.html
@@ -121,7 +121,7 @@
 
         {% if multiple_tags %}
             <h1>Sounds with {{ multiple_tags|length|pluralize:"this,these" }} tag{{ multiple_tags|length|pluralize }}</h1>
-            {% if num_results > 0 %}
+            {% if non_grouped_number_of_results > 0 %}
                 <div class="search_paginator">
                     {% show_paginator paginator page current_page request "sound" non_grouped_number_of_results %}
                 </div>


### PR DESCRIPTION
**Issue(s)**
#1491

**Description**
Paginator objects are passed a request object which includes a list of request GET parameters and values. The paginator uses this object to get parameters like the current page that is requested, and also to construct pagination links which contain all the same GET parameters as the initial request so that whatever things are determined there, will be preserved when moving to the next page. To do that the paginator iterates over all GET parameters and values. This PR adds proper handling of non-ascii characters in the GET parameters passed to the paginator. Even though the original issue was caused by some attacker trying things in the browse tags page, this PR should fix the same error happening in any page using the paginator.

Also in this PR I included a small refactor of tags view, see commit message in https://github.com/MTG/freesound/pull/1492/commits/fb6b85833496987b6f8fb68a379eb3388bfe2ae5
