### PR TITLE
BW follow modals optimizations

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -391,8 +391,9 @@ def home(request):
         new_posts = Post.objects.filter(moderation_state='NM').count()
 
     # Followers
-    following, followers, following_tags, following_count, followers_count, following_tags_count \
-        = follow_utils.get_vars_for_home_view(user)
+    following = follow_utils.get_users_following_qs(user)
+    followers = follow_utils.get_users_followers_qs(user)
+    following_tags = follow_utils.get_tags_following_qs(user)
 
     current_bulkdescribe = BulkUploadProgress.objects.filter(user=user).exclude(progress_type="C")
     tvars = {
@@ -409,9 +410,6 @@ def home(request):
         'following': following,
         'followers': followers,
         'following_tags': following_tags,
-        'following_count': following_count,
-        'followers_count': followers_count,
-        'following_tags_count': following_tags_count,
         'tags': tags,
     }
     return render(request, 'accounts/account.html', tvars)
@@ -981,8 +979,9 @@ def account(request, username):
     latest_sounds = list(Sound.objects.bulk_sounds_for_user(user.id, settings.SOUNDS_PER_PAGE))
     latest_packs = Pack.objects.select_related().filter(user=user, num_sounds__gt=0).exclude(is_deleted=True) \
                                 .order_by("-last_updated")[0:10 if not using_beastwhoosh(request) else 15]
-    following, followers, following_tags, following_count, followers_count, following_tags_count = \
-        follow_utils.get_vars_for_account_view(user)
+    following = follow_utils.get_users_following_qs(user)
+    followers = follow_utils.get_users_followers_qs(user)
+    following_tags = follow_utils.get_tags_following_qs(user)
     follow_user_url = reverse('follow-user', args=[username])
     unfollow_user_url = reverse('unfollow-user', args=[username])
     show_unfollow_button = request.user.is_authenticated() and follow_utils.is_user_following_user(request.user, user)
@@ -1001,31 +1000,21 @@ def account(request, username):
                   or user.profile.num_sounds > 0)  # user has uploads
 
     tvars = {
+        'home': request.user == user if using_beastwhoosh(request) else False,
         'user': user,
         'tags': tags,
         'latest_sounds': latest_sounds,
         'latest_packs': latest_packs,
-        'following_count': following_count,
-        'followers_count': followers_count,
-        'following_tags_count': following_tags_count,
         'follow_user_url': follow_user_url,
+        'following': following,
+        'followers': followers,
+        'following_tags': following_tags,
         'unfollow_user_url': unfollow_user_url,
         'show_unfollow_button': show_unfollow_button,
         'has_bookmarks': has_bookmarks,
         'show_about': show_about,
         'num_sounds_pending_count': num_sounds_pending_count,
     }
-    if using_beastwhoosh(request):
-        tvars.update({
-            'home': request.user == user
-        })
-    else:
-        tvars.update({
-            'home': False,
-            'following': following,
-            'followers': followers,
-            'following_tags': following_tags
-        })
     return render(request, 'accounts/account.html', tvars)
 
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1014,6 +1014,9 @@ def account(request, username):
         'has_bookmarks': has_bookmarks,
         'show_about': show_about,
         'num_sounds_pending_count': num_sounds_pending_count,
+        'following_modal_page': request.GET.get('following', 1),  # BW only, used to load a specific modal page
+        'followers_modal_page': request.GET.get('followers', 1),  # BW only
+        'following_tags_modal_page': request.GET.get('followingTags', 1),  # BW only
     }
     return render(request, 'accounts/account.html', tvars)
 

--- a/follow/follow_utils.py
+++ b/follow/follow_utils.py
@@ -32,68 +32,36 @@ import urllib
 SOLR_QUERY_LIMIT_PARAM = 3
 
 
+def get_users_following_qs(user):
+    return FollowingUserItem.objects.select_related('user_to__profile').filter(user_from=user)
+
+
 def get_users_following(user):
-    items = FollowingUserItem.objects.select_related('user_to__profile').filter(user_from=user)
-    return [item.user_to for item in items]
+    return [item.user_to for item in get_users_following_qs(user)]
+
+
+def get_users_followers_qs(user):
+    return FollowingUserItem.objects.select_related('user_from__profile').filter(user_to=user)
 
 
 def get_users_followers(user):
-    items = FollowingUserItem.objects.select_related('user_from__profile').filter(user_to=user)
-    return [item.user_from for item in items]
+    return [item.user_from for item in get_users_followers_qs(user)]
+
+
+def get_tags_following_qs(user):
+    return FollowingQueryItem.objects.filter(user=user)
 
 
 def get_tags_following(user):
-    items = FollowingQueryItem.objects.filter(user=user)
-    return [item.query for item in items]
+    return [item.query for item in get_tags_following_qs(user)]
 
 
 def is_user_following_user(user_from, user_to):
-    return user_to in get_users_following(user=user_from)
+    return FollowingUserItem.objects.filter(user_from=user_from, user_to=user_to).exists()
 
 
 def is_user_following_tag(user, slash_tag):
-    tags_following = get_tags_following(user)
-    space_tag = slash_tag.replace("/", " ")
-    return space_tag in tags_following
-
-
-def is_user_being_followed_by_user(user_from, user_to):
-    return user_to in get_users_followers(user_from)
-
-
-def get_vars_for_account_view(user):
-    return get_vars_for_views_helper(user, clip=True)
-
-
-def get_vars_for_home_view(user):
-    return get_vars_for_views_helper(user, clip=False)
-
-
-def get_vars_for_views_helper(user, clip):
-
-    following = get_users_following(user)
-    followers = get_users_followers(user)
-    following_tags = get_tags_following(user)
-
-    following_count = len(following)
-    followers_count = len(followers)
-    following_tags_count = len(following_tags)
-
-    # show only the first 21 (3 rows) followers and following users and 5 following tags
-    if clip:
-        following = following[:21]
-        followers = followers[:21]
-        following_tags = following_tags[:5]
-
-    space_tags = following_tags
-    split_tags = [tag.split(" ") for tag in space_tags]
-    slash_tags = [tag.replace(" ", "/") for tag in space_tags]
-
-    following_tags = []
-    for i in range(len(space_tags)):
-        following_tags.append((space_tags[i], slash_tags[i], split_tags[i]))
-
-    return following, followers, following_tags, following_count, followers_count, following_tags_count
+    return FollowingQueryItem.objects.filter(user=user, query=slash_tag.replace("/", " ")).exists()
 
 
 def get_stream_sounds(user, time_lapse):

--- a/follow/models.py
+++ b/follow/models.py
@@ -39,12 +39,21 @@ class FollowingUserItem(models.Model):
 
 class FollowingQueryItem(models.Model):
     user = models.ForeignKey(User)
-    # TODO: refactor to tags instead of query
+    # TODO: refactor this to name it "tags" instead of "query"
     query = models.TextField()
     created = models.DateTimeField(auto_now_add=True)
 
     def __unicode__(self):
         return u"%s following tag '%s'" % (self.user, self.query)
+
+    def get_slash_tags(self):
+        return self.query.replace(" ", "/")
+
+    def get_split_tags(self):
+        return self.query.split(" ")
+
+    def get_space_tags(self):
+        return self.query
 
     class Meta:
         verbose_name_plural = 'Tags'

--- a/follow/views.py
+++ b/follow/views.py
@@ -63,7 +63,7 @@ def following_users(request, username):
         paginator = paginate(request, following, settings.FOLLOW_ITEMS_PER_PAGE)
         tvars.update(paginator)
         tvars.update({
-            'next_path': reverse('account', args=[username]) + '?following=1',
+            'next_path': reverse('account', args=[username]) + '?following={}'.format(paginator['current_page']),
             'follow_page': 'following'
         })
         return render(request, 'accounts/modal_follow.html', tvars)
@@ -99,7 +99,7 @@ def followers(request, username):
         paginator = paginate(request, followers, settings.FOLLOW_ITEMS_PER_PAGE)
         tvars.update(paginator)
         tvars.update({
-            'next_path': reverse('account', args=[username]) + '?followers=1',
+            'next_path': reverse('account', args=[username]) + '?followers={}'.format(paginator['current_page']),
             'follow_page': 'followers'
         })
         return render(request, 'accounts/modal_follow.html', tvars)
@@ -135,7 +135,7 @@ def following_tags(request, username):
         paginator = paginate(request, following_tags, settings.FOLLOW_ITEMS_PER_PAGE)
         tvars.update(paginator)
         tvars.update({
-            'next_path': reverse('account', args=[username]) + '?following_tags=1', # Used in BW
+            'next_path': reverse('account', args=[username]) + '?following_tags={}'.format(paginator['current_page']),
             'follow_page': 'tags' # Used in BW
         })
         return render(request, 'accounts/modal_follow.html', tvars)

--- a/follow/views.py
+++ b/follow/views.py
@@ -50,8 +50,7 @@ def following_users(request, username):
     is_owner = False
     if request.user.is_authenticated:
         is_owner = request.user == user
-    following = follow_utils.get_users_following(user)
-
+    following = follow_utils.get_users_following_qs(user)
     tvars = {
         'user': user
     }
@@ -87,8 +86,7 @@ def followers(request, username):
     is_owner = False
     if request.user.is_authenticated:
         is_owner = request.user == user
-    followers = follow_utils.get_users_followers(user)
-
+    followers = follow_utils.get_users_followers_qs(user)
     tvars = {
         'user': user
     }
@@ -124,18 +122,9 @@ def following_tags(request, username):
     is_owner = False
     if request.user.is_authenticated:
         is_owner = request.user == user
-    following = follow_utils.get_tags_following(user)
-    space_tags = following
-    split_tags = [tag.split(" ") for tag in space_tags]
-    slash_tags = [tag.replace(" ", "/") for tag in space_tags]
-
-    following_tags = []
-    for i in range(len(space_tags)):
-        following_tags.append((space_tags[i], slash_tags[i], split_tags[i]))
-
+    following_tags = follow_utils.get_tags_following_qs(user)
     tvars = {
         'user': user,
-        'following_tags': following_tags
     }
 
     if using_beastwhoosh(request):
@@ -152,10 +141,7 @@ def following_tags(request, username):
         return render(request, 'accounts/modal_follow.html', tvars)
     else:
         tvars.update({
-            'following': following,
-            'slash_tags': slash_tags,
-            'split_tags': split_tags,
-            'space_tags': space_tags,
+            'following_tags': following_tags,
             'is_owner': is_owner,
         })
         return render(request, 'follow/following_tags.html', tvars)

--- a/freesound/static/bw-frontend/src/components/modal.js
+++ b/freesound/static/bw-frontend/src/components/modal.js
@@ -1,5 +1,5 @@
 import {initRegistrationForm, initProblemsLoggingInForm} from "../pages/loginAndRegistration";
-import {showToast} from "./toast";
+import {showToast, showToastNoTimeout, dismissToast} from "./toast";
 
 const modals = [...document.querySelectorAll('[data-toggle="modal"]')];
 
@@ -74,10 +74,12 @@ if (problemsLoggingInParam) {
 const genericModalWrapper = document.getElementById('generiModalWrapper');
 
 const handleGenericModal = fetchContentUrl => {
+  showToastNoTimeout('Loading...');
   const req = new XMLHttpRequest();
   req.open('GET', fetchContentUrl, true);
   req.onload = () => {
     if (req.status >= 200 && req.status < 400) {
+        dismissToast();
 
         // Add modal contents to the generic modal wrapper (the requested URL should return a modal template
         // extending "modal_base.html")
@@ -105,11 +107,14 @@ const handleGenericModal = fetchContentUrl => {
             };
           });
         });
+    } else {
+      // Unexpected errors happened while processing request: close modal and show error in toast
+      showToast('Some errors occurred while loading the requested content.')
     }
   };
   req.onerror = () => {
     // Unexpected errors happened while processing request: close modal and show error in toast
-    showToast('Some errors occurred while loading requested content.')
+    showToast('Some errors occurred while loading the requested content.')
   };
 
   // Send the form

--- a/freesound/static/bw-frontend/src/components/toast.js
+++ b/freesound/static/bw-frontend/src/components/toast.js
@@ -1,10 +1,24 @@
-export const showToast = text => {
-  const toastElement = document.querySelector('[role="alert"]');
+let hideToastTimeout;
 
+export const showToast = text => {
+  clearTimeout(hideToastTimeout);
+  const toastElement = document.querySelector('[role="alert"]');
   toastElement.style.display = 'block';
   toastElement.children[0].innerHTML = text;
-
-  setTimeout(function() {
+  hideToastTimeout = setTimeout(() => {
     toastElement.style.display = 'none';
   }, 5000);
+};
+
+export const showToastNoTimeout = text => {
+  clearTimeout(hideToastTimeout);
+  const toastElement = document.querySelector('[role="alert"]');
+  toastElement.style.display = 'block';
+  toastElement.children[0].innerHTML = text;
+};
+
+export const dismissToast = () => {
+  clearTimeout(hideToastTimeout);
+  const toastElement = document.querySelector('[role="alert"]');
+  toastElement.style.display = 'none';
 };

--- a/freesound/static/bw-frontend/src/pages/profile.js
+++ b/freesound/static/bw-frontend/src/pages/profile.js
@@ -30,27 +30,67 @@ taps.forEach(tap => {
 const userFollowersButton = document.getElementById('user-followers-button');
 const userFollowUsersButton = document.getElementById('user-following-users-button');
 const userFollowTagsButton = document.getElementById('user-following-tags-button');
+
+const removeFollowModalUrlParams = () => {
+  const searchParams = new URLSearchParams(window.location.search);
+  [userFollowersButton, userFollowUsersButton, userFollowTagsButton].forEach(button => {
+    searchParams.delete(button.dataset.modalActivationParam);
+  });
+  const url = window.location.protocol + '//' + window.location.host + window.location.pathname + '?' + searchParams.toString();
+  window.history.replaceState(null, "", url);
+};
+
+const setFollowModalUrlParamToCurrentPage = (modalActivationParam) => {
+  const searchParams = new URLSearchParams(window.location.search);
+
+  // Find current page from paginator element in loaded modal
+  let page = 1;
+  const genericModalWrapperElement = document.getElementById('genericModalWrapper');
+  genericModalWrapperElement.getElementsByClassName('bw-pagination_selected').forEach(element => {
+    page = parseInt(element.innerHTML, 10);
+  });
+  searchParams.set(modalActivationParam, page);
+  const url = window.location.protocol + '//' + window.location.host + window.location.pathname + '?' + searchParams.toString();
+  window.history.replaceState(null, "", url);
+};
+
 [userFollowersButton, userFollowUsersButton, userFollowTagsButton].forEach(button => {
   button.addEventListener('click', () => {
-    handleGenericModal(button.dataset.modalContentUrl);
+    handleGenericModal(button.dataset.modalContentUrl, () => {
+      setFollowModalUrlParamToCurrentPage(button.dataset.modalActivationParam);
+    }, () => {
+      removeFollowModalUrlParams();
+    });
   });
 });
 
 const urlParams = new URLSearchParams(window.location.search);
-const followersModalParam = urlParams.get('followers');
-const followingModalParam = urlParams.get('following');
-const followingTagsModalParam = urlParams.get('followingTags');
+const followersModalParam = urlParams.get(userFollowersButton.dataset.modalActivationParam);
+const followingModalParam = urlParams.get(userFollowUsersButton.dataset.modalActivationParam);
+const followingTagsModalParam = urlParams.get(userFollowTagsButton.dataset.modalActivationParam);
 
 if (followersModalParam) {
-  handleGenericModal(userFollowersButton.dataset.modalContentUrl);
+  handleGenericModal(userFollowersButton.dataset.modalContentUrl, () => {
+      setFollowModalUrlParamToCurrentPage(userFollowersButton.dataset.modalActivationParam);
+    }, () => {
+      removeFollowModalUrlParams();
+    });
 }
 
 if (followingModalParam) {
-  handleGenericModal(userFollowUsersButton.dataset.modalContentUrl);
+  handleGenericModal(userFollowUsersButton.dataset.modalContentUrl, () => {
+      setFollowModalUrlParamToCurrentPage(userFollowUsersButton.dataset.modalActivationParam);
+    }, () => {
+      removeFollowModalUrlParams();
+    });
 }
 
 if (followingTagsModalParam) {
-  handleGenericModal(userFollowTagsButton.dataset.modalContentUrl);
+  handleGenericModal(userFollowTagsButton.dataset.modalContentUrl, () => {
+      setFollowModalUrlParamToCurrentPage(userFollowTagsButton.dataset.modalActivationParam);
+    }, () => {
+      removeFollowModalUrlParams();
+    });
 }
 
 

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -282,11 +282,7 @@ def sound(request, username, sound_id):
     qs = Comment.objects.select_related("user", "user__profile")\
         .filter(sound_id=sound_id)
     display_random_link = request.GET.get('random_browsing', False)
-    is_following = False
-    if request.user.is_authenticated:
-        users_following = follow_utils.get_users_following(request.user)
-        if sound.user in users_following:
-            is_following = True
+    is_following = request.user.is_authenticated() and follow_utils.is_user_following_user(request.user, sound.user)
     is_explicit = sound.is_explicit and (not request.user.is_authenticated or not request.user.profile.is_adult)
 
     tvars = {

--- a/templates/accounts/account.html
+++ b/templates/accounts/account.html
@@ -283,14 +283,14 @@
 
             {% if following %}
                 {% if home %}
-                    <h3>Users you are following ({{ following_count}})</h3>
+                    <h3>Users you are following ({{ following.count }})</h3>
                 {% else %}
-                    <h3>Users {{ user.username }} is following ({{ following_count}})</h3>
+                    <h3>Users {{ user.username }} is following ({{ following.count }})</h3>
                 {% endif %}
 
                 <ul>
-                    {% for suser in following %}
-                        <a href="{% url "account" suser %}" title="{{suser}}"><img src="{{suser.profile.locations.avatar.M.url}}" alt="avatar" /></a>
+                    {% for follow_user_item in following|slice:":21" %}
+                        <a href="{% url "account" follow_user_item.user_to.username %}" title="{{ follow_user_item.user_to.username }}"><img src="{{follow_user_item.user_to.profile.locations.avatar.M.url}}" alt="avatar" /></a>
                     {% endfor %}
                 </ul>
                 <p><a href="{% url "user-following-users" user %}">more...</a></p>
@@ -298,14 +298,14 @@
 
             {% if followers %}
                 {% if home %}
-                    <h3>Users that are following you ({{ followers_count}})</h3>
+                    <h3>Users that are following you ({{ followers.count }})</h3>
                 {% else %}
-                    <h3>Users that are following {{ user.username }} ({{ followers_count}})</h3>
+                    <h3>Users that are following {{ user.username }} ({{ followers.count }})</h3>
                 {% endif %}
 
                 <ul>
-                    {% for suser in followers %}
-                        <a href="{% url "account" suser %}" title="{{suser}}"><img src="{{suser.profile.locations.avatar.M.url}}" alt="avatar" /></a>
+                    {% for follow_user_item in followers|slice:":21" %}
+                        <a href="{% url "account" follow_user_item.user_from.username %}" title="{{follow_user_item.user_from.username}}"><img src="{{follow_user_item.user_from.profile.locations.avatar.M.url}}" alt="avatar" /></a>
                     {% endfor %}
                 </ul>
                 <p><a href="{% url "user-followers" user %}">more...</a></p>
@@ -314,15 +314,15 @@
             {% if following_tags %}
                 <div id="following_tags">
                     {% if home %}
-                        <h3>Tags you are following ({{ following_tags_count }})</h3>
+                        <h3>Tags you are following ({{ following_tags.count }})</h3>
                     {% else %}
-                        <h3>Tags {{ user.username }} is following ({{ following_tags_count }})</h3>
+                        <h3>Tags {{ user.username }} is following ({{ following_tags.count }})</h3>
                     {% endif %}
                     <ul>
-                        {% for space_tags, slash_tags, split_tags in following_tags %}
-                            <span class="tag_group" onclick="location.href='{% url "tags" slash_tags %}'">
+                        {% for follow_tag_item in following_tags|slice:":5" %}
+                            <span class="tag_group" onclick="location.href='{% url "tags" follow_tag_item.get_slash_tags %}'">
                             <ul class="tags" id="following_tags">
-                            {% for tag in split_tags %}
+                            {% for tag in follow_tag_item.get_split_tags %}
                                 {% comment %}<li><a href="{% url "tags"tag %}">{{ tag }}</a></li>{% endcomment %}
                                 <li><a>{{ tag }}</a></li>
                                 {% comment %}<li>{{ tag }}</li>{% endcomment %}

--- a/templates/follow/followers.html
+++ b/templates/follow/followers.html
@@ -18,13 +18,13 @@
 {% if followers %}
 	<h3>{% if is_owner %}You have{% else %}{{ user.username }} has {% endif %} {{ followers|length }} follower{{ followers|pluralize }}</h3>
 	<ul>
-        {% for user in followers %}
+        {% for follow_user_item in followers %}
 		 	    <div class="followers_page_user_info">
-			        <img src="{{user.profile.locations.avatar.M.url}}" alt="avatar" />
-			        <div class="post_author"><a href="{% url "account" user.username %}">{{user.username|truncate_string:12}}</a></div>
+			        <img src="{{follow_user_item.user_from.profile.locations.avatar.M.url}}" alt="avatar" />
+			        <div class="post_author"><a href="{% url "account" follow_user_item.user_from.username %}">{{follow_user_item.user_from.username|truncate_string:12}}</a></div>
 			        <div class="people_user_info">
-			            {{user.profile.num_sounds}} sound{{user.profile.num_sounds|pluralize}}<br>
-			            {{user.profile.num_posts}} post{{user.profile.num_posts|pluralize}}<br>
+			            {{follow_user_item.user_from.profile.num_sounds}} sound{{follow_user_item.user_from.profile.num_sounds|pluralize}}<br>
+			            {{follow_user_item.user_from.profile.num_posts}} post{{follow_user_item.user_from.profile.num_posts|pluralize}}<br>
 			        </div>
 		    	</div>
         {% endfor %}

--- a/templates/follow/following_tags.html
+++ b/templates/follow/following_tags.html
@@ -15,15 +15,15 @@
 
 <div id="content">
 <div class="content_box">
-{% if following %}
+{% if following_tags %}
 	<div id="following_tags">
-	<h3>{% if is_owner %}You are{% else %}{{ user.username }} is {% endif %} following {{ following|length }} tag{{ following|pluralize }} (or tag group{{ following|pluralize }})</h3>
+	<h3>{% if is_owner %}You are{% else %}{{ user.username }} is {% endif %} following {{ following_tags|length }} tag{{ following_tags|pluralize }} (or tag group{{ following_tags|pluralize }})</h3>
 
 	<ul>
-        {% for space_tags, slash_tags, split_tags in following_tags %}
-            <span class="tag_group" onclick="location.href='{% url "tags" slash_tags %}'">
+        {% for follow_tag_item in following_tags %}
+            <span class="tag_group" onclick="location.href='{% url "tags" follow_tag_item.get_slash_tags %}'">
             <ul class="tags" id="following_tags">
-            {% for tag in split_tags %}
+            {% for tag in follow_tag_item.get_split_tags %}
                 <li><a>{{ tag }}</a></li>
             {% endfor %}
             </ul></span>

--- a/templates/follow/following_users.html
+++ b/templates/follow/following_users.html
@@ -18,13 +18,13 @@
 {% if following %}
 	<h3>{% if is_owner %}You are{% else %}{{ user.username }} is {% endif %} following {{ following|length }} user{{ following|pluralize }}</h3>
 	<ul>
-        {% for user in following %}
+        {% for follow_user_item in following %}
 		 	    <div class="followers_page_user_info">
-			        <img src="{{user.profile.locations.avatar.M.url}}" alt="avatar" />
-			        <div class="post_author"><a href="{% url "account" user.username %}">{{user.username|truncate_string:12}}</a></div>
+			        <img src="{{follow_user_item.user_to.profile.locations.avatar.M.url}}" alt="avatar" />
+			        <div class="post_author"><a href="{% url "account" follow_user_item.user_to.username %}">{{follow_user_item.user_to.username|truncate_string:12}}</a></div>
 			        <div class="people_user_info">
-			            {{user.profile.num_sounds}} sound{{user.profile.num_sounds|pluralize}}<br>
-			            {{user.profile.num_posts}} post{{user.profile.num_posts|pluralize}}<br>
+			            {{follow_user_item.user_to.profile.num_sounds}} sound{{follow_user_item.user_to.profile.num_sounds|pluralize}}<br>
+			            {{follow_user_item.user_to.profile.num_posts}} post{{follow_user_item.user_to.profile.num_posts|pluralize}}<br>
 			        </div>
 		    	</div>
         {% endfor %}

--- a/templates_bw/accounts/account.html
+++ b/templates_bw/accounts/account.html
@@ -83,9 +83,9 @@
                 </div>
                 <div class="bw-profile__stats v-spacing-top-3">
                     <div class="text-grey">Has been a user for {{user.date_joined|timesince}}</div>
-                    <div><a id="user-followers-button" data-modal-content-url="{% url 'user-followers' user.username %}?ajax=1" href="javascript:void(0);">{{ followers_count }} followers</a></div>
-                    <div><a id="user-following-users-button" data-modal-content-url="{% url 'user-following-users' user.username %}?ajax=1" href="javascript:void(0);">{{ following_count }} following</a></div>
-                    <div><a id="user-following-tags-button" data-modal-content-url="{% url 'user-following-tags' user.username %}?ajax=1" href="javascript:void(0);">{{ following_tags_count }} tags following</a></div>
+                    <div><a id="user-followers-button" data-modal-content-url="{% url 'user-followers' user.username %}?ajax=1" href="javascript:void(0);">{{ followers.count }} followers</a></div>
+                    <div><a id="user-following-users-button" data-modal-content-url="{% url 'user-following-users' user.username %}?ajax=1" href="javascript:void(0);">{{ following.count }} following</a></div>
+                    <div><a id="user-following-tags-button" data-modal-content-url="{% url 'user-following-tags' user.username %}?ajax=1" href="javascript:void(0);">{{ following_tags.count }} tags following</a></div>
                 </div>
             {% endif %}
         </div>

--- a/templates_bw/accounts/account.html
+++ b/templates_bw/accounts/account.html
@@ -83,9 +83,9 @@
                 </div>
                 <div class="bw-profile__stats v-spacing-top-3">
                     <div class="text-grey">Has been a user for {{user.date_joined|timesince}}</div>
-                    <div><a id="user-followers-button" data-modal-content-url="{% url 'user-followers' user.username %}?ajax=1" href="javascript:void(0);">{{ followers.count }} followers</a></div>
-                    <div><a id="user-following-users-button" data-modal-content-url="{% url 'user-following-users' user.username %}?ajax=1" href="javascript:void(0);">{{ following.count }} following</a></div>
-                    <div><a id="user-following-tags-button" data-modal-content-url="{% url 'user-following-tags' user.username %}?ajax=1" href="javascript:void(0);">{{ following_tags.count }} tags following</a></div>
+                    <div><a id="user-followers-button" data-modal-activation-param="followers" data-modal-content-url="{% url 'user-followers' user.username %}?ajax=1&page={{ followers_modal_page }}" href="javascript:void(0);">{{ followers.count }} followers</a></div>
+                    <div><a id="user-following-users-button" data-modal-activation-param="following" data-modal-content-url="{% url 'user-following-users' user.username %}?ajax=1&page={{ following_modal_page }}" href="javascript:void(0);">{{ following.count }} following</a></div>
+                    <div><a id="user-following-tags-button" data-modal-activation-param="followingTags" data-modal-content-url="{% url 'user-following-tags' user.username %}?ajax=1&page={{ following_tags_modal_page }}" href="javascript:void(0);">{{ following_tags.count }} tags following</a></div>
                 </div>
             {% endif %}
         </div>

--- a/templates_bw/accounts/account.html
+++ b/templates_bw/accounts/account.html
@@ -81,12 +81,14 @@
                         </div>
                     {% endif %}
                 </div>
+                {% cache 43200 bw_user_profile_follow_stats user.id %}
                 <div class="bw-profile__stats v-spacing-top-3">
                     <div class="text-grey">Has been a user for {{user.date_joined|timesince}}</div>
                     <div><a id="user-followers-button" data-modal-activation-param="followers" data-modal-content-url="{% url 'user-followers' user.username %}?ajax=1&page={{ followers_modal_page }}" href="javascript:void(0);">{{ followers.count }} followers</a></div>
                     <div><a id="user-following-users-button" data-modal-activation-param="following" data-modal-content-url="{% url 'user-following-users' user.username %}?ajax=1&page={{ following_modal_page }}" href="javascript:void(0);">{{ following.count }} following</a></div>
                     <div><a id="user-following-tags-button" data-modal-activation-param="followingTags" data-modal-content-url="{% url 'user-following-tags' user.username %}?ajax=1&page={{ following_tags_modal_page }}" href="javascript:void(0);">{{ following_tags.count }} tags following</a></div>
                 </div>
+                {% endcache %}
             {% endif %}
         </div>
         <div class="divider-light"></div>

--- a/templates_bw/accounts/modal_follow.html
+++ b/templates_bw/accounts/modal_follow.html
@@ -15,8 +15,8 @@
         <div class="v-spacing-5 text-center">
             <h5>{{ user.username }}'s followers</h5>
         </div>
-        {% for user in followers %}
-            {% display_user_follow_lists user %}
+        {% for fuser in page.object_list %}
+            {% display_user_follow_lists fuser %}
             <div class="padding-left-3">
                 <div class="col-md-11 offset-1 v-spacing-top-3 v-spacing-3 divider-light"></div>
             </div>
@@ -30,8 +30,8 @@
         <div class="v-spacing-5 text-center">
             <h5>Users followed by {{ user.username }}</h5>
         </div>
-        {% for user in page.object_list %}
-            {% display_user_follow_lists user %}
+        {% for fuser in page.object_list %}
+            {% display_user_follow_lists fuser %}
             <div class="padding-left-3">
                 <div class="col-md-11 offset-1 v-spacing-top-3 v-spacing-3 divider-light"></div>
             </div>
@@ -48,7 +48,7 @@
         <div class="v-spacing-5 text-center">
             <h5>Tags followed by {{ user.username }}</h5>
         </div>
-        {% for space_tags, slash_tags, split_tags in following_tags %}
+        {% for space_tags, slash_tags, split_tags in page.object_list %}
             <div class="row bw-follows middle">
                 <div class="col-md-8">
                     {% if split_tags|length > 1 %}
@@ -77,6 +77,9 @@
                 <div class="text-grey v-spacing-top-1">Looks like {{ user.username }} is not following any tags yet... &#128543</div>
             </div>
         {% endfor %}
+        <div class="v-spacing-top-5">
+            {% bw_paginator paginator page current_page request "" -1 %}
+        </div>
     {% endif %}
 </div>
 {% endblock %}

--- a/templates_bw/accounts/modal_follow.html
+++ b/templates_bw/accounts/modal_follow.html
@@ -15,8 +15,8 @@
         <div class="v-spacing-5 text-center">
             <h5>{{ user.username }}'s followers</h5>
         </div>
-        {% for fuser in page.object_list %}
-            {% display_user_follow_lists fuser %}
+        {% for follow_user_item in page.object_list %}
+            {% display_user_follow_lists follow_user_item.user_from %}
             <div class="padding-left-3">
                 <div class="col-md-11 offset-1 v-spacing-top-3 v-spacing-3 divider-light"></div>
             </div>
@@ -25,13 +25,16 @@
                 <div class="text-grey v-spacing-top-1">Looks like {{ user.username }} has no followers yet... &#128543</div>
             </div>
         {% endfor %}
+        <div class="v-spacing-top-5">
+            {% bw_paginator paginator page current_page request "" -1 %}
+        </div>
 
     {% elif follow_page == 'following' %}
         <div class="v-spacing-5 text-center">
             <h5>Users followed by {{ user.username }}</h5>
         </div>
-        {% for fuser in page.object_list %}
-            {% display_user_follow_lists fuser %}
+        {% for follow_user_item in page.object_list %}
+            {% display_user_follow_lists follow_user_item.user_to %}
             <div class="padding-left-3">
                 <div class="col-md-11 offset-1 v-spacing-top-3 v-spacing-3 divider-light"></div>
             </div>
@@ -48,24 +51,24 @@
         <div class="v-spacing-5 text-center">
             <h5>Tags followed by {{ user.username }}</h5>
         </div>
-        {% for space_tags, slash_tags, split_tags in page.object_list %}
+        {% for follow_tag_item in page.object_list %}
             <div class="row bw-follows middle">
                 <div class="col-md-8">
-                    {% if split_tags|length > 1 %}
-                        <div class="border-light-grey-bottom-hover cursor-pointer" style="display: inline-block" onclick="location.href='{% url "tags" slash_tags %}'">
-                            {% for tag in split_tags %}
+                    {% if follow_tag_item.get_split_tags|length > 1 %}
+                        <div class="border-light-grey-bottom-hover cursor-pointer" style="display: inline-block" onclick="location.href='{% url "tags" follow_tag_item.get_slash_tags %}'">
+                            {% for tag in follow_tag_item.get_split_tags %}
                                 {% bw_tag tag 1 'v-spacing-top-1' %}
                             {% endfor %}
                         </div>
                     {% else %}
-                        {% bw_tag split_tags.0 %}
+                        {% bw_tag follow_tag_item.get_split_tags.0 %}
                     {% endif %}
                 </div>
                 <div class="col-md-4 text-right">
-                    {% if request.user|user_following_tags:slash_tags %}
-                        <a class="no-hover" href="{% url 'unfollow-tags' slash_tags %}?next={{ next_path }}"><button class="btn-primary">Unfollow</button></a>
+                    {% if request.user|user_following_tags:follow_tag_item.get_slash_tags %}
+                        <a class="no-hover" href="{% url 'unfollow-tags' follow_tag_item.get_slash_tags %}?next={{ next_path }}"><button class="btn-primary">Unfollow</button></a>
                     {% else %}
-                        <a class="no-hover" href="{% url 'follow-tags' slash_tags %}?next={{ next_path }}"><button class="btn-inverse btn-profile-adapt">Follow</button></a>
+                        <a class="no-hover" href="{% url 'follow-tags' follow_tag_item.get_slash_tags %}?next={{ next_path }}"><button class="btn-inverse btn-profile-adapt">Follow</button></a>
                     {% endif %}
                 </div>
             </div>

--- a/templates_bw/base.html
+++ b/templates_bw/base.html
@@ -23,7 +23,7 @@
     {% include 'accounts/modal_password_reset.html' %}
     {% include 'accounts/modal_registration.html' %}
     {% include 'accounts/modal_registration_feedback.html' %}
-    <div id="generiModalWrapper"></div>
+    <div id="genericModalWrapper"></div>
     {% include 'molecules/toast.html' %}
     <div class="notifications-wrapper"></div>
     {% if messages %}

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -34,4 +34,5 @@ def invalidate_user_template_caches(user_id):
     invalidate_template_cache('user_header', user_id)
     invalidate_template_cache('bw_user_header', user_id)
     invalidate_template_cache('bw_user_profile_stats', user_id)
+    invalidate_template_cache('bw_user_profile_follow_stats', user_id)
 


### PR DESCRIPTION
This PR implements some improvements in the follow modals of BW:

- Optimizations in the code used to query user/tags followers/following. All the queries to get follow items now happen lazily so we can easily cache them in the template if we want. We made changes in old templates as well to make these changes backwards compatible.
- Improvements in the way modals are handled in BW: now when opening/closing the follow modals the URL gets updated so it can be copy/pasted and shared and the same model (at the same page) will be opened.
- Fix some bugs in BW modal templates
- While a template is loading, a message will be shown at the bottom of the page

