### PR TITLE
Install procps (top) in the base image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -13,6 +13,7 @@ RUN apt-get update \
                        git \
                        gosu \
                        pkg-config \
+                       procps \
                        python \
                        python-dev \
                        wget \


### PR DESCRIPTION
This is often useful for debugging, so nice to not need to always install it
