### PR TITLE
Fix integrity error in Forum.num_trheads if count field is out of sync

### DIFF
--- a/accounts/tests/test_user.py
+++ b/accounts/tests/test_user.py
@@ -187,6 +187,7 @@ class UserDelete(TestCase):
         # Create threads and posts (use mock to avoid trying to index the posts to solr)
         with mock.patch('forum.models.send_posts_to_solr'):
             forum, _ = Forum.objects.get_or_create(name="Test forum")
+            self.forum = forum
             thread = Thread.objects.create(author=user, title="Test thread by {}".format(username), forum=forum)
             for i in range(0, 3):
                 Post.objects.create(author=user, thread=thread, body="Post %i body" % i)
@@ -440,6 +441,10 @@ class UserDelete(TestCase):
         user.profile.num_sounds = user.profile.num_sounds - 1
         user.profile.num_posts = user.profile.num_posts - 1
         user.profile.save()
+
+        # Also set count fields of objects related to those that will be deleted to be out-of-sync
+        self.forum.num_threads = 0
+        self.forum.save()
 
         # Delete user including sounds (which will delete Download objects as well) and also deleting the User object
         # from DB which will trigger deleting associated content like posts, etc.

--- a/forum/views.py
+++ b/forum/views.py
@@ -30,6 +30,7 @@ from django.template import loader
 from django.urls import reverse
 from django.db import transaction
 
+from accounts.models import DeletedUser
 from forum.forms import PostReplyForm, NewThreadForm, PostModerationForm
 from forum.models import Forum, Thread, Post, Subscription
 from utils.mail import send_mail_template
@@ -413,7 +414,9 @@ def moderate_posts(request):
                     post.save()
                 elif action == "Delete User":
                     try:
-                        post.author.delete()
+                        deletion_reason = DeletedUser.DELETION_REASON_SPAMMER
+                        post.author.profile.delete_user(delete_user_object_from_db=True,
+                                                        deletion_reason=deletion_reason)
                         messages.add_message(request, messages.INFO, 'The user has been successfully deleted.')
                     except User.DoesNotExist:
                         messages.add_message(request, messages.INFO, 'The user has already been deleted.')


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1552

**Description**
Fixes an integrity error that could cause deleting some users to fail (specially forum spammers, who we do want to delete).
Also updated the code for forum moderation so that it uses the new user deletion functions.