### PR TITLE
Use basic reverse geocoding to show location names

### DIFF
--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -351,8 +351,10 @@ NUMBER_OF_DAYS_FOR_USER_RANDOM_SOUNDS = 30
 NUMBER_OF_RANDOM_SOUNDS_IN_ADVANCE = 5
 RANDOM_SOUND_OF_THE_DAY_CACHE_KEY = "random_sound"
 
+#Geotags  stuff
 # Cache key for storing "all geotags" bytearray
 ALL_GEOTAGS_BYTEARRAY_CACHE_KEY = "geotags_bytearray"
+USE_TEXTUAL_LOCATION_NAMES_IN_BW = True
 
 # Avatar background colors (only BW)
 from utils.audioprocessing.processing import interpolate_colors

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ networkx==1.5
 numpy==1.16.6
 pillow==6.2.2
 psycopg2==2.7.3.2
+pycountry==19.8.18
 pycrypto==2.6.1
 PyJWT==1.4.2
 pyparsing==2.4.7
@@ -48,6 +49,7 @@ python-memcached==1.53
 pytz==2020.1
 PyYAML==3.11
 raven==6.10.0
+reverse_geocoder==1.5.0
 recaptcha-client==1.0.6
 redis==3.2.0
 redis==3.2.0

--- a/templates_bw/sounds/sound.html
+++ b/templates_bw/sounds/sound.html
@@ -101,10 +101,8 @@
                             {% if sound.geotag_id %}
                                 <div>
                                     <a href="{% url 'sound-geotag' sound.user.username sound.id %}">
-                                        {% bw_icon 'pin' %} {{ sound.geotag.lat|floatformat:3 }}, {{ sound.geotag.lon|floatformat:3 }}
+                                        {% bw_icon 'pin' %} {{ sound.geotag.get_location_name }}
                                     </a>
-                                    {% comment %}In the span above we should put the textual name of the place where the sound was recorded
-                                    (if there is geotag). For now we'll put cooedinates{% endcomment %}
                                 </div>
                                 {% if sound.pack_id or sound.remix_group.all.count %}
                                     <div class="text-grey h-spacing-left-1 h-spacing-1">·</div>


### PR DESCRIPTION
As suggested by the designer of the new frontend, this PR adds reverse geocoding so that we can display location names in the sound page for sounds with a geotag. The current implementation is very basic and uses offline data for city names and locations as bundled with reverse-geocoder python package: https://github.com/thampiman/reverse-geocoder

A more refined implementation could use Mapbox geocoding API to get more accurate information given a lat/lon coordinate, and store such information in the `GeoTag` model. That information could be requested at `GeoTag` creation and/or with a cronjob to fill out missing/failed ones.