### PR TITLE
Use static maps instead of "load map" in pack and profile pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ build_static.sh
 create_caches.sh
 run_tests.sh
 clear_cache.sh
+.venv
 
 # BW fornt end
 .cache

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1156,14 +1156,12 @@ def account(request, username):
                   or user.profile.get_total_downloads > 0  # user has downloads
                   or user.profile.num_sounds > 0)  # user has uploads
 
-    latest_geotags_static_image_url = None
-    if user.profile.has_geotags:
-        pins = [] # "pin-s+555555(42,21),pin-s+ff2600(67,42)"
+    last_geotags_serialized = []
+    if user.profile.has_geotags and settings.MAPBOX_USE_STATIC_MAPS_BEFORE_LOADING:
         for sound in Sound.public.select_related('geotag').filter(user__username__iexact=username).exclude(geotag=None)[0:10]:
-            pins.append('pin-s+ff2600({},{})'.format(sound.geotag.lon, sound.geotag.lat))
-        latest_geotags_static_image_url = "https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v11/static/{0}/auto/300x300@2x?padding=60%2C60%2C60%2C60&access_token={1}".format(','.join(pins), settings.MAPBOX_ACCESS_TOKEN)
-        print latest_geotags_static_image_url
-        
+            last_geotags_serialized.append({'lon': sound.geotag.lon, 'lat': sound.geotag.lat})
+        last_geotags_serialized = json.dumps(last_geotags_serialized)
+
     tvars = {
         'home': request.user == user if using_beastwhoosh(request) else False,
         'user': user,
@@ -1182,7 +1180,7 @@ def account(request, username):
         'following_modal_page': request.GET.get('following', 1),  # BW only, used to load a specific modal page
         'followers_modal_page': request.GET.get('followers', 1),  # BW only
         'following_tags_modal_page': request.GET.get('followingTags', 1),  # BW only
-        'latest_geotags_static_image_url': latest_geotags_static_image_url,  # BW only
+        'last_geotags_serialized': last_geotags_serialized,  # BW only
     }
     return render(request, 'accounts/account.html', tvars)
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1157,10 +1157,11 @@ def account(request, username):
                   or user.profile.num_sounds > 0)  # user has uploads
 
     last_geotags_serialized = []
-    if user.profile.has_geotags and settings.MAPBOX_USE_STATIC_MAPS_BEFORE_LOADING:
-        for sound in Sound.public.select_related('geotag').filter(user__username__iexact=username).exclude(geotag=None)[0:10]:
-            last_geotags_serialized.append({'lon': sound.geotag.lon, 'lat': sound.geotag.lat})
-        last_geotags_serialized = json.dumps(last_geotags_serialized)
+    if using_beastwhoosh(request):
+        if user.profile.has_geotags and settings.MAPBOX_USE_STATIC_MAPS_BEFORE_LOADING:
+            for sound in Sound.public.select_related('geotag').filter(user__username__iexact=username).exclude(geotag=None)[0:10]:
+                last_geotags_serialized.append({'lon': sound.geotag.lon, 'lat': sound.geotag.lat})
+            last_geotags_serialized = json.dumps(last_geotags_serialized)
 
     tvars = {
         'home': request.user == user if using_beastwhoosh(request) else False,

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1156,6 +1156,14 @@ def account(request, username):
                   or user.profile.get_total_downloads > 0  # user has downloads
                   or user.profile.num_sounds > 0)  # user has uploads
 
+    latest_geotags_static_image_url = None
+    if user.profile.has_geotags:
+        pins = [] # "pin-s+555555(42,21),pin-s+ff2600(67,42)"
+        for sound in Sound.public.select_related('geotag').filter(user__username__iexact=username).exclude(geotag=None)[0:10]:
+            pins.append('pin-s+ff2600({},{})'.format(sound.geotag.lon, sound.geotag.lat))
+        latest_geotags_static_image_url = "https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v11/static/{0}/auto/300x300@2x?padding=60%2C60%2C60%2C60&access_token={1}".format(','.join(pins), settings.MAPBOX_ACCESS_TOKEN)
+        print latest_geotags_static_image_url
+        
     tvars = {
         'home': request.user == user if using_beastwhoosh(request) else False,
         'user': user,
@@ -1174,6 +1182,7 @@ def account(request, username):
         'following_modal_page': request.GET.get('following', 1),  # BW only, used to load a specific modal page
         'followers_modal_page': request.GET.get('followers', 1),  # BW only
         'following_tags_modal_page': request.GET.get('followingTags', 1),  # BW only
+        'latest_geotags_static_image_url': latest_geotags_static_image_url,  # BW only
     }
     return render(request, 'accounts/account.html', tvars)
 

--- a/freesound.code-workspace
+++ b/freesound.code-workspace
@@ -80,5 +80,8 @@
 				"problemMatcher": []
 			}
 		]
+	},
+	"settings": {
+		"python.pythonPath": ".venv/bin/python"
 	}
 }

--- a/freesound.code-workspace
+++ b/freesound.code-workspace
@@ -32,6 +32,12 @@
 				"problemMatcher": []
 			},
 			{
+				"label": "Docker compose build",
+				"type": "shell",
+				"command": "docker-compose build",
+				"problemMatcher": []
+			},
+			{
 				"label": "Build static",
 				"type": "shell",
 				"command": "docker-compose run --rm web npm run build && docker-compose run --rm web python manage.py collectstatic --noinput",
@@ -59,6 +65,18 @@
 				"label": "Run tests",
 				"type": "shell",
 				"command": "docker-compose run --rm web python manage.py test --settings=freesound.test_settings",
+				"problemMatcher": []
+			},
+			{
+				"label": "Migrate",
+				"type": "shell",
+				"command": "docker-compose run --rm web python manage.py migrate",
+				"problemMatcher": []
+			},
+			{
+				"label": "Make migrations",
+				"type": "shell",
+				"command": "docker-compose run --rm web python manage.py makemigrations",
 				"problemMatcher": []
 			}
 		]

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -528,6 +528,7 @@ GRAYLOG_PASSWORD = ''
 # Mapbox
 
 MAPBOX_ACCESS_TOKEN = ''
+MAPBOX_USE_STATIC_MAPS_BEFORE_LOADING = True
 
 
 # -------------------------------------------------------------------------------
@@ -538,7 +539,7 @@ RECAPTCHA_PUBLIC_KEY = ''
 
 
 # -------------------------------------------------------------------------------
-# Mapbox
+# Akismet
 
 AKISMET_KEY = ''
 

--- a/freesound/static/bw-frontend/src/components/geotagPicker.js
+++ b/freesound/static/bw-frontend/src/components/geotagPicker.js
@@ -26,7 +26,7 @@ const showGeotagPickerHelpTool = refElementID => {
         wrapperElement.append(mapElement)
         wrapperElement.append(lowerButtonsElement)
         refElement.append(wrapperElement);
-        window.map = makeGeotagEditMap('geotag_picker_map', '{{media_url}}/images/arrow.png', showLatLonZoomFields);
+        window.map = makeGeotagEditMap('geotag_picker_map', showLatLonZoomFields);
     }
 }
 

--- a/freesound/static/bw-frontend/src/components/mapsMapbox.js
+++ b/freesound/static/bw-frontend/src/components/mapsMapbox.js
@@ -5,7 +5,7 @@ import {createPlayer} from './player/player-ui'
 var FREESOUND_SATELLITE_STYLE_ID = 'cjgxefqkb00142roas6kmqneq';
 var FREESOUND_STREETS_STYLE_ID = 'cjkmk0h7p79z32spe9j735hrd';
 var MIN_INPUT_CHARACTERS_FOR_GEOCODER =  3; // From mapbox docs: "Minimum number of characters to enter before [geocoder] results are shown"
-
+var MAP_MARKER_URL = '/media/images/map_marker.png';
 
 function setMaxZoomCenter(lat, lng, zoom) {
     window.map.flyTo({'center': [lng, lat], 'zoom': zoom - 1});  // Subtract 1 for compatibility with gmaps zoom levels
@@ -321,7 +321,7 @@ function makeSoundsMap(geotags_url, map_element_id, on_built_callback, on_bounds
 
 
             map.on('style.load', function () {  // Triggered when `setStyle` is called, add all data layers
-                map.loadImage('/media/images/map_marker.png', function(error, image) {
+                map.loadImage(MAP_MARKER_URL, function(error, image) {
                     map.addImage("custom-marker", image);
 
                     // Setup clustering
@@ -407,8 +407,7 @@ function makeSoundsMap(geotags_url, map_element_id, on_built_callback, on_bounds
 }
 
 
-function makeGeotagEditMap(map_element_id, arrow_url, on_bounds_changed_callback,
-                           center_lat, center_lon, zoom, idx){
+function makeGeotagEditMap(map_element_id, on_bounds_changed_callback, center_lat, center_lon, zoom, idx){
 
     /*
     This function is used to display the map used to add a geotag to a sound maps with sounds. It is used in the sound
@@ -479,7 +478,7 @@ function makeGeotagEditMap(map_element_id, arrow_url, on_bounds_changed_callback
     });
 
     map.on('style.load', function () {  // Triggered when `setStyle` is called, add all data layers
-        map.loadImage('/media/images/map_marker.png', function(error, image) {
+        map.loadImage(MAP_MARKER_URL, function(error, image) {
             map.addImage("custom-marker", image);
 
             // Add position marker
@@ -519,4 +518,20 @@ function makeGeotagEditMap(map_element_id, arrow_url, on_bounds_changed_callback
     return map;
 }
 
-export {makeSoundsMap, makeGeotagEditMap};
+const makeStaticMap = (map_wrapper_element_id, width, height, onclick) => {
+    const mapWrapperElement = document.getElementById(map_wrapper_element_id);
+    const token = mapboxgl.accessToken;
+    const padding = 60;
+    const pins = [];
+    JSON.parse(mapWrapperElement.dataset.pins).forEach( pin => {
+        pins.push(`url-https://freesound.org${MAP_MARKER_URL}(${pin.lon},${pin.lat})`)
+    });
+    const imageUrl = `https://api.mapbox.com/styles/v1/freesound/${FREESOUND_SATELLITE_STYLE_ID}/static/${encodeURIComponent(pins.join(','))}/auto/${width}x${height}?padding=${padding}%2C${padding}%2C${padding}%2C${padding}&access_token=${token}`;
+    mapWrapperElement.style.background = `url("${imageUrl}")`;
+    mapWrapperElement.style.backgroundSize = 'cover';
+    mapWrapperElement.addEventListener('click', () => {
+        onclick();
+    });
+}
+
+export {makeSoundsMap, makeGeotagEditMap, makeStaticMap};

--- a/freesound/static/bw-frontend/src/components/mapsMapbox.js
+++ b/freesound/static/bw-frontend/src/components/mapsMapbox.js
@@ -518,8 +518,8 @@ function makeGeotagEditMap(map_element_id, on_bounds_changed_callback, center_la
     return map;
 }
 
-const makeStaticMap = (map_wrapper_element_id, width, height, onclick) => {
-    const mapWrapperElement = document.getElementById(map_wrapper_element_id);
+const makeStaticMap = (mapWrapperElementId, width, height, onclick) => {
+    const mapWrapperElement = document.getElementById(mapWrapperElementId);
     const token = mapboxgl.accessToken;
     const padding = 60;
     const pins = [];
@@ -534,4 +534,53 @@ const makeStaticMap = (map_wrapper_element_id, width, height, onclick) => {
     });
 }
 
-export {makeSoundsMap, makeGeotagEditMap, makeStaticMap};
+/**
+ * @param {string} mainWrapperElementId
+ * @param {string} mapCanvasId
+ * @param {string} staticMapWrapperElementId
+ */
+const makeSoundsMapWithStaticMapFirst = (mainWrapperElementId, mapCanvasId, staticMapWrapperElementId) => {
+    // Load the map only when user clicks on "load map" button (or when clicking on static map image if using static map images)
+    const mapCanvas = document.getElementById(mapCanvasId);
+    const staticMapWrapper = document.getElementById(staticMapWrapperElementId);
+    const mainWrapperElement = document.getElementById(mainWrapperElementId);
+    const loadButtonWrapper = document.createElement('div');
+
+    const loadMapButton = document.createElement('button');
+    const loadMap = () => {
+    loadMapButton.disabled = true;
+    loadMapButton.innerText = 'Loading...'
+    if (mainWrapperElement.getAttribute('data-map-loaded') !== 'true') {
+        makeSoundsMap(mapCanvas.dataset.geotagsUrl, 'map_canvas', () => {
+        if (staticMapWrapper !== null){
+            staticMapWrapper.remove();
+        }
+        if (loadButtonWrapper !== null){
+            loadButtonWrapper.remove();
+        }
+        mainWrapperElement.setAttribute('data-map-loaded', "true");
+        mapCanvas.style.display = 'block'; // Once map is ready, show geotags section
+        });
+    }
+    }
+    loadButtonWrapper.id = 'loadMapButtonWrapper';
+    loadButtonWrapper.classList.add('middle', 'center', 'sidebar-map', 'border-radius-5', 'bg-navy-light-grey', 'w-100');
+    loadMapButton.onclick = () => {loadMap()};
+    loadMapButton.classList.add('btn-inverse');
+    loadMapButton.innerText = 'Load map...';
+    if (mainWrapperElement !== null){
+    if (staticMapWrapper !== null){
+        makeStaticMap('static_map_wrapper', 300, 300, () => {
+        loadMapButton.style.backgroundColor = "white";
+        staticMapWrapper.appendChild(loadMapButton);
+        loadMap();
+        })
+    } else {
+        loadButtonWrapper.appendChild(loadMapButton);
+        mainWrapperElement.insertBefore(loadButtonWrapper, mapCanvas);
+    }
+    }
+}
+
+
+export {makeSoundsMap, makeGeotagEditMap, makeSoundsMapWithStaticMapFirst};

--- a/freesound/static/bw-frontend/src/pages/pack.js
+++ b/freesound/static/bw-frontend/src/pages/pack.js
@@ -1,6 +1,6 @@
 import './page-polyfills';
 import {showToast} from '../components/toast';
-import {makeSoundsMap} from "../components/mapsMapbox";
+import {makeSoundsMapWithStaticMapFirst} from "../components/mapsMapbox";
 
 // Share pack button
 
@@ -29,28 +29,4 @@ toggleShareLinkElement.addEventListener('click',  toggleShareLink);
 shareLinkElement.style.display = "none"
 
 // Pack geotags map
-// Load the map only when user clicks on "load map" button
-const mapCanvas = document.getElementById('map_canvas');
-const geotagsSection = document.getElementById('pack_geotags');
-const loadButtonWrapper = document.createElement('div');
-const loadMapButton = document.createElement('button');
-const loadMap = () => {
-    loadMapButton.disabled = true;
-    loadMapButton.innerText = 'Loading...'
-    if (geotagsSection.getAttribute('data-map-loaded') !== 'true') {
-        makeSoundsMap(mapCanvas.dataset.geotagsUrl, 'map_canvas', () => {
-            loadButtonWrapper.remove();
-            geotagsSection.setAttribute('data-map-loaded', "true");
-            mapCanvas.style.display = 'block'; // Once map is ready, show geotags section
-        });
-    }
-}
-loadButtonWrapper.id = 'loadMapButtonWrapper';
-loadButtonWrapper.classList.add('middle', 'center', 'sidebar-map', 'border-radius-5', 'bg-navy-light-grey', 'w-100');
-loadMapButton.onclick = () => {loadMap()};
-loadMapButton.classList.add('btn-inverse');
-loadMapButton.innerText = 'Load map...';
-loadButtonWrapper.appendChild(loadMapButton);
-if (geotagsSection !== null){
-    geotagsSection.insertBefore(loadButtonWrapper, mapCanvas);
-}
+makeSoundsMapWithStaticMapFirst('pack_geotags', 'map_canvas', 'static_map_wrapper')

--- a/freesound/static/bw-frontend/src/pages/profile.js
+++ b/freesound/static/bw-frontend/src/pages/profile.js
@@ -1,4 +1,4 @@
-import {makeSoundsMap} from '../components/mapsMapbox';
+import {makeSoundsMap, makeStaticMap} from '../components/mapsMapbox';
 import {handleGenericModal, handleModal} from "../components/modal";
 
 // Latest sounds/Latest tags taps
@@ -95,8 +95,9 @@ if (followingTagsModalParam) {
 
 
 // User geotags map
-// Load the map only when user clicks on "load map" button
+// Load the map only when user clicks on "load map" button (or when clicking on static map image if using static map images)
 const mapCanvas = document.getElementById('map_canvas');
+const staticMapWrapper = document.getElementById('static_map_wrapper');
 const latestGeotagsSection = document.getElementById('latest_geotags');
 const loadButtonWrapper = document.createElement('div');
 const loadMapButton = document.createElement('button');
@@ -105,7 +106,12 @@ const loadMap = () => {
   loadMapButton.innerText = 'Loading...'
   if (latestGeotagsSection.getAttribute('data-map-loaded') !== 'true') {
     makeSoundsMap(mapCanvas.dataset.geotagsUrl, 'map_canvas', () => {
-      loadButtonWrapper.remove();
+      if (staticMapWrapper !== null){
+        staticMapWrapper.remove();
+      }
+      if (loadButtonWrapper !== null){
+        loadButtonWrapper.remove();
+      }
       latestGeotagsSection.setAttribute('data-map-loaded', "true");
       mapCanvas.style.display = 'block'; // Once map is ready, show geotags section
     });
@@ -116,8 +122,15 @@ loadButtonWrapper.classList.add('middle', 'center', 'sidebar-map', 'border-radiu
 loadMapButton.onclick = () => {loadMap()};
 loadMapButton.classList.add('btn-inverse');
 loadMapButton.innerText = 'Load map...';
-loadButtonWrapper.appendChild(loadMapButton);
 if (latestGeotagsSection !== null){
-  latestGeotagsSection.insertBefore(loadButtonWrapper, mapCanvas);
+  if (staticMapWrapper !== null){
+    makeStaticMap('static_map_wrapper', 300, 300, () => {
+      loadMapButton.style.backgroundColor = "white";
+      staticMapWrapper.appendChild(loadMapButton);
+      loadMap();
+    })
+  } else {
+    loadButtonWrapper.appendChild(loadMapButton);
+    latestGeotagsSection.insertBefore(loadButtonWrapper, mapCanvas);
+  }
 }
-

--- a/freesound/static/bw-frontend/src/pages/profile.js
+++ b/freesound/static/bw-frontend/src/pages/profile.js
@@ -94,5 +94,4 @@ if (followingTagsModalParam) {
 }
 
 // User geotags map
-// Load the map only when user clicks on "load map" button (or when clicking on static map image if using static map images)
 makeSoundsMapWithStaticMapFirst('latest_geotags', 'map_canvas', 'static_map_wrapper')

--- a/freesound/static/bw-frontend/src/pages/profile.js
+++ b/freesound/static/bw-frontend/src/pages/profile.js
@@ -1,4 +1,4 @@
-import {makeSoundsMap, makeStaticMap} from '../components/mapsMapbox';
+import {makeSoundsMapWithStaticMapFirst} from '../components/mapsMapbox';
 import {handleGenericModal, handleModal} from "../components/modal";
 
 // Latest sounds/Latest tags taps
@@ -93,44 +93,6 @@ if (followingTagsModalParam) {
   });
 }
 
-
 // User geotags map
 // Load the map only when user clicks on "load map" button (or when clicking on static map image if using static map images)
-const mapCanvas = document.getElementById('map_canvas');
-const staticMapWrapper = document.getElementById('static_map_wrapper');
-const latestGeotagsSection = document.getElementById('latest_geotags');
-const loadButtonWrapper = document.createElement('div');
-const loadMapButton = document.createElement('button');
-const loadMap = () => {
-  loadMapButton.disabled = true;
-  loadMapButton.innerText = 'Loading...'
-  if (latestGeotagsSection.getAttribute('data-map-loaded') !== 'true') {
-    makeSoundsMap(mapCanvas.dataset.geotagsUrl, 'map_canvas', () => {
-      if (staticMapWrapper !== null){
-        staticMapWrapper.remove();
-      }
-      if (loadButtonWrapper !== null){
-        loadButtonWrapper.remove();
-      }
-      latestGeotagsSection.setAttribute('data-map-loaded', "true");
-      mapCanvas.style.display = 'block'; // Once map is ready, show geotags section
-    });
-  }
-}
-loadButtonWrapper.id = 'loadMapButtonWrapper';
-loadButtonWrapper.classList.add('middle', 'center', 'sidebar-map', 'border-radius-5', 'bg-navy-light-grey', 'w-100');
-loadMapButton.onclick = () => {loadMap()};
-loadMapButton.classList.add('btn-inverse');
-loadMapButton.innerText = 'Load map...';
-if (latestGeotagsSection !== null){
-  if (staticMapWrapper !== null){
-    makeStaticMap('static_map_wrapper', 300, 300, () => {
-      loadMapButton.style.backgroundColor = "white";
-      staticMapWrapper.appendChild(loadMapButton);
-      loadMap();
-    })
-  } else {
-    loadButtonWrapper.appendChild(loadMapButton);
-    latestGeotagsSection.insertBefore(loadButtonWrapper, mapCanvas);
-  }
-}
+makeSoundsMapWithStaticMapFirst('latest_geotags', 'map_canvas', 'static_map_wrapper')

--- a/templates_bw/accounts/account.html
+++ b/templates_bw/accounts/account.html
@@ -186,6 +186,9 @@
                 <div class="divider-light"></div>
                 <section id="latest_geotags" class="v-spacing-top-5" data-map-loaded="false">
                     <h5 class="padding-bottom-3">Latest geotags</h5>
+                    {% if last_geotags_serialized %}
+                        <div id="static_map_wrapper"  class="sidebar-map w-100 middle center cursor-pointer" data-pins="{{ last_geotags_serialized }}"></div>
+                    {% endif %}
                     <div id="map_canvas" class="sidebar-map display-none w-100" data-geotags-url="{% url "geotags-for-user-latest-barray" user.username %}"></div>
                     <div class="v-spacing-top-2 center">
                         <a class="no-hover" href="{% url "geotags-for-user" user.username %}">See all geotags by {{ user.username }}</a>

--- a/templates_bw/sounds/pack.html
+++ b/templates_bw/sounds/pack.html
@@ -119,10 +119,15 @@
                         <div id="share-link" class="v-spacing-top-5">
                              <span class="text-grey">Share url: </span><br><input class="w-100" type="text" readonly value="{% absurl 'short-pack-link' pack.id %}" />
                         </div>
-                        {% if pack.has_geotags %}<div id="pack_geotags" class="v-spacing-top-6" data-map-loaded="false">
-                            <h5 class="padding-bottom-3">Geotags in this pack</h5>
-                            <div id="map_canvas" class="sidebar-map display-none w-100" data-geotags-url="{% url "geotags-for-pack-barray" pack.id %}"></div>
-                        </div>{% endif %}
+                        {% if pack.has_geotags %}
+                            <div id="pack_geotags" class="v-spacing-top-6" data-map-loaded="false">
+                                <h5 class="padding-bottom-3">Geotags in this pack</h5>
+                                {% if geotags_in_pack_serialized %}
+                                    <div id="static_map_wrapper"  class="sidebar-map w-100 middle center cursor-pointer" data-pins="{{ geotags_in_pack_serialized }}"></div>
+                                {% endif %}
+                                <div id="map_canvas" class="sidebar-map display-none w-100" data-geotags-url="{% url "geotags-for-pack-barray" pack.id %}"></div>
+                            </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
In order to reduce mapbox map loads in pack and profile pages we recently added a "load" map button that would trigger the load map only after user specifically requesting it. This PR uses the mapbox static maps API to generate a non-interactive map image to be shown instead of the load map button. Static map loads are cheaper than dynamic map loads so this is a viable option to keep showing maps by default. Upon clicking the static map, a dynamic map is loaded. The use of static maps can be toggled with the Django setting `MAPBOX_USE_STATIC_MAPS_BEFORE_LOADING`.