### PR TITLE
Handle invalid client ip addresses

### DIFF
--- a/utils/logging_filters.py
+++ b/utils/logging_filters.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+import ipaddress
 import logging
 import json
 
@@ -35,6 +36,11 @@ def get_client_ip(request):
     x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
     if x_forwarded_for:
         ip = x_forwarded_for.split(',')[0].strip()
+        try:
+            ipaddress.ip_network(unicode(ip))
+        except ValueError:
+            # Not a valid ip address
+            ip = '-'
     else:
         ip = '-'
     return ip

--- a/utils/tests/test_logging_filters.py
+++ b/utils/tests/test_logging_filters.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+from django.test import TestCase
+
+from utils.logging_filters import get_client_ip
+
+
+class DummyRequest:
+    """A dummy request to check the X-Forwarded-For header in logging_filters.get_client_ip"""
+    def __init__(self, xforwardedfor):
+        self.META = {"HTTP_X_FORWARDED_FOR": xforwardedfor}
+
+class LoggingFiltersTest(TestCase):
+
+    def test_get_client_ip_valid(self):
+        req = DummyRequest('127.0.0.1,10.10.10.10')
+        ip = get_client_ip(req)
+        self.assertEqual(ip, '127.0.0.1')
+
+        # It doesn't matter if any further items are invalid, we only use the first
+        req = DummyRequest('127.0.0.1,foo')
+        ip = get_client_ip(req)
+        self.assertEqual(ip, '127.0.0.1')
+
+    def test_get_client_ip_empty(self):
+        req = DummyRequest(None)
+        ip = get_client_ip(req)
+        self.assertEqual(ip, '-')
+
+        req = DummyRequest('')
+        ip = get_client_ip(req)
+        self.assertEqual(ip, '-')
+
+    def test_get_client_ip_invalid(self):
+        req = DummyRequest('foo')
+        ip = get_client_ip(req)
+        self.assertEqual(ip, '-')
+
+        req = DummyRequest('foo,127.0.0.1')
+        ip = get_client_ip(req)
+        self.assertEqual(ip, '-')


### PR DESCRIPTION
**Description**

If we end up with invalid data in the X-Forwarded-For header (i.e. not an ip address), then the rate limiter fails to process it

Check this value before returning it, and return the sentinel '-' if it's not a valid ip address.