### PR TITLE
Concurrent log handler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ beautifulsoup4==4.6.0
 bleach==3.1.5
 boto3==1.7.10
 celery==4.1.1
-ConcurrentLogHandler==0.9.1
 debugpy==1.5.1
 dj-database-url==0.5.0
 django-amazon-ses==3.0.1

--- a/similarity/requirements.txt
+++ b/similarity/requirements.txt
@@ -3,3 +3,4 @@ Twisted==20.3.0
 graypy==2.1.0
 concurrent-log-handler==0.9.20
 #gaia2
+future

--- a/similarity/requirements.txt
+++ b/similarity/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==5.3
 Twisted==20.3.0
 graypy==2.1.0
-ConcurrentLogHandler==0.9.1
+concurrent-log-handler==0.9.20
 #gaia2

--- a/similarity/similarity_server.py
+++ b/similarity/similarity_server.py
@@ -18,21 +18,22 @@
 #     See AUTHORS file.
 #
 
-from __future__ import print_function
 from __future__ import absolute_import
-from twisted.web import server, resource
-from twisted.internet import reactor
-from gaia_wrapper import GaiaWrapper
-from similarity_settings import LISTEN_PORT, LOGFILE, DEFAULT_PRESET, DEFAULT_NUMBER_OF_RESULTS, INDEX_NAME, PRESETS, \
-    BAD_REQUEST_CODE, NOT_FOUND_CODE, SERVER_ERROR_CODE, LOGSERVER_IP_ADDRESS, LOGSERVER_PORT, LOG_TO_STDOUT, \
-    LOG_TO_GRAYLOG, LOG_TO_FILE
-import logging
-import graypy
-from logging.handlers import RotatingFileHandler
-from similarity_server_utils import parse_filter, parse_target, parse_metric_descriptors
+from __future__ import print_function
+
 import json
+import logging
+
+import graypy
 import yaml
-import cloghandler
+from concurrent_log_handler import ConcurrentRotatingFileHandler
+from gaia_wrapper import GaiaWrapper
+from similarity_server_utils import parse_filter, parse_target, parse_metric_descriptors
+from similarity_settings import LISTEN_PORT, LOGFILE, DEFAULT_PRESET, DEFAULT_NUMBER_OF_RESULTS, INDEX_NAME, \
+    BAD_REQUEST_CODE, LOGSERVER_IP_ADDRESS, LOGSERVER_PORT, LOG_TO_STDOUT, \
+    LOG_TO_GRAYLOG, LOG_TO_FILE
+from twisted.internet import reactor
+from twisted.web import server, resource
 
 
 def server_interface(resource):
@@ -236,7 +237,7 @@ if __name__ == '__main__':
     logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     if LOG_TO_FILE:
-        handler = cloghandler.ConcurrentRotatingFileHandler(LOGFILE, "a", maxBytes=2*1024*1024, backupCount=5)
+        handler = ConcurrentRotatingFileHandler(LOGFILE, "a", maxBytes=2*1024*1024, backupCount=5)
         handler.setLevel(logging.DEBUG)
         handler.setFormatter(formatter)
         logger.addHandler(handler)

--- a/similarity/similarity_server.py
+++ b/similarity/similarity_server.py
@@ -21,6 +21,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from builtins import str
 import json
 import logging
 
@@ -162,7 +163,7 @@ class SimilarityServer(resource.Resource):
                             return json.dumps({'error': True, 'result': target, 'status_code': BAD_REQUEST_CODE})
                         else:
                             return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
-                    if not target.items():
+                    if not list(target.items()):
                         return json.dumps({'error': True, 'result': 'Invalid target.', 'status_code': BAD_REQUEST_CODE})
                 except Exception as e:
                     return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
@@ -208,7 +209,7 @@ class SimilarityServer(resource.Resource):
             offset = int(offset[0])
 
         if target_type == 'descriptor_values' and target:
-            metric_descriptor_names = parse_metric_descriptors(','.join(target.keys()), self.gaia.descriptor_names['fixed-length'])
+            metric_descriptor_names = parse_metric_descriptors(','.join(list(target.keys())), self.gaia.descriptor_names['fixed-length'])
         else:
             metric_descriptor_names = False  # For the moment metric_descriptor_names can only be set by us
 

--- a/similarity/similarity_server.py
+++ b/similarity/similarity_server.py
@@ -163,7 +163,7 @@ class SimilarityServer(resource.Resource):
                             return json.dumps({'error': True, 'result': target, 'status_code': BAD_REQUEST_CODE})
                         else:
                             return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
-                    if not list(target.items()):
+                    if not target.items():
                         return json.dumps({'error': True, 'result': 'Invalid target.', 'status_code': BAD_REQUEST_CODE})
                 except Exception as e:
                     return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
@@ -209,7 +209,7 @@ class SimilarityServer(resource.Resource):
             offset = int(offset[0])
 
         if target_type == 'descriptor_values' and target:
-            metric_descriptor_names = parse_metric_descriptors(','.join(list(target.keys())), self.gaia.descriptor_names['fixed-length'])
+            metric_descriptor_names = parse_metric_descriptors(','.join(target.keys()), self.gaia.descriptor_names['fixed-length'])
         else:
             metric_descriptor_names = False  # For the moment metric_descriptor_names can only be set by us
 

--- a/tagrecommendation/requirements.txt
+++ b/tagrecommendation/requirements.txt
@@ -5,3 +5,4 @@ scipy==1.2.3
 numpy==1.9.0  # Needs to be this version for csc-pysparse to work
 scikit-learn==0.17.1  # Using this old version for compatibility with pickled models
 # csc-pysparse==1.1.1.4   # This one is installed separately in the Dockerfile
+future

--- a/tagrecommendation/requirements.txt
+++ b/tagrecommendation/requirements.txt
@@ -1,6 +1,6 @@
 Twisted==20.3.0
 graypy==2.1.0
-ConcurrentLogHandler==0.9.1
+concurrent-log-handler==0.9.20
 scipy==1.2.3
 numpy==1.9.0  # Needs to be this version for csc-pysparse to work
 scikit-learn==0.17.1  # Using this old version for compatibility with pickled models

--- a/tagrecommendation/tagrecommendation_server.py
+++ b/tagrecommendation/tagrecommendation_server.py
@@ -83,8 +83,8 @@ class TagRecommendationServer(resource.Resource):
 
         try:
             self.index = loadFromJson(tr_settings.RECOMMENDATION_DATA_DIR, 'Index.json')
-            self.index_stats['biggest_id_in_index'] = max([int(key) for key in list(self.index.keys())])
-            self.index_stats['n_sounds_in_index'] = len(list(self.index.keys()))
+            self.index_stats['biggest_id_in_index'] = max([int(key) for key in self.index.keys()])
+            self.index_stats['n_sounds_in_index'] = len(self.index.keys())
         except Exception as e:
             logger.error("Index file not present. Listening for indexing data from appservers.")
             self.index_stats['biggest_id_in_index'] = 0
@@ -141,12 +141,12 @@ class TagRecommendationServer(resource.Resource):
             stags = sound_tags[count]
             self.index[sid] = stags
 
-        if len(list(self.index.keys())) % 1000 == 0:
+        if len(self.index.keys()) % 1000 == 0:
             # Every 1000 indexed sounds, save the index
             logger.info('Saving tagrecommendation index...')
             saveToJson(tr_settings.RECOMMENDATION_DATA_DIR + 'Index.json', self.index, verbose=False)
-            self.index_stats['biggest_id_in_index'] = max([int(key) for key in list(self.index.keys())])
-            self.index_stats['n_sounds_in_index'] = len(list(self.index.keys()))
+            self.index_stats['biggest_id_in_index'] = max([int(key) for key in self.index.keys()])
+            self.index_stats['n_sounds_in_index'] = len(self.index.keys())
 
         result = {'error': False, 'result': True}
         return json.dumps(result)

--- a/tagrecommendation/tagrecommendation_server.py
+++ b/tagrecommendation/tagrecommendation_server.py
@@ -26,6 +26,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from builtins import str
 import json
 import logging
 
@@ -82,8 +83,8 @@ class TagRecommendationServer(resource.Resource):
 
         try:
             self.index = loadFromJson(tr_settings.RECOMMENDATION_DATA_DIR, 'Index.json')
-            self.index_stats['biggest_id_in_index'] = max([int(key) for key in self.index.keys()])
-            self.index_stats['n_sounds_in_index'] = len(self.index.keys())
+            self.index_stats['biggest_id_in_index'] = max([int(key) for key in list(self.index.keys())])
+            self.index_stats['n_sounds_in_index'] = len(list(self.index.keys()))
         except Exception as e:
             logger.error("Index file not present. Listening for indexing data from appservers.")
             self.index_stats['biggest_id_in_index'] = 0
@@ -140,12 +141,12 @@ class TagRecommendationServer(resource.Resource):
             stags = sound_tags[count]
             self.index[sid] = stags
 
-        if len(self.index.keys()) % 1000 == 0:
+        if len(list(self.index.keys())) % 1000 == 0:
             # Every 1000 indexed sounds, save the index
             logger.info('Saving tagrecommendation index...')
             saveToJson(tr_settings.RECOMMENDATION_DATA_DIR + 'Index.json', self.index, verbose=False)
-            self.index_stats['biggest_id_in_index'] = max([int(key) for key in self.index.keys()])
-            self.index_stats['n_sounds_in_index'] = len(self.index.keys())
+            self.index_stats['biggest_id_in_index'] = max([int(key) for key in list(self.index.keys())])
+            self.index_stats['n_sounds_in_index'] = len(list(self.index.keys()))
 
         result = {'error': False, 'result': True}
         return json.dumps(result)

--- a/tagrecommendation/tagrecommendation_server.py
+++ b/tagrecommendation/tagrecommendation_server.py
@@ -23,19 +23,19 @@
 #   - numpy
 #   - sklearn (joblib)
 
-from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
 
 import json
 import logging
 
-import cloghandler
 import graypy
+import tagrecommendation_settings as tr_settings
+from communityBasedTagRecommendation import CommunityBasedTagRecommender
+from concurrent_log_handler import ConcurrentRotatingFileHandler
 from twisted.internet import reactor
 from twisted.web import server, resource
 
-from communityBasedTagRecommendation import CommunityBasedTagRecommender
-import tagrecommendation_settings as tr_settings
 from utils import loadFromJson, saveToJson
 
 
@@ -159,8 +159,9 @@ if __name__ == '__main__':
     logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     if tr_settings.LOG_TO_FILE:
-        handler = cloghandler.ConcurrentRotatingFileHandler(tr_settings.LOGFILE,
-                                                            mode="a", maxBytes=2 * 1024 * 1024, backupCount=5)
+        handler = ConcurrentRotatingFileHandler(
+            tr_settings.LOGFILE, mode="a", maxBytes=2 * 1024 * 1024, backupCount=5,
+        )
         handler.setLevel(logging.DEBUG)
         handler.setFormatter(formatter)
         logger.addHandler(handler)


### PR DESCRIPTION
**Issue(s)**
Part of #1083 

**Description**
[ConcurrentLogHandler](https://pypi.org/project/ConcurrentLogHandler/) is superseded by [concurrent-log-handler](https://github.com/Preston-Landers/concurrent-log-handler). 

This seems to only affect `similarity/similarity_server.py` and `tagrecommendation/tagrecommendation_server.py`. 
Additionally, both files were futurized. (Pay attention to the `from builtins import str`)

**Deployment steps**:
None
