### PR TITLE
Upgrade akismet to 1.0.1

### DIFF
--- a/accounts/tests/test_spam.py
+++ b/accounts/tests/test_spam.py
@@ -18,8 +18,6 @@
 #     See AUTHORS file.
 #
 
-import mock
-
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-akismet==0.2.0
+akismet==1.0.1
 autopep8==1.5.7
 beautifulsoup4==4.6.0
 bleach==3.1.5

--- a/utils/spam.py
+++ b/utils/spam.py
@@ -22,7 +22,7 @@ from future import standard_library
 standard_library.install_aliases()
 from urllib.error import HTTPError, URLError
 
-from akismet import Akismet, AkismetError, APIKeyError
+from akismet import Akismet, AkismetError, APIKeyError, ConfigurationError
 from django.conf import settings
 from django.contrib.sites.models import Site
 
@@ -45,7 +45,7 @@ def is_spam(request, comment):
     domain = "https://%s" % Site.objects.get_current().domain
     try:
         api = Akismet(key=settings.AKISMET_KEY, blog_url=domain)
-    except APIKeyError:
+    except (APIKeyError, ConfigurationError):
         return False
 
     try:

--- a/utils/spam.py
+++ b/utils/spam.py
@@ -18,9 +18,11 @@
 #     See AUTHORS file.
 #
 
-from urllib2 import HTTPError, URLError
+from future import standard_library
+standard_library.install_aliases()
+from urllib.error import HTTPError, URLError
 
-from akismet import Akismet, AkismetError
+from akismet import Akismet, AkismetError, APIKeyError
 from django.conf import settings
 from django.contrib.sites.models import Site
 
@@ -41,26 +43,24 @@ def is_spam(request, comment):
 
     # Akismet check
     domain = "https://%s" % Site.objects.get_current().domain
-    api = Akismet(key=settings.AKISMET_KEY, blog_url=domain)
-    data = {
-        'user_ip': request.META.get('REMOTE_ADDR', '127.0.0.1'),
-        'user_agent': request.META.get('HTTP_USER_AGENT', ''),
-        'referrer': request.META.get('HTTP_REFERER', ''),
-        'comment_type': 'comment',
-        'comment_author': request.user.username.encode("utf-8") if request.user.is_authenticated else '',
-    }
-    if False: # set this to true to force a spam detection
-        data['comment_author'] = "viagra-test-123"
     try:
-        if api.comment_check(comment.encode('utf-8'), data=data, build_data=True):
+        api = Akismet(key=settings.AKISMET_KEY, blog_url=domain)
+    except APIKeyError:
+        return False
+
+    try:
+        if api.comment_check(
+                user_ip=request.META.get("REMOTE_ADDR", "127.0.0.1"),
+                user_agent=request.META.get("HTTP_USER_AGENT", None),
+                referrer=request.META.get("HTTP_REFERER", None),
+                comment_type="comment",
+                comment_author=request.user.username.encode("utf-8") if request.user.is_authenticated else None,
+                comment_content=comment.encode("utf-8"),
+        ):
             if request.user.is_authenticated:
                 AkismetSpam.objects.create(user=request.user, spam=comment)
             return True
         else:
             return False
-    except AkismetError: # failed to contact akismet...
-        return False
-    except HTTPError: # failed to contact akismet...
-        return False
-    except URLError: # failed to contact akismet...
+    except (AkismetError, HTTPError, URLError):  # failed to contact akismet...
         return False

--- a/utils/tests/test_spam.py
+++ b/utils/tests/test_spam.py
@@ -1,0 +1,22 @@
+from unittest import skipIf
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import RequestFactory, TestCase
+
+from utils.spam import is_spam
+
+
+class SpamTest(TestCase):
+    def setUp(self):
+        spam_user = User.objects.create_user(
+            username="viagra-test-123", email="akismet-guaranteed-spam@example.com"
+        )
+        self.client.force_login(spam_user)
+        rf = RequestFactory()
+        self.spam_request = rf.post("/some_form/")
+        self.spam_request.user = spam_user
+
+    @skipIf(not settings.AKISMET_KEY, "No Akismet API key set.")
+    def test_spam(self):
+        self.assertTrue(is_spam(self.spam_request, ""))


### PR DESCRIPTION
**Issue(s)**
Part of #1083 

**Description**
Before upgrading to Py3 we need to update the [`akismet` dependency to 1.0.1](https://akismet.readthedocs.io/en/1.0.1/upgrade.html)
As part of the upgrade a few tests failed if the akismet API key is not provided; fixed by catching APIKeyError ad ConfigurationError

**Deployment steps**:
None
