### PR TITLE
Delete items from solr quickly using query

### DIFF
--- a/search/management/commands/reindex_search_engine_sounds.py
+++ b/search/management/commands/reindex_search_engine_sounds.py
@@ -58,11 +58,12 @@ class Command(BaseCommand):
         if clear_index:
             delete_all_sounds_from_search_engine()
 
-        # Get all sounds moderated and processed ok and add them to the search engine (also delete them before re-indexing)
+        # Get all sounds moderated and processed ok and add them to the search engine
+        # Don't delete existing sounds in each loop because we clean up in the final step
         sounds_to_index_ids = list(
             Sound.objects.filter(processing_state="OK", moderation_state="OK").values_list('id', flat=True))
         console_logger.info("Re-indexing %d sounds to the search engine", len(sounds_to_index_ids))
-        send_sounds_to_search_engine(sounds_to_index_ids, slice_size=options['size_size'], delete_if_existing=True)
+        send_sounds_to_search_engine(sounds_to_index_ids, slice_size=options['size_size'], delete_if_existing=False)
 
         # Delete all sounds in the search engine which are not found in the DB. This part of code is to make sure that
         # no "leftover" sounds remain in the search engine, but should normally do nothing, specially if the

--- a/search/management/commands/reindex_search_engine_sounds.py
+++ b/search/management/commands/reindex_search_engine_sounds.py
@@ -24,7 +24,7 @@ from django.core.management.base import BaseCommand
 
 from sounds.models import Sound
 from search.management.commands.post_dirty_sounds_to_search_engine import send_sounds_to_search_engine
-from utils.search.search_sounds import add_sounds_to_search_engine, delete_sounds_from_search_engine, get_all_sound_ids_from_search_engine
+from utils.search.search_sounds import add_sounds_to_search_engine, delete_all_sounds_from_search_engine, delete_sounds_from_search_engine, get_all_sound_ids_from_search_engine
 
 console_logger = logging.getLogger("console")
 
@@ -56,8 +56,7 @@ class Command(BaseCommand):
         clear_index = options['clear_index']
         indexed_sound_ids = None
         if clear_index:
-            indexed_sound_ids = get_all_sound_ids_from_search_engine()
-            delete_sounds_from_search_engine(indexed_sound_ids)
+            delete_all_sounds_from_search_engine()
 
         # Get all sounds moderated and processed ok and add them to the search engine (also delete them before re-indexing)
         sounds_to_index_ids = list(

--- a/utils/search/__init__.py
+++ b/utils/search/__init__.py
@@ -197,6 +197,10 @@ class SearchEngineBase(object):
         """
         raise NotImplementedError
 
+    def remove_all_sounds(self):
+        """Removes all sounds from the search index"""
+        raise NotImplementedError
+
     def sound_exists_in_index(self, sound_object_or_id):
         """Check if a sound is indexed in the search engine
 

--- a/utils/search/backends/solr451custom.py
+++ b/utils/search/backends/solr451custom.py
@@ -812,6 +812,10 @@ class Solr451CustomSearchEngine(SearchEngineBase):
             # testing, but it is not needed in production
             self.get_sounds_index().commit()
 
+    def remove_all_sounds(self):
+        """Removes all sounds from the search index"""
+        self.get_sounds_index().delete_by_query("*:*")
+
     def sound_exists_in_index(self, sound_object_or_id):
         if type(sound_object_or_id) != Sound:
             sound_id = sound_object_or_id

--- a/utils/search/backends/solr451pysolr.py
+++ b/utils/search/backends/solr451pysolr.py
@@ -106,6 +106,10 @@ class Solr451PySolrSearchEngine(SearchEngineBase):
             # testing, but it is not needed in production
             self.get_sounds_index().commit()
 
+    def remove_all_sounds(self):
+        """Removes all sounds from the search index"""
+        self.get_sounds_index().delete(query="*:*")
+
     def sound_exists_in_index(self, sound_object_or_id):
         if type(sound_object_or_id) != Sound:
             sound_id = sound_object_or_id

--- a/utils/search/search_sounds.py
+++ b/utils/search/search_sounds.py
@@ -374,6 +374,17 @@ def delete_sounds_from_search_engine(sound_ids):
         search_logger.error("Could not delete sounds: %s" % str(e))
 
 
+def delete_all_sounds_from_search_engine():
+    """Delete all sounds from the search engine """
+    console_logger.info("Deleting ALL sounds from search engine")
+    search_logger.info("Deleting ALL sounds from search engine")
+    try:
+        get_search_engine().remove_all_sounds()
+    except SearchEngineException as e:
+        console_logger.error("Could not delete sounds: %s" % str(e))
+        search_logger.error("Could not delete sounds: %s" % str(e))
+
+
 def get_all_sound_ids_from_search_engine(page_size=2000):
     """Retrieves the list of all sound IDs currently indexed in the search engine
 


### PR DESCRIPTION
**Description**
In some cases we want to clear the entire solr index, so use a delete query `*:*` instead of getting a list of sound ids and deleting them one by one (which takes a long time)

Also update the `reindex_search_engine_sounds` command to not attempt to delete sound ids before inserting each batch, we do this once at the end of all inserts.

