### PR TITLE
Load maps only upon user request in BW pack/profile pages

### DIFF
--- a/freesound/static/bw-frontend/src/pages/pack.js
+++ b/freesound/static/bw-frontend/src/pages/pack.js
@@ -29,9 +29,26 @@ toggleShareLinkElement.addEventListener('click',  toggleShareLink);
 shareLinkElement.style.display = "none"
 
 // Pack geotags map
-
+// Load the map only when user clicks on "load map" button
 const mapCanvas = document.getElementById('map_canvas');
 const geotagsSection = document.getElementById('pack_geotags');
-makeSoundsMap(mapCanvas.dataset.geotagsUrl, 'map_canvas', () => {
-  geotagsSection.style.display = 'block'; // Once map is ready, show geotags section
-});
+const loadButtonWrapper = document.createElement('div');
+const loadMapButton = document.createElement('button');
+const loadMap = () => {
+    loadMapButton.disabled = true;
+    loadMapButton.innerText = 'Loading...'
+    if (geotagsSection.getAttribute('data-map-loaded') !== 'true') {
+        makeSoundsMap(mapCanvas.dataset.geotagsUrl, 'map_canvas', () => {
+            loadButtonWrapper.remove();
+            geotagsSection.setAttribute('data-map-loaded', "true");
+            mapCanvas.style.display = 'block'; // Once map is ready, show geotags section
+        });
+    }
+}
+loadButtonWrapper.id = 'loadMapButtonWrapper';
+loadButtonWrapper.classList.add('text-center', 'v-spacing-top-6', 'v-spacing-6');
+loadMapButton.onclick = () => {loadMap()};
+loadMapButton.classList.add('btn-inverse');
+loadMapButton.innerText = 'Load map...';
+loadButtonWrapper.appendChild(loadMapButton);
+geotagsSection.insertBefore(loadButtonWrapper, mapCanvas);

--- a/freesound/static/bw-frontend/src/pages/profile.js
+++ b/freesound/static/bw-frontend/src/pages/profile.js
@@ -9,7 +9,7 @@ const tapsElements = document.getElementsByClassName('bw-profile__tap_container'
 const cleanActiveClass = () => {
   taps.forEach(tap => tap.classList.remove('active'));
   tapsElements.forEach(tapElement =>
-    tapElement.classList.remove('bw-profile__tap_container__active')
+      tapElement.classList.remove('bw-profile__tap_container__active')
   );
 };
 
@@ -71,32 +71,48 @@ const followingTagsModalParam = urlParams.get(userFollowTagsButton.dataset.modal
 
 if (followersModalParam) {
   handleGenericModal(userFollowersButton.dataset.modalContentUrl, () => {
-      setFollowModalUrlParamToCurrentPage(userFollowersButton.dataset.modalActivationParam);
-    }, () => {
-      removeFollowModalUrlParams();
-    });
+    setFollowModalUrlParamToCurrentPage(userFollowersButton.dataset.modalActivationParam);
+  }, () => {
+    removeFollowModalUrlParams();
+  });
 }
 
 if (followingModalParam) {
   handleGenericModal(userFollowUsersButton.dataset.modalContentUrl, () => {
-      setFollowModalUrlParamToCurrentPage(userFollowUsersButton.dataset.modalActivationParam);
-    }, () => {
-      removeFollowModalUrlParams();
-    });
+    setFollowModalUrlParamToCurrentPage(userFollowUsersButton.dataset.modalActivationParam);
+  }, () => {
+    removeFollowModalUrlParams();
+  });
 }
 
 if (followingTagsModalParam) {
   handleGenericModal(userFollowTagsButton.dataset.modalContentUrl, () => {
-      setFollowModalUrlParamToCurrentPage(userFollowTagsButton.dataset.modalActivationParam);
-    }, () => {
-      removeFollowModalUrlParams();
-    });
+    setFollowModalUrlParamToCurrentPage(userFollowTagsButton.dataset.modalActivationParam);
+  }, () => {
+    removeFollowModalUrlParams();
+  });
 }
 
 
 // User geotags map
+// Load the map only when user clicks on "load map" button
 const mapCanvas = document.getElementById('map_canvas');
 const latestGeotagsSection = document.getElementById('latest_geotags');
-makeSoundsMap(mapCanvas.dataset.geotagsUrl, 'map_canvas', () => {
-  latestGeotagsSection.style.display = 'block'; // Once map is ready, show geotags section
-});
+const loadButtonWrapper = document.createElement('div');
+const loadMapButton = document.createElement('button');
+const loadMap = () => {
+  loadButtonWrapper.remove();
+  if (latestGeotagsSection.getAttribute('data-map-loaded') !== 'true') {
+    makeSoundsMap(mapCanvas.dataset.geotagsUrl, 'map_canvas', () => {
+      latestGeotagsSection.setAttribute('data-map-loaded', "true");
+      latestGeotagsSection.style.display = 'block'; // Once map is ready, show geotags section
+    });
+  }
+}
+loadButtonWrapper.id = 'loadMapButtonWrapper';
+loadButtonWrapper.classList.add('text-center v-spacing-top-4 v-spacing-bottom-4');
+loadMapButton.onclick = () => {loadMap()};
+loadMapButton.classList.add('btn-inverted');
+loadMapButton.innerText = 'Load map...';
+loadButtonWrapper.appendChild(loadMapButton);
+latestGeotagsSection.parentNode.insertBefore(loadButtonWrapper, latestGeotagsSection);

--- a/freesound/static/bw-frontend/src/pages/profile.js
+++ b/freesound/static/bw-frontend/src/pages/profile.js
@@ -101,18 +101,20 @@ const latestGeotagsSection = document.getElementById('latest_geotags');
 const loadButtonWrapper = document.createElement('div');
 const loadMapButton = document.createElement('button');
 const loadMap = () => {
-  loadButtonWrapper.remove();
+  loadMapButton.disabled = true;
+  loadMapButton.innerText = 'Loading...'
   if (latestGeotagsSection.getAttribute('data-map-loaded') !== 'true') {
     makeSoundsMap(mapCanvas.dataset.geotagsUrl, 'map_canvas', () => {
+      loadButtonWrapper.remove();
       latestGeotagsSection.setAttribute('data-map-loaded', "true");
-      latestGeotagsSection.style.display = 'block'; // Once map is ready, show geotags section
+      mapCanvas.style.display = 'block'; // Once map is ready, show geotags section
     });
   }
 }
 loadButtonWrapper.id = 'loadMapButtonWrapper';
-loadButtonWrapper.classList.add('text-center v-spacing-top-4 v-spacing-bottom-4');
+loadButtonWrapper.classList.add('text-center', 'v-spacing-top-6', 'v-spacing-6');
 loadMapButton.onclick = () => {loadMap()};
-loadMapButton.classList.add('btn-inverted');
+loadMapButton.classList.add('btn-inverse');
 loadMapButton.innerText = 'Load map...';
 loadButtonWrapper.appendChild(loadMapButton);
-latestGeotagsSection.parentNode.insertBefore(loadButtonWrapper, latestGeotagsSection);
+latestGeotagsSection.insertBefore(loadButtonWrapper, mapCanvas);

--- a/templates_bw/accounts/account.html
+++ b/templates_bw/accounts/account.html
@@ -183,7 +183,7 @@
                 {% endif %}
 
                 <div class="divider-light"></div>
-                <section id="latest_geotags" class="v-spacing-top-5 display-none">
+                <section id="latest_geotags" class="v-spacing-top-5 display-none" data-map-loaded="false">
                     <h5 class="padding-bottom-3">Latest geotags</h5>
                     <div id="map_canvas" class="sidebar-map" data-geotags-url="{% url "geotags-for-user-latest-barray" user.username %}"></div>
                     <div class="v-spacing-top-2 center">

--- a/templates_bw/accounts/account.html
+++ b/templates_bw/accounts/account.html
@@ -183,9 +183,9 @@
                 {% endif %}
 
                 <div class="divider-light"></div>
-                <section id="latest_geotags" class="v-spacing-top-5 display-none" data-map-loaded="false">
+                <section id="latest_geotags" class="v-spacing-top-5" data-map-loaded="false">
                     <h5 class="padding-bottom-3">Latest geotags</h5>
-                    <div id="map_canvas" class="sidebar-map" data-geotags-url="{% url "geotags-for-user-latest-barray" user.username %}"></div>
+                    <div id="map_canvas" class="sidebar-map display-none" data-geotags-url="{% url "geotags-for-user-latest-barray" user.username %}"></div>
                     <div class="v-spacing-top-2 center">
                         <a class="no-hover" href="{% url "geotags-for-user" user.username %}">See all geotags by {{ user.username }}</a>
                     </div>

--- a/templates_bw/sounds/pack.html
+++ b/templates_bw/sounds/pack.html
@@ -118,9 +118,9 @@
                         <div id="share-link" class="v-spacing-top-5">
                              <span class="text-grey">Share url: </span><br><input class="w-100" type="text" readonly value="{% absurl 'short-pack-link' pack.id %}" />
                         </div>
-                        <div id="pack_geotags" class="v-spacing-top-6 display-none">
+                        <div id="pack_geotags" class="v-spacing-top-6" data-map-loaded="false">
                             <h5 class="padding-bottom-3">Geotags in this pack</h5>
-                            <div id="map_canvas" class="sidebar-map" data-geotags-url="{% url "geotags-for-pack-barray" pack.id %}"></div>
+                            <div id="map_canvas" class="sidebar-map display-none" data-geotags-url="{% url "geotags-for-pack-barray" pack.id %}"></div>
                         </div>
                     </div>
                 </div>

--- a/utils/images.py
+++ b/utils/images.py
@@ -25,10 +25,10 @@ class ImageProcessingError(Exception):
 
 def extract_square(input_filename, output_filename, size):
     im = Image.open(input_filename)
-    
+
     if im.mode not in ('L', 'RGB'):
         im = im.convert('RGB')
-        
+
     #fill out and resize the image
     if im.size[0] < size and im.size[1] < size:
         if im.size[0] < im.size[1]:
@@ -38,7 +38,7 @@ def extract_square(input_filename, output_filename, size):
             ratio = im.size[0] / im.size[1] 
             im = im.resize((size,size / ratio), Image.ANTIALIAS)
         #fill out          
-        background = Image.new("RGBA", (size,size), (255, 255, 255, 0)) # use white for empty space  
+        background = Image.new("RGB", (size,size), (255, 255, 255)) # use white for empty space
         background.paste(im, ((size - im.size[0]) / 2, (size - im.size[1]) / 2))  
         background.save(output_filename)
         return


### PR DESCRIPTION
Similar to a fix for the main frontend, this one is now applied to BW so that maps of profile and pack pages are only loaded upon request. This PR also includes a fix for avatar processing.
