### PR TITLE
Update some hardcoded http:// URLs to https://

### DIFF
--- a/apiv2/forms.py
+++ b/apiv2/forms.py
@@ -189,7 +189,7 @@ class SoundCombinedSearchFormAPI(forms.Form):
                 link += '&group_by_pack=%s' % self.cleaned_data['group_by_pack']
         else:
             link += '&group_by_pack=%s' % group_by_pack
-        return "http://%s%s%s" % (Site.objects.get_current().domain, base_url, link)
+        return "https://%s%s%s" % (Site.objects.get_current().domain, base_url, link)
 
 
 class SoundTextSearchFormAPI(SoundCombinedSearchFormAPI):

--- a/apiv2/management/commands/basic_api_tests.py
+++ b/apiv2/management/commands/basic_api_tests.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
         section = options['section']
 
         if not base_url:
-            base_url = "http://%s/" % Site.objects.get_current().domain
+            base_url = "https://%s/" % Site.objects.get_current().domain
 
         test_client = None
         if not token:

--- a/donations/views.py
+++ b/donations/views.py
@@ -167,7 +167,7 @@ def donation_session_stripe(request):
         if form.is_valid():
             email_to = request.user.email if request.user.is_authenticated() else None
             amount = form.cleaned_data['amount']
-            domain = "http://%s" % Site.objects.get_current().domain
+            domain = "https://%s" % Site.objects.get_current().domain
             return_url_success = urlparse.urljoin(domain, reverse('donation-success'))
             return_url_success += '?token={}'.format(form.encoded_data)
             return_url_cancel = urlparse.urljoin(domain, reverse('donate'))

--- a/freesound/urls.py
+++ b/freesound/urls.py
@@ -120,7 +120,7 @@ urlpatterns = [
     url(r'^monitor/', include('monitor.urls')),
     url(r'^follow/', include('follow.urls')),
 
-    url(r'^blog/$', RedirectView.as_view(url='http://blog.freesound.org/'), name="blog"),
+    url(r'^blog/$', RedirectView.as_view(url='https://blog.freesound.org/'), name="blog"),
     url(r'^crossdomain\.xml$', TemplateView.as_view(template_name='crossdomain.xml'), name="crossdomain"),
 
     # admin views

--- a/utils/spam.py
+++ b/utils/spam.py
@@ -34,7 +34,7 @@ def is_spam(request, comment):
     if request.user.profile.num_sounds > 0:
         return False
 
-    domain = "http://%s" % Site.objects.get_current().domain
+    domain = "https://%s" % Site.objects.get_current().domain
     api = Akismet(key=settings.AKISMET_KEY, blog_url=domain)
 
     data = {


### PR DESCRIPTION
This PR removes some hardcoded references to http:// URLs which should be updated to https://. Most importantly, in the API paginators URLs had hardcoded http:// scheme and this was triggering unnecessary redirects.