### PR TITLE
Anchor "http"->"https" replacement to prevent duplicate letters

### DIFF
--- a/_docs/api/add_examples_to_api_docs_source_files.py
+++ b/_docs/api/add_examples_to_api_docs_source_files.py
@@ -20,7 +20,7 @@ def get_formatted_examples_for_view(view_name):
                 output += '  %s%s\n' % (base_url, urllib.quote(element, safe='?/=&",:()'))
                 #output += '  curl -H "Authorization: Token {{token}}" \'%s%s\'\n' % (base_url, element)
             else:
-                output += '  %s\n' % (element % base_url[:-1].replace('http', 'https'))
+                output += '  %s\n' % (element % base_url[:-1].replace('http:', 'https:'))
 
     return output
 


### PR DESCRIPTION
**Issue(s)**
<!-- URL to issue(s) related to this PR -->
Fixes #1573 

**Description**
<!-- Description of the contents of this PR -->
This anchors the replacement to the `:` after `http`/`https` so the replacement doesn't erroneously change "[http]s" to "[https]s".

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
