### PR TITLE
Add sound analysis data in bulk queries and index to search engine

### DIFF
--- a/apiv2/serializers.py
+++ b/apiv2/serializers.py
@@ -282,8 +282,7 @@ class SoundListSerializer(AbstractSoundSerializer):
     def get_ac_analysis(self, obj):
         # Get ac analysis data form the object itself as it will have been included in the Sound
         # by SoundManager.bulk_query
-        query_select_name = \
-            settings.ANALYZERS_CONFIGURATION[settings.AUDIOCOMMONS_ANALYZER_NAME]['query_select_name']
+        query_select_name = settings.AUDIOCOMMONS_ANALYZER_NAME.replace('-', '_')
         return getattr(obj, query_select_name, None)
 
     def get_analyzers_output(self, obj):
@@ -294,8 +293,8 @@ class SoundListSerializer(AbstractSoundSerializer):
         # for legacy reasons.
         analyzers_output = {}
         for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
-            if 'query_select_name' in analyzer_info:
-                query_select_name = analyzer_info['query_select_name']
+            if 'descriptors_map' in analyzer_info:
+                query_select_name = analyzer_name.replace('-', '_')
                 analysis_data = getattr(obj, query_select_name, None)
                 if analysis_data is not None:
                     analyzers_output.update(analysis_data)
@@ -328,8 +327,7 @@ class SoundSerializer(AbstractSoundSerializer):
     def get_ac_analysis(self, obj):
         # Retrieve analysis data already loaded in the provided object of get it from related SoundAnalysis object
         # corresponding to the Audio Commons extractor.
-        query_select_name = \
-            settings.ANALYZERS_CONFIGURATION[settings.AUDIOCOMMONS_ANALYZER_NAME]['query_select_name']
+        query_select_name = settings.AUDIOCOMMONS_ANALYZER_NAME.replace('-', '_')
         if hasattr(obj, query_select_name):
             return getattr(obj, query_select_name)
         else:
@@ -350,8 +348,8 @@ class SoundSerializer(AbstractSoundSerializer):
         # via analyzers_output field. This is kept like that for legacy reasons.
         analyzers_output = {}
         for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
-            if 'query_select_name' in analyzer_info:
-                query_select_name = analyzer_info['query_select_name']
+            if 'descriptors_map' in analyzer_info:
+                query_select_name = analyzer_name.replace('-', '_')
                 if hasattr(obj, query_select_name):
                     analysis_data = getattr(obj, query_select_name)
                 else:

--- a/apiv2/serializers.py
+++ b/apiv2/serializers.py
@@ -99,6 +99,7 @@ class AbstractSoundSerializer(serializers.HyperlinkedModelSerializer):
                   'analysis_frames',
                   'analysis_stats',
                   'ac_analysis',
+                  'analyzers_output'
                   )
 
     url = serializers.SerializerMethodField()
@@ -188,7 +189,6 @@ class AbstractSoundSerializer(serializers.HyperlinkedModelSerializer):
                                           request_is_secure=self.context['request'].is_secure()),
         }
 
-
     analysis = serializers.SerializerMethodField()
     def get_analysis(self, obj):
         raise NotImplementedError  # Should be implemented in subclasses
@@ -259,6 +259,10 @@ class AbstractSoundSerializer(serializers.HyperlinkedModelSerializer):
     def get_ac_analysis(self, obj):
         raise NotImplementedError  # Should be implemented in subclasses
 
+    analyzers_output = serializers.SerializerMethodField()
+    def get_analyzers_output(self, obj):
+        raise NotImplementedError  # Should be implemented in subclasses
+
 
 class SoundListSerializer(AbstractSoundSerializer):
 
@@ -278,9 +282,22 @@ class SoundListSerializer(AbstractSoundSerializer):
     def get_ac_analysis(self, obj):
         # Get ac analysis data form the object itself as it will have been included in the Sound
         # by SoundManager.bulk_query
-        if obj.ac_analysis:
-            return obj.ac_analysis
-        return None
+        query_select_name = \
+            settings.ANALYZERS_CONFIGURATION[settings.AUDIOCOMMONS_ANALYZER_NAME]['query_select_name']
+        return getattr(obj, query_select_name, None)
+
+    def get_analyzers_output(self, obj):
+        # Get the output of analyzers configured in settings.ANALYZERS_CONFIGURATION.
+        # Analysis data will have been included in the Sound object by SoundManager.bulk_query.
+        # Note that audio commons analyzer data can also be obtained with the ac_analysis field name but all
+        # other analyzers' output is only accessible via analyzers_output field. This is kept like that
+        # for legacy reasons.
+        analyzers_output = {}
+        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
+            if 'query_select_name' in analyzer_info:
+                query_select_name = analyzer_info['query_select_name']
+                analyzers_output[analyzer_name] = getattr(obj, query_select_name, None)
+        return analyzers_output
 
 
 class SoundSerializer(AbstractSoundSerializer):
@@ -309,10 +326,10 @@ class SoundSerializer(AbstractSoundSerializer):
     def get_ac_analysis(self, obj):
         # Retrieve analysis data already loaded in the provided object of get it from related SoundAnalysis object
         # corresponding to the Audio Commons extractor.
-
-        if hasattr(obj, 'ac_analysis'):
-            if obj.ac_analysis is not None:
-                return obj.ac_analysis
+        query_select_name = \
+            settings.ANALYZERS_CONFIGURATION[settings.AUDIOCOMMONS_ANALYZER_NAME]['query_select_name']
+        if hasattr(obj, query_select_name):
+            return getattr(obj, query_select_name)
         else:
             # No ac analysis data already loaded in the object, load it with an extra query
             try:
@@ -321,8 +338,29 @@ class SoundSerializer(AbstractSoundSerializer):
             except SoundAnalysis.DoesNotExist:
                 # Do nothing, will lead to end of the method returning None
                 pass
-
         return None
+
+    def get_analyzers_output(self, obj):
+        # Get the output of analyzers configured in settings.ANALYZERS_CONFIGURATION.
+        # Analysis data will have been included in the Sound object by SoundManager.bulk_query,
+        # otherwise it is loaded from db. Note that audio commons analyzer data can also be
+        # obtained with the ac_analysis field name but all other analyzers' output is only accessible
+        # via analyzers_output field. This is kept like that for legacy reasons.
+        analyzers_output = {}
+        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
+            if 'query_select_name' in analyzer_info:
+                query_select_name = analyzer_info['query_select_name']
+                if hasattr(obj, query_select_name):
+                    analyzers_output[analyzer_name] = getattr(obj, query_select_name)
+                else:
+                    # Retrieve the analysis data from the db
+                    try:
+                        analyzers_output[analyzer_name] = obj.analyses\
+                            .get(analyzer=analyzer_name, analysis_status="OK").analysis_data
+                    except SoundAnalysis.DoesNotExist:
+                        # Do nothing, will return None for this analyzer
+                        analyzers_output[analyzer_name] = None
+        return analyzers_output
 
 
 ##################

--- a/apiv2/serializers.py
+++ b/apiv2/serializers.py
@@ -296,7 +296,9 @@ class SoundListSerializer(AbstractSoundSerializer):
         for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
             if 'query_select_name' in analyzer_info:
                 query_select_name = analyzer_info['query_select_name']
-                analyzers_output[analyzer_name] = getattr(obj, query_select_name, None)
+                analysis_data = getattr(obj, query_select_name, None)
+                if analysis_data is not None:
+                    analyzers_output.update(analysis_data)
         return analyzers_output
 
 
@@ -351,15 +353,15 @@ class SoundSerializer(AbstractSoundSerializer):
             if 'query_select_name' in analyzer_info:
                 query_select_name = analyzer_info['query_select_name']
                 if hasattr(obj, query_select_name):
-                    analyzers_output[analyzer_name] = getattr(obj, query_select_name)
+                    analysis_data = getattr(obj, query_select_name)
                 else:
                     # Retrieve the analysis data from the db
                     try:
-                        analyzers_output[analyzer_name] = obj.analyses\
-                            .get(analyzer=analyzer_name, analysis_status="OK").analysis_data
+                        analysis_data = obj.analyses.get(analyzer=analyzer_name, analysis_status="OK").analysis_data
                     except SoundAnalysis.DoesNotExist:
-                        # Do nothing, will return None for this analyzer
-                        analyzers_output[analyzer_name] = None
+                        analysis_data = None
+                if analysis_data is not None:
+                    analyzers_output.update(analysis_data)
         return analyzers_output
 
 

--- a/apiv2/serializers.py
+++ b/apiv2/serializers.py
@@ -98,7 +98,7 @@ class AbstractSoundSerializer(serializers.HyperlinkedModelSerializer):
                   'analysis',
                   'analysis_frames',
                   'analysis_stats',
-                  'ac_analysis',
+                  'ac_analysis',  # Kept for legacy reasons only as it is also contained in 'analyzers_output'
                   'analyzers_output'
                   )
 

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -451,7 +451,6 @@ AUDIOSET_YAMNET_ANALYZER_NAME = 'audioset-yamnet_v1'
 
 ANALYZERS_CONFIGURATION = {
     AUDIOCOMMONS_ANALYZER_NAME: {
-        'query_select_name': 'ac_analysis',  # db field name used in bulk_query_id/bulk_query_solr for this analyzer
         'descriptors_map': [
             ('loudness', 'ac_loudness', float),
             ('dynamic_range', 'ac_dynamic_range', float),
@@ -479,7 +478,6 @@ ANALYZERS_CONFIGURATION = {
     },
     FREESOUND_ESSENTIA_EXTRACTOR_NAME: {},
     AUDIOSET_YAMNET_ANALYZER_NAME: {
-        'query_select_name': 'yamnet_analysis',
         'descriptors_map': [
             ('classes', 'yamnet_class', list)
         ]

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -451,6 +451,7 @@ AUDIOSET_YAMNET_ANALYZER_NAME = 'audioset-yamnet_v1'
 
 ANALYZERS_CONFIGURATION = {
     AUDIOCOMMONS_ANALYZER_NAME: {
+        'query_select_name': 'ac_analysis',  # db field name used in bulk_query_id/bulk_query_solr for this analyzer
         'descriptors_map': [
             ('loudness', 'ac_loudness', float),
             ('dynamic_range', 'ac_dynamic_range', float),
@@ -478,6 +479,7 @@ ANALYZERS_CONFIGURATION = {
     },
     FREESOUND_ESSENTIA_EXTRACTOR_NAME: {},
     AUDIOSET_YAMNET_ANALYZER_NAME: {
+        'query_select_name': 'yamnet_analysis',
         'descriptors_map': [
             ('classes', 'classes', str)
         ]

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -481,7 +481,7 @@ ANALYZERS_CONFIGURATION = {
     AUDIOSET_YAMNET_ANALYZER_NAME: {
         'query_select_name': 'yamnet_analysis',
         'descriptors_map': [
-            ('classes', 'classes', str)
+            ('classes', 'yamnet_class', list)
         ]
     },
 }

--- a/sounds/admin.py
+++ b/sounds/admin.py
@@ -202,7 +202,7 @@ admin.site.register(BulkUploadProgress, BulkUploadProgressAdmin)
 class SoundAnalysisAdmin(DjangoObjectActions, admin.ModelAdmin):
     list_display = ('analyzer', 'sound_id',  'analysis_status', 'last_sent_to_queue', 'last_analyzer_finished',
                     'num_analysis_attempts', 'analysis_time')
-    ordering = ('-last_sent_to_queue',)
+    ordering = ('-last_analyzer_finished',)
     list_filter = ('analyzer', 'analysis_status')
     search_fields = ('=sound__id',)
     actions = ('re_run_analysis',)

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -1648,12 +1648,7 @@ class SoundLicenseHistory(models.Model):
 class SoundAnalysis(models.Model):
     """Reference to the analysis output for a given sound and extractor.
     The actual output can be either directly stored in the model (using analysis_data field),
-    or can be stored in a JSON file in disk (using the analysis_filename field).
-
-    NOTE: currently we only use this model to store the output of the Audio Commons extractor (using
-    analysis_data field). We chose to implement it more generically (i.e. name the model SoundAnalysis
-    instead of AudioCommonsAnalysis) so that we can use it in the future for standard Essentia analysis
-    or for other extractors as well, but for the current use case that wouldn't be needed.
+    or can be stored in a JSON/YAML file in disk.
     """
     STATUS_CHOICES = (
             ("QU", 'Queued'),

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -351,9 +351,9 @@ class SoundManager(models.Manager):
         in the bulk query"""
         analyzers_select_section_parts = []
         for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
-            if 'query_select_name' in analyzer_info:
+            if 'descriptors_map' in analyzer_info:
                 analyzers_select_section_parts.append("{0}.analysis_data as {0},"
-                                                      .format(analyzer_info['query_select_name']))
+                                                      .format(analyzer_name.replace('-', '_')))
         return "\n          ".join(analyzers_select_section_parts)
 
     def get_analyzers_data_left_join_sql(self):
@@ -361,10 +361,10 @@ class SoundManager(models.Manager):
         in the bulk query"""
         analyzers_left_join_section_parts = []
         for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
-            if 'query_select_name' in analyzer_info:
+            if 'descriptors_map' in analyzer_info:
                 analyzers_left_join_section_parts.append(
                     "LEFT JOIN sounds_soundanalysis {0} ON (sound.id = {0}.sound_id AND {0}.analyzer = '{1}')"
-                        .format(analyzer_info['query_select_name'], analyzer_name))
+                        .format(analyzer_name.replace('-', '_'), analyzer_name))
         return "\n          ".join(analyzers_left_join_section_parts)
 
     def bulk_query_solr(self, sound_ids):

--- a/sounds/tests/test_manager.py
+++ b/sounds/tests/test_manager.py
@@ -34,16 +34,18 @@ class SoundManagerQueryMethods(TestCase):
                                      'processing_ongoing_state', 'similarity_state', 'created', 'num_downloads',
                                      'num_comments', 'pack_id', 'duration', 'pack_name', 'license_id', 'license_name',
                                      'license_deed_url', 'geotag_id', 'remixgroup_id', 'tag_array'] \
-                                    + [item['query_select_name'] for item in settings.ANALYZERS_CONFIGURATION.values()
-                                       if 'query_select_name' in item]
+                                    + [analyzer_name.replace('-', '_') for analyzer_name, analyzer_info
+                                       in settings.ANALYZERS_CONFIGURATION.items()
+                                       if 'descriptors_map' in analyzer_info]
 
     fields_to_check_bulk_query_solr = ['username', 'user_id', 'id', 'type', 'original_filename', 'is_explicit',
                                        'filesize', 'md5', 'channels', 'avg_rating', 'num_ratings', 'description',
                                        'created', 'num_downloads', 'num_comments', 'duration', 'pack_id', 'geotag_id',
                                        'bitrate', 'bitdepth', 'samplerate', 'pack_name', 'license_name', 'geotag_lat',
                                        'geotag_lon', 'is_remix', 'was_remixed', 'tag_array', 'comments_array'] \
-                                    + [item['query_select_name'] for item in settings.ANALYZERS_CONFIGURATION.values()
-                                       if 'query_select_name' in item]
+                                      + [analyzer_name.replace('-', '_') for analyzer_name, analyzer_info
+                                         in settings.ANALYZERS_CONFIGURATION.items()
+                                         if 'descriptors_map' in analyzer_info]
 
     def setUp(self):
         user, packs, sounds = create_user_and_sounds(num_sounds=3, num_packs=1, tags="tag1 tag2 tag3")

--- a/sounds/tests/test_manager.py
+++ b/sounds/tests/test_manager.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from django.conf import settings
 from django.test import TestCase
 
 from sounds.models import Sound, Pack
@@ -32,14 +33,17 @@ class SoundManagerQueryMethods(TestCase):
                                      'avg_rating', 'num_ratings', 'description', 'moderation_state', 'processing_state',
                                      'processing_ongoing_state', 'similarity_state', 'created', 'num_downloads',
                                      'num_comments', 'pack_id', 'duration', 'pack_name', 'license_id', 'license_name',
-                                     'license_deed_url', 'geotag_id', 'remixgroup_id', 'ac_analysis', 'tag_array']
+                                     'license_deed_url', 'geotag_id', 'remixgroup_id', 'tag_array'] \
+                                    + [item['query_select_name'] for item in settings.ANALYZERS_CONFIGURATION.values()
+                                       if 'query_select_name' in item]
 
     fields_to_check_bulk_query_solr = ['username', 'user_id', 'id', 'type', 'original_filename', 'is_explicit',
                                        'filesize', 'md5', 'channels', 'avg_rating', 'num_ratings', 'description',
                                        'created', 'num_downloads', 'num_comments', 'duration', 'pack_id', 'geotag_id',
                                        'bitrate', 'bitdepth', 'samplerate', 'pack_name', 'license_name', 'geotag_lat',
-                                       'geotag_lon', 'ac_analysis', 'is_remix', 'was_remixed', 'tag_array',
-                                       'comments_array']
+                                       'geotag_lon', 'is_remix', 'was_remixed', 'tag_array', 'comments_array'] \
+                                    + [item['query_select_name'] for item in settings.ANALYZERS_CONFIGURATION.values()
+                                       if 'query_select_name' in item]
 
     def setUp(self):
         user, packs, sounds = create_user_and_sounds(num_sounds=3, num_packs=1, tags="tag1 tag2 tag3")

--- a/utils/search/backends/solr451custom.py
+++ b/utils/search/backends/solr451custom.py
@@ -172,8 +172,8 @@ def convert_sound_to_search_engine_document(sound):
 
     # Analyzer's output
     for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
-        if 'query_select_name' in analyzer_info:
-            query_select_name = analyzer_info['query_select_name']
+        if 'descriptors_map' in analyzer_info:
+            query_select_name = analyzer_name.replace('-', '_')
             analysis_data = getattr(sound, query_select_name, None)
             if analysis_data is not None:
                 # If analysis is present, index all existing analysis fields using SOLR dynamic fields depending on

--- a/utils/search/backends/solr451custom.py
+++ b/utils/search/backends/solr451custom.py
@@ -74,14 +74,15 @@ SORT_OPTIONS_MAP = {
 }
 
 # Map of suffixes used for each type of dynamic fields defined in our Solr schema
-# The dynamic field names we define in Solr schema are '*_b' (for bool), '*_d' (for float), '*_i' (for integer)
-# and '*_s' (for string)
+# The dynamic field names we define in Solr schema are '*_b' (for bool), '*_d' (for float), '*_i' (for integer),
+# '*_s' (for string) and '*_ls' (for lists of strings)
 SOLR_DYNAMIC_FIELDS_SUFFIX_MAP = {
     float: '_d',
     int: '_i',
     bool: '_b',
     str: '_s',
     unicode: '_s',
+    list: '_ls',
 }
 
 SOLR_SOUND_FACET_DEFAULT_OPTIONS = {
@@ -169,18 +170,21 @@ def convert_sound_to_search_engine_document(sound):
     document["spectral_path_l"] = locations["display"]["spectral"]["L"]["path"]
     document["preview_path"] = locations["preview"]["LQ"]["mp3"]["path"]
 
-    # Audio Commons analysis
-    # NOTE: as the sound object here is the one returned by SoundManager.bulk_query_solr, it will have the Audio Commons
-    # descriptor fields under a property called 'ac_analysis'.
-    ac_analysis = getattr(sound, "ac_analysis")
-    if ac_analysis is not None:
-        # If analysis is present, index all existing analysis fields under Solr's dynamic fields "*_i", "*_d", "*_s"
-        # and "*_b" depending on the value's type. Also add Audio Commons prefix.
-        for key, value in ac_analysis.items():
-            suffix = SOLR_DYNAMIC_FIELDS_SUFFIX_MAP.get(type(value), None)
-            if suffix:
-                document['{0}{1}'.format(key, suffix)] = value
-
+    # Analyzer's output
+    for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
+        if 'query_select_name' in analyzer_info:
+            query_select_name = analyzer_info['query_select_name']
+            analysis_data = getattr(sound, query_select_name, None)
+            if analysis_data is not None:
+                # If analysis is present, index all existing analysis fields using SOLR dynamic fields depending on
+                # the value type (see SOLR_DYNAMIC_FIELDS_SUFFIX_MAP) so solr knows how to treat when filtering, etc.
+                for key, value in analysis_data.items():
+                    if type(value) == list:
+                        # Make sure that the list is formed by strings
+                        value = ['{}'.format(item) for item in value]
+                    suffix = SOLR_DYNAMIC_FIELDS_SUFFIX_MAP.get(type(value), None)
+                    if suffix:
+                        document['{0}{1}'.format(key, suffix)] = value
     return document
 
 

--- a/utils/search/solr4.5.1/solr.home/fs2/conf/schema.xml
+++ b/utils/search/solr4.5.1/solr.home/fs2/conf/schema.xml
@@ -311,11 +311,12 @@
 		<field name="preview_path" type="string" indexed="false" stored="true" required="true" />
 
         <!-- Dynamic fields -->
-        <!-- This will be used to index Audio Commons analysis fields and potentially other stuff -->
-        <dynamicField name="*_i" type="sint" indexed="true" stored="true"/>
-        <dynamicField name="*_d" type="sdouble" indexed="true" stored="true"/>
-        <dynamicField name="*_b" type="boolean" indexed="true" stored="true"/>
-        <dynamicField name="*_s" type="string" indexed="true" stored="true"/>
+        <!-- This will be used to index analyzer results fields and potentially other stuff -->
+        <dynamicField name="*_i" type="sint" indexed="true" stored="true"/> <!-- integer -->
+        <dynamicField name="*_d" type="sdouble" indexed="true" stored="true"/> <!-- double -->
+        <dynamicField name="*_b" type="boolean" indexed="true" stored="true"/> <!-- bool -->
+        <dynamicField name="*_s" type="string" indexed="true" stored="true"/> <!-- string -->
+        <dynamicField name="*_ls" type="alphaOnlySort" indexed="true" stored="true" required="false" multiValued="true"/> <!-- list of string (or tags) -->
 
         <!-- Other fields -->
         <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>


### PR DESCRIPTION
This PR complements recent efforts in re-factoring of the analysis code and adds support for indexing in the search engine the outputs of the analyzers listed in `descriptors_map` configuration as well as support for retrieving the values from the DB with optimized number of queries (like it was previously done only for the audio commons descriptors)