### PR TITLE
Add support for "weights" parameter in search view and API

### DIFF
--- a/_docs/api/source/resources.rst
+++ b/_docs/api/source/resources.rst
@@ -40,6 +40,7 @@ Name                    Type                       Description
 ``filter``              string                     Allows filtering query results. See below for more information.
 ``sort``                string                     Indicates how query results should be sorted. See below for a list of the sorting options. By default ``sort=score``.
 ``group_by_pack``       bool (yes=1, no=0)         This parameter represents a boolean option to indicate whether to collapse results belonging to sounds of the same pack into single entries in the results list. If ``group_by_pack=1`` and search results contain more than one sound that belongs to the same pack, only one sound for each distinct pack is returned (sounds with no packs are returned as well). However, the returned sound will feature two extra properties to access these other sounds omitted from the results list: ``n_from_same_pack``: indicates how many other results belong to the same pack (and have not been returned) ``more_from_same_pack``: uri pointing to the list of omitted sound results of the same pack (also including the result which has already been returned). See examples below. By default ``group_by_pack=0``.
+``weights``             string                     Allows definition of custom weights when matching queries with sound metadata fields. You should most likely never use that :)
 ======================  =========================  ======================
 
 
@@ -160,6 +161,16 @@ downloads_asc   Same as above, but least downloaded sounds first.
 rating_desc     Sort by the average rating given to the sounds, highest rated first.
 rating_asc      Same as above, but lowest rated sounds first.
 ==============  ====================================================================
+
+
+**The 'weights' parameter**
+
+The ``weights`` parameter can be sued to define custom weights when matching queries with sound metadata fields. You can use any of the field names listed above 
+(although some might not make sense when preparing a query) and specify integer weights for each field using the following syntax::
+
+  weights=field_name:integer_weight,field_name2:integer_weight2
+
+If the format is not correct, custom weights will not be applied. The default weights are something like ``id:4,tag:4,description:3,original_filename:2,username:2,pack:2``.
 
 
 **Filter queries using geotagging data**

--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -50,6 +50,7 @@ from similarity.client import SimilarityException
 from utils.encryption import create_hash
 from utils.logging_filters import get_client_ip
 from utils.search import SearchEngineException, get_search_engine
+from utils.search.search_sounds import parse_weights_parameter
 from utils.similarity_utilities import api_search as similarity_api_search
 from utils.similarity_utilities import get_sounds_descriptors
 
@@ -329,6 +330,7 @@ def api_search(
             result = get_search_engine().search_sounds(
                 textual_query=unquote(search_form.cleaned_data['query'] or ""),
                 query_filter=unquote(search_form.cleaned_data['filter'] or ""),
+                query_fields=parse_weights_parameter(search_form.cleaned_data['weights']),
                 sort=processed_sort,
                 offset=(search_form.cleaned_data['page'] - 1) * search_form.cleaned_data['page_size'],
                 num_sounds=search_form.cleaned_data['page_size'],

--- a/apiv2/combined_search_strategies.py
+++ b/apiv2/combined_search_strategies.py
@@ -22,6 +22,7 @@
 from apiv2.forms import API_SORT_OPTIONS_MAP
 from utils.similarity_utilities import api_search as similarity_api_search
 from utils.search import SearchEngineException, get_search_engine
+from utils.search.search_sounds import parse_weights_parameter
 from similarity.client import SimilarityException
 from exceptions import ServerErrorException, BadRequestException, NotFoundException
 from urllib import unquote
@@ -338,6 +339,7 @@ def get_solr_results(search_form, page_size, max_pages, start_page=1, valid_ids=
             result = search_engine.search_sounds(
                 textual_query=unquote(search_form.cleaned_data['query'] or ""),
                 query_filter=unquote(query_filter or ""),
+                query_fields=parse_weights_parameter(search_form.cleaned_data['weights']),
                 sort=processed_sort,
                 offset=(current_page - 1) * page_size,
                 num_sounds=page_size,

--- a/apiv2/forms.py
+++ b/apiv2/forms.py
@@ -176,6 +176,8 @@ class SoundCombinedSearchFormAPI(forms.Form):
                 link += '&filter=%s' % my_quote(self.cleaned_data['filter'])
         else:
             link += '&filter=%s' % my_quote(filt)
+        if self.cleaned_data['weights'] is not None:
+            link += '&weights=%s' % self.cleaned_data['weights']
         if self.original_url_sort_value and not self.original_url_sort_value == SEARCH_SOUNDS_SORT_DEFAULT_API.split(' ')[0]:
             link += '&sort=%s' % self.original_url_sort_value
         if self.cleaned_data['descriptors_filter']:

--- a/apiv2/forms.py
+++ b/apiv2/forms.py
@@ -81,6 +81,7 @@ class SoundCombinedSearchFormAPI(forms.Form):
     query = forms.CharField(required=False, label='query')
     page = forms.CharField(required=False, label='page')
     filter = forms.CharField(required=False, label='filter')
+    weights = forms.CharField(required=False, label='weights')
     sort = forms.CharField(required=False, label='sort')
     fields = forms.CharField(required=False, label='fields')
     descriptors = forms.CharField(required=False, label='descriptors')

--- a/search/templatetags/search.py
+++ b/search/templatetags/search.py
@@ -29,7 +29,7 @@ register = template.Library()
 
 
 @register.inclusion_tag('search/facet.html', takes_context=True)
-def display_facet(context, flt, facet, type, title=""):
+def display_facet(context, flt, facet, facet_type, title=""):
     facet = annotate_tags([dict(name=f[0], count=f[1]) for f in facet if f[0] != "0"],
                           sort="name", small_size=0.7, large_size=2.0)
 
@@ -56,12 +56,13 @@ def display_facet(context, flt, facet, type, title=""):
 
         element['params'] = u'{0} {1}:"{2}"'.format(filter_query, flt, urlquote_plus(element['name']))
         element['id'] = u'{0}--{1}'.format(flt, urlquote_plus(element['name']))
-        element['add_filter_url'] = u'.?g={0}&only_p={1}&q={2}&f={3}&s={4}'.format(
+        element['add_filter_url'] = u'.?g={0}&only_p={1}&q={2}&f={3}&s={4}&w={5}'.format(
             context['grouping'],
             context['only_sounds_with_pack'],
             context['search_query'],
             element['params'],
-            context['sort']
+            context['sort'] if context['sort'] is not None else '',
+            context['weights'] or ''
         )
         filtered_facet.append(element)
 
@@ -75,7 +76,7 @@ def display_facet(context, flt, facet, type, title=""):
 
     context.update({
         "facet": filtered_facet,
-        "type": type,
+        "type": facet_type,
         "filter": flt,
         "title": title
     })

--- a/search/views.py
+++ b/search/views.py
@@ -88,7 +88,8 @@ def search(request):
         'current_page': query_params['current_page'],
         'url_query_params_string': url_query_params_string,
         'cluster_id': extra_vars['cluster_id'],
-        'clustering_on': settings.ENABLE_SEARCH_RESULTS_CLUSTERING
+        'clustering_on': settings.ENABLE_SEARCH_RESULTS_CLUSTERING,
+        'weights': extra_vars['raw_weights_parameter']
     }
 
     tvars.update(advanced_search_params_dict)

--- a/templates/search/facet.html
+++ b/templates/search/facet.html
@@ -1,10 +1,10 @@
 {% ifequal type "list" %}
  <ul>
-     {% for f in facet %}<li class="facet_item"><a href=".?g={{grouping}}&q={{search_query}}&f={{f.params}}&s={{sort}}&cluster_id={{cluster_id}}">{{f.display_name}}</a> ({{f.count}})</li>{% endfor %}
+     {% for f in facet %}<li class="facet_item"><a href="{{ f.add_filter_url }}">{{f.display_name}}</a> ({{f.count}})</li>{% endfor %}
 </ul>
 {% endifequal %}
 {% ifequal type "cloud" %}
 <p class="search-tagcloud">
-    {% for f in facet %}<span class="facet_item" style="font-size:{{f.size}}em"><a href=".?g={{grouping}}&q={{search_query}}&f={{f.params}}&s={{sort}}&cluster_id={{cluster_id}}">{{f.display_name}}</a></span> {% endfor %}
+    {% for f in facet %}<span class="facet_item" style="font-size:{{f.size}}em"><a href="{{ f.add_filter_url }}">{{f.display_name}}</a></span> {% endfor %}
 </p>
 {% endifequal %}

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -25,6 +25,7 @@
 
        <input id="query_input" type="text" name="q" value="{{search_query}}" size="30" />
        <input id="filter_query" type="hidden" name="f" value="{{filter_query}}" size="30" />
+       <input id="weights" type="hidden" name="w" value="{{weights}}" />
        {% comment %}
        <span class="advanced_search_options">Sort results by </span>
        {% endcomment %}
@@ -47,7 +48,7 @@
 <p id="filter_query_display">
 
 {% for filter in filter_query_split %}
-    <a href=".?g={{grouping}}&q={{search_query}}&f={{ filter.remove_url }}&s={{ sort }}&cluster_id={{ filter.cluster_id }}" title="remove this filter">{{ filter.name }}</a>
+    <a href=".?g={{grouping}}&q={{search_query}}&f={{ filter.remove_url }}&s={{ sort }}&cluster_id={{ filter.cluster_id }}&w={{ weights }}" title="remove this filter">{{ filter.name }}</a>
 {% endfor %}
 
 </p>

--- a/templates/templatetags/plausible_scripts.html
+++ b/templates/templatetags/plausible_scripts.html
@@ -2,8 +2,7 @@
         <script defer data-domain="freesound.org" src="https://analytics.freesound.org/js/plausible.manual.js"></script>
         <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
         <script>
-          let url = window.location.href;
-          let redactedUrl = url.replace(/\/\d+\//g, "/_ID_/"); // Replace numberic IDs
+          let redactedUrl = window.location.href.replace(/\/\d+\//g, "/_ID_/"); // Replace numberic IDs
           redactedUrl = redactedUrl.replace(/people\/(\w+)\//ig, "people/_ID_/");  // Replace usernames
           redactedUrl = redactedUrl.replace(/browse\/geotags\/(\w+)\//ig, "browse/geotags/_TAG_/");  // Replace tag frm geotags
           redactedUrl = redactedUrl.replace(/browse\/tags\/.*/ig, "browse/tags/_TAGS_/");  // Replace multiple tags form tags

--- a/templates_bw/molecules/plausible_scripts.html
+++ b/templates_bw/molecules/plausible_scripts.html
@@ -2,8 +2,7 @@
         <script defer data-domain="freesound.org" src="https://analytics.freesound.org/js/plausible.manual.js"></script>
         <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
         <script>
-          let url = window.location.href;
-          let redactedUrl = url.replace(/\/\d+\//g, "/_ID_/"); // Replace numberic IDs
+          let redactedUrl = window.location.href.replace(/\/\d+\//g, "/_ID_/"); // Replace numberic IDs
           redactedUrl = redactedUrl.replace(/people\/(\w+)\//ig, "people/_ID_/");  // Replace usernames
           redactedUrl = redactedUrl.replace(/browse\/geotags\/(\w+)\//ig, "browse/geotags/_TAG_/");  // Replace tag frm geotags
           redactedUrl = redactedUrl.replace(/browse\/tags\/.*/ig, "browse/tags/_TAGS_/");  // Replace multiple tags form tags

--- a/templates_bw/search/search.html
+++ b/templates_bw/search/search.html
@@ -30,6 +30,7 @@
                             <div></div>
                             <input id="search-input-browse" name="q" type="text" value="{{ search_query }}" placeholder="Start browsing here" class="bw-search__input" autocomplete="off" />
                             <input id="filter_query" type="hidden" name="f" value="{{filter_query}}" />
+                            <input id="weights" type="hidden" name="w" value="{{weights}}" />
                             <span class="bw-search_remove-query" id="remove-content-search">{% bw_icon 'close' %}</span>
                         </div>
                     </div>
@@ -235,7 +236,7 @@
                         {% if filter_query_split %}
                         <div class="v-spacing-3 v-spacing-top-2">
                             {% for filter in filter_query_split %}
-                                <a class="no-hover btn-inverse bw-search__active-filters-button" href=".?g={{grouping}}&q={{search_query}}&f={{ filter.remove_url }}" title="Remove this filter">
+                                <a class="no-hover btn-inverse bw-search__active-filters-button" href=".?g={{grouping}}&s={{ sort }}&cluster_id={{ filter.cluster_id }}&w={{ weights }}&q={{search_query}}&f={{ filter.remove_url }}" title="Remove this filter">
                                     {{ filter.name }}<span class="h-spacing-left-1">{% bw_icon 'close' %} </span>
                                 </a>
                             {% endfor %}
@@ -249,13 +250,13 @@
                                             {% display_sound_middle result.sound %}
                                             {% if result.n_more_in_group %}
                                                 <p class="text-grey text-right v-spacing-top-negative-2">
-                                                    {% bw_icon 'plus' %} <a href='{% url "sounds-search"  %}?q={{ search_query }}&f=grouping_pack:"{{ result.sound.pack_id }}_{{ result.sound.pack_name }}" {{filter_query_link_more_when_grouping_packs }}&s={{ sort }}&g={{ grouping }}&advanced={{ advanced }}&a_tag={{ a_tag }}&a_filename={{ a_filename }}&a_description={{ a_description }}&a_packname={{ a_packname }}&a_soundid={{ a_soundid }}&a_username={{ a_username }}'>See {{result.n_more_in_group}} more result{{ result.n_more_in_group|pluralize }} from the same pack</a> <a class="bw-link--black" href="{% url 'pack' result.sound.username result.sound.pack_id %}">{{ result.sound.pack_name|truncate_string:35 }}</a>
+                                                    {% bw_icon 'plus' %} <a href='{% url "sounds-search"  %}?q={{ search_query }}&f=grouping_pack:"{{ result.sound.pack_id }}_{{ result.sound.pack_name }}" {{filter_query_link_more_when_grouping_packs }}&s={{ sort }}&g={{ grouping }}&w={{ weights }}&advanced={{ advanced }}&a_tag={{ a_tag }}&a_filename={{ a_filename }}&a_description={{ a_description }}&a_packname={{ a_packname }}&a_soundid={{ a_soundid }}&a_username={{ a_username }}'>See {{result.n_more_in_group}} more result{{ result.n_more_in_group|pluralize }} from the same pack</a> <a class="bw-link--black" href="{% url 'pack' result.sound.username result.sound.pack_id %}">{{ result.sound.pack_name|truncate_string:35 }}</a>
                                                 </p>
                                             {% endif %}
                                         {% else %}
                                             {% display_pack_big result.sound.pack_id %}
                                             <p class="text-grey text-right v-spacing-top-negative-2">
-                                                {% bw_icon 'plus' %} <a href='{% url "sounds-search"  %}?q={{ search_query }}&f=grouping_pack:"{{ result.sound.pack_id }}_{{ result.sound.pack_name }}" {{filter_query_link_more_when_grouping_packs }}&s={{ sort }}&g={{ grouping }}&advanced={{ advanced }}&a_tag={{ a_tag }}&a_filename={{ a_filename }}&a_description={{ a_description }}&a_packname={{ a_packname }}&a_soundid={{ a_soundid }}&a_username={{ a_username }}'>See all {{result.n_more_in_group|add:1}} result{{ result.n_more_in_group|add:1|pluralize }} from this pack</a>
+                                                {% bw_icon 'plus' %} <a href='{% url "sounds-search"  %}?q={{ search_query }}&f=grouping_pack:"{{ result.sound.pack_id }}_{{ result.sound.pack_name }}" {{filter_query_link_more_when_grouping_packs }}&s={{ sort }}&g={{ grouping }}&w={{ weights }}&advanced={{ advanced }}&a_tag={{ a_tag }}&a_filename={{ a_filename }}&a_description={{ a_description }}&a_packname={{ a_packname }}&a_soundid={{ a_soundid }}&a_username={{ a_username }}'>See all {{result.n_more_in_group|add:1}} result{{ result.n_more_in_group|add:1|pluralize }} from this pack</a>
                                             </p>
                                         {% endif %}
                                         {% if not forloop.last %}

--- a/utils/search/search_sounds.py
+++ b/utils/search/search_sounds.py
@@ -148,7 +148,8 @@ def search_prepare_parameters(request):
     }
 
     # if query param 'w' is present, override field weights
-    custom_field_weights = parse_weights_parameter(request.GET.get("w", ""))
+    weights_parameter = request.GET.get("w", "")
+    custom_field_weights = parse_weights_parameter(weights_parameter)
     if custom_field_weights is not None:
         field_weights = custom_field_weights
    
@@ -187,7 +188,8 @@ def search_prepare_parameters(request):
         'filter_query_non_facets': filter_query_non_facets,
         'has_facet_filter': has_facet_filter,
         'parsed_filters': parsed_filters,
-        'parsing_error': parsing_error
+        'parsing_error': parsing_error,
+        'raw_weights_parameter': weights_parameter
     }
 
     return query_params, advanced_search_params_dict, extra_vars

--- a/utils/search/search_sounds.py
+++ b/utils/search/search_sounds.py
@@ -79,7 +79,7 @@ def search_prepare_parameters(request):
     if only_sounds_with_pack:
         group_by_pack = True
 
-    # Set default values
+    # Set default values for field weights
     id_weight = settings.SEARCH_SOUNDS_DEFAULT_FIELD_WEIGHTS[settings.SEARCH_SOUNDS_FIELD_ID]
     tag_weight = settings.SEARCH_SOUNDS_DEFAULT_FIELD_WEIGHTS[settings.SEARCH_SOUNDS_FIELD_TAGS]
     description_weight = settings.SEARCH_SOUNDS_DEFAULT_FIELD_WEIGHTS[settings.SEARCH_SOUNDS_FIELD_DESCRIPTION]
@@ -147,6 +147,11 @@ def search_prepare_parameters(request):
         settings.SEARCH_SOUNDS_FIELD_NAME: original_filename_weight
     }
 
+    # if query param 'w' is present, override field weights
+    custom_field_weights = parse_weights_parameter(request.GET.get("w", ""))
+    if custom_field_weights is not None:
+        field_weights = custom_field_weights
+   
     # parse query filter string and remove empty value fields
     parsing_error = False
     try:
@@ -186,6 +191,30 @@ def search_prepare_parameters(request):
     }
 
     return query_params, advanced_search_params_dict, extra_vars
+
+
+def parse_weights_parameter(weights_param):
+    """param weights can be used to specify custom field weights with this format 
+    w=field_name1:integer_weight1,field_name2:integrer_weight2, eg: w=name:4,tags:1
+    ideally, field names should any of those specified in settings.SEARCH_SOUNDS_FIELD_*
+    so the search engine can implement ways to translate the "web names" to "search engine"
+    names if needed.
+    """
+    parsed_field_weights = {}
+    if weights_param:
+        for part in weights_param.split(','):
+            if ':' in part:
+                try:
+                    field_name = part.split(':')[0]
+                    weight = int(part.split(':')[1])
+                    parsed_field_weights[field_name] = weight
+                except Exception as e:
+                    # If format is wrong, ignore parameter
+                    pass
+    if len(parsed_field_weights):
+        return parsed_field_weights
+    else:
+        return None
 
 
 def split_filter_query(filter_query, parsed_filters, cluster_id):

--- a/utils/tests/test_search_general.py
+++ b/utils/tests/test_search_general.py
@@ -54,7 +54,8 @@ class SearchUtilsTest(TestCase):
             'filter_query_non_facets': '',
             'has_facet_filter': False,
             'parsed_filters': [],
-            'parsing_error': False
+            'parsing_error': False,
+            'raw_weights_parameter': '',
         }
 
         self.assertDictEqual(query_params, expected_default_query_params)
@@ -95,6 +96,7 @@ class SearchUtilsTest(TestCase):
             'has_facet_filter': False,
             'parsed_filters': [[u'duration', ':', '[', u'1', ' TO ', u'10', ']'], [u'is_geotagged', ':', u'1']],
             'parsing_error': False,
+            'raw_weights_parameter': ''
         }
 
         expected_advanced_search_params_dict = {


### PR DESCRIPTION
This PR adds support for `weights` query parameter in APIv2 (and `w` for normal web view) which allows to define custom field weights for matching queries in the search engine. Custom field weights can be defined with a syntax like `weights=field_name:weight,field_name2:weight2`.

TODO: update API documentation with this new feature