### PR TITLE
Python 3 compatibility (futurize --step2)

### DIFF
--- a/_docs/api/add_examples_to_api_docs_source_files.py
+++ b/_docs/api/add_examples_to_api_docs_source_files.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 import sys
-import urllib
+import urllib.request, urllib.parse, urllib.error
 sys.path.append("../../apiv2")
 from examples import examples
 base_url = 'https://freesound.org/'
@@ -18,7 +20,7 @@ def get_formatted_examples_for_view(view_name):
         output += '::\n\n'
         for element in elements:
             if element[0:5] == 'apiv2':
-                output += '  %s%s\n' % (base_url, urllib.quote(element, safe='?/=&",:()'))
+                output += '  %s%s\n' % (base_url, urllib.parse.quote(element, safe='?/=&",:()'))
                 #output += '  curl -H "Authorization: Token {{token}}" \'%s%s\'\n' % (base_url, element)
             else:
                 output += '  %s\n' % (element % base_url[:-1].replace('http:', 'https:'))

--- a/_docs/api/generate_analysis_documentation/generate_analysis_rst.py
+++ b/_docs/api/generate_analysis_documentation/generate_analysis_rst.py
@@ -3,7 +3,10 @@
 
 from __future__ import print_function
 
-import urllib2,json
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
+import urllib.request, urllib.error, urllib.parse,json
 
 
 header = """
@@ -56,8 +59,8 @@ desc_exceptions = ["metadata.audio_properties","metadata.version","rhythm.onset_
 
 example_url = "https://freesound.org/api/sounds/1234/analysis/?api_key=53b80e4d8a674ccaa80b780372103680&all=True"
 
-req = urllib2.Request(example_url)
-resp = urllib2.urlopen(req)
+req = urllib.request.Request(example_url)
+resp = urllib.request.urlopen(req)
 top = json.loads(resp.read())
 
 
@@ -72,7 +75,7 @@ for k in sorted_namespaces:
 	ns = k[0].upper()+k[1:]
 	print(ns+ " Descriptors")
 	print(">>>>>>>>>>>>>>>>>>>>\n\n")
-	for d in top[k].keys():
+	for d in list(top[k].keys()):
 		descriptor = k+"."+d
 		print(descriptor)
 		print("-------------------------")
@@ -87,12 +90,12 @@ for k in sorted_namespaces:
 			continue
 		if type(stats) ==dict:
 			print("\n\n**Stats**::\n\n")
-			for s in stats.keys():
+			for s in list(stats.keys()):
 				print("/"+s)
 
 			print("\n\n**Distribution in Freesound**\n")
 
-			if "mean" in stats.keys():
+			if "mean" in list(stats.keys()):
 				if  type(stats['mean'])==list:
 					for i in range(len(stats['mean'])):
 						img = image_str+descriptor+".mean.%03d"%i

--- a/_docs/api/generate_analysis_documentation/generate_analysis_rst.py
+++ b/_docs/api/generate_analysis_documentation/generate_analysis_rst.py
@@ -75,7 +75,7 @@ for k in sorted_namespaces:
 	ns = k[0].upper()+k[1:]
 	print(ns+ " Descriptors")
 	print(">>>>>>>>>>>>>>>>>>>>\n\n")
-	for d in list(top[k].keys()):
+	for d in top[k].keys():
 		descriptor = k+"."+d
 		print(descriptor)
 		print("-------------------------")
@@ -90,12 +90,12 @@ for k in sorted_namespaces:
 			continue
 		if type(stats) ==dict:
 			print("\n\n**Stats**::\n\n")
-			for s in list(stats.keys()):
+			for s in stats.keys():
 				print("/"+s)
 
 			print("\n\n**Distribution in Freesound**\n")
 
-			if "mean" in list(stats.keys()):
+			if "mean" in stats.keys():
 				if  type(stats['mean'])==list:
 					for i in range(len(stats['mean'])):
 						img = image_str+descriptor+".mean.%03d"%i

--- a/_docs/api/generate_analysis_documentation/generate_plots.py
+++ b/_docs/api/generate_analysis_documentation/generate_plots.py
@@ -44,7 +44,7 @@ normalization_coeffs = None
 for i in range(0,len(transformation_history)):
     if transformation_history[-(i+1)]['Analyzer name'] == 'normalize':
         normalization_coeffs = transformation_history[-(i+1)]['Applier parameters']['coeffs']
-print([x for x in list(normalization_coeffs.keys()) if (".tonal" in x and "chords" in x)])
+print([x for x in normalization_coeffs.keys() if (".tonal" in x and "chords" in x)])
 descriptor_names = ds.layout().descriptorNames()
 point_names = ds.pointNames()
 example_point = ds.point(point_names[0])
@@ -89,7 +89,7 @@ for descriptor_name in descriptor_names:
             for point_name in point_names:
                 point = ds.point(point_name)
                 normalized_value = point.value(descriptor_name)[i]
-                if not normalization_coeffs or descriptor_name not in list(normalization_coeffs.keys()):
+                if not normalization_coeffs or descriptor_name not in normalization_coeffs.keys():
                     value = normalized_value
                 else:
                     a = normalization_coeffs[descriptor_name]['a']

--- a/_docs/api/generate_analysis_documentation/generate_plots.py
+++ b/_docs/api/generate_analysis_documentation/generate_plots.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from builtins import range
 import gaia2
 import pylab as pl
 
@@ -27,7 +28,7 @@ def plot_histogram(pool, label,  x_label_ticks = False):
     if not x_label_ticks:
         ax.ticklabel_format(axis='x', style='sci', scilimits=(-3,3))
     else:
-        pl.xticks(range(0, len(x_label_ticks)),['           %s'%tick for tick in x_label_ticks])
+        pl.xticks(list(range(0, len(x_label_ticks))),['           %s'%tick for tick in x_label_ticks])
     ax.ticklabel_format(axis='y', style='sci', scilimits=(-2,2))
     ax.set_xlabel('Value')
     ax.set_ylabel('Frequency of occurrence')
@@ -43,7 +44,7 @@ normalization_coeffs = None
 for i in range(0,len(transformation_history)):
     if transformation_history[-(i+1)]['Analyzer name'] == 'normalize':
         normalization_coeffs = transformation_history[-(i+1)]['Applier parameters']['coeffs']
-print([x for x in normalization_coeffs.keys() if (".tonal" in x and "chords" in x)])
+print([x for x in list(normalization_coeffs.keys()) if (".tonal" in x and "chords" in x)])
 descriptor_names = ds.layout().descriptorNames()
 point_names = ds.pointNames()
 example_point = ds.point(point_names[0])
@@ -88,7 +89,7 @@ for descriptor_name in descriptor_names:
             for point_name in point_names:
                 point = ds.point(point_name)
                 normalized_value = point.value(descriptor_name)[i]
-                if not normalization_coeffs or descriptor_name not in normalization_coeffs.keys():
+                if not normalization_coeffs or descriptor_name not in list(normalization_coeffs.keys()):
                     value = normalized_value
                 else:
                     a = normalization_coeffs[descriptor_name]['a']

--- a/_docs/api/generate_analysis_documentation/generate_plots.py
+++ b/_docs/api/generate_analysis_documentation/generate_plots.py
@@ -1,8 +1,7 @@
 from __future__ import print_function
+
 import gaia2
 import pylab as pl
-from numpy import std, average, percentile
-
 
 OUT_FOLDER = 'out_plots' # Must be created
 GAIA_INDEX_FILE = 'fs_index.db' # File with gaia index

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -237,7 +237,7 @@ class FreesoundUserAdmin(DjangoObjectActions, UserAdmin):
         user_info = obj.profile.get_info_before_delete_user(include_sounds=True, include_other_related_objects=False)
         user_info['deleted_objects_details'] = {}
         model_count = {model._meta.verbose_name_plural: len(objs) for
-                       model, objs in list(user_info['deleted'].model_objs.items())}
+                       model, objs in user_info['deleted'].model_objs.items()}
         user_info['deleted_objects_details']['model_count'] = list(dict(model_count).items())
 
         tvars = {'users_to_delete': [], 'type': 'delete_include_sounds'}
@@ -274,7 +274,7 @@ class FreesoundUserAdmin(DjangoObjectActions, UserAdmin):
         user_info = obj.profile.get_info_before_delete_user(include_sounds=True, include_other_related_objects=True)
         user_info['deleted_objects_details'] = {}
         model_count = {model._meta.verbose_name_plural: len(objs) for
-                       model, objs in list(user_info['deleted'].model_objs.items())}
+                       model, objs in user_info['deleted'].model_objs.items()}
         user_info['deleted_objects_details']['model_count'] = list(dict(model_count).items())
 
         tvars = {'users_to_delete': [], 'type': 'delete_spammer'}
@@ -311,7 +311,7 @@ class FreesoundUserAdmin(DjangoObjectActions, UserAdmin):
         user_info = obj.profile.get_info_before_delete_user(include_sounds=True, include_other_related_objects=True)
         user_info['deleted_objects_details'] = {}
         model_count = {model._meta.verbose_name_plural: len(objs) for
-                       model, objs in list(user_info['deleted'].model_objs.items())}
+                       model, objs in user_info['deleted'].model_objs.items()}
         user_info['deleted_objects_details']['model_count'] = list(dict(model_count).items())
 
         tvars = {'users_to_delete': [], 'type': 'full_delete'}

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -20,10 +20,8 @@
 #     See AUTHORS file.
 #
 
-import json
 import logging
 
-from django.conf import settings
 from django.contrib import admin
 from django.contrib import messages
 from django.contrib.auth.admin import UserAdmin

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -237,8 +237,8 @@ class FreesoundUserAdmin(DjangoObjectActions, UserAdmin):
         user_info = obj.profile.get_info_before_delete_user(include_sounds=True, include_other_related_objects=False)
         user_info['deleted_objects_details'] = {}
         model_count = {model._meta.verbose_name_plural: len(objs) for
-                       model, objs in user_info['deleted'].model_objs.items()}
-        user_info['deleted_objects_details']['model_count'] = dict(model_count).items()
+                       model, objs in list(user_info['deleted'].model_objs.items())}
+        user_info['deleted_objects_details']['model_count'] = list(dict(model_count).items())
 
         tvars = {'users_to_delete': [], 'type': 'delete_include_sounds'}
         tvars['users_to_delete'].append(user_info)
@@ -274,8 +274,8 @@ class FreesoundUserAdmin(DjangoObjectActions, UserAdmin):
         user_info = obj.profile.get_info_before_delete_user(include_sounds=True, include_other_related_objects=True)
         user_info['deleted_objects_details'] = {}
         model_count = {model._meta.verbose_name_plural: len(objs) for
-                       model, objs in user_info['deleted'].model_objs.items()}
-        user_info['deleted_objects_details']['model_count'] = dict(model_count).items()
+                       model, objs in list(user_info['deleted'].model_objs.items())}
+        user_info['deleted_objects_details']['model_count'] = list(dict(model_count).items())
 
         tvars = {'users_to_delete': [], 'type': 'delete_spammer'}
         tvars['users_to_delete'].append(user_info)
@@ -311,8 +311,8 @@ class FreesoundUserAdmin(DjangoObjectActions, UserAdmin):
         user_info = obj.profile.get_info_before_delete_user(include_sounds=True, include_other_related_objects=True)
         user_info['deleted_objects_details'] = {}
         model_count = {model._meta.verbose_name_plural: len(objs) for
-                       model, objs in user_info['deleted'].model_objs.items()}
-        user_info['deleted_objects_details']['model_count'] = dict(model_count).items()
+                       model, objs in list(user_info['deleted'].model_objs.items())}
+        user_info['deleted_objects_details']['model_count'] = list(dict(model_count).items())
 
         tvars = {'users_to_delete': [], 'type': 'full_delete'}
         tvars['users_to_delete'].append(user_info)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -20,6 +20,10 @@
 #     See AUTHORS file.
 #
 
+from __future__ import division
+from builtins import str
+from builtins import object
+from past.utils import old_div
 import datetime
 import os
 import random
@@ -202,7 +206,7 @@ class Profile(SocialModel):
 
     @staticmethod
     def locations_static(user_id, has_avatar):
-        id_folder = str(user_id / 1000)
+        id_folder = str(old_div(user_id, 1000))
         if has_avatar:
             s_avatar = settings.AVATARS_URL + "%s/%d_S.jpg" % (id_folder, user_id)
             m_avatar = settings.AVATARS_URL + "%s/%d_M.jpg" % (id_folder, user_id)
@@ -570,14 +574,14 @@ class Profile(SocialModel):
         # TODO: don't compute this realtime, store it in DB
         ratings = list(SoundRating.objects.filter(sound__user=self.user).values_list('rating', flat=True))
         if ratings:
-            return 1.0*sum(ratings)/len(ratings)
+            return old_div(1.0*sum(ratings),len(ratings))
         else:
             return 0
 
     @property
     def avg_rating_0_5(self):
         # Returns the average raring, normalized from 0 tp 5
-        return self.avg_rating/2
+        return old_div(self.avg_rating,2)
 
     def get_total_uploaded_sounds_length(self):
         # TODO: don't compute this realtime, store it in DB
@@ -611,7 +615,7 @@ class UserFlag(models.Model):
     def __unicode__(self):
         return u"Flag %s: %s" % (self.content_type, self.object_id)
 
-    class Meta:
+    class Meta(object):
         ordering = ("-user__username",)
 
 
@@ -722,7 +726,7 @@ class EmailBounce(models.Model):
 
     timestamp = models.DateTimeField(default=now)
 
-    class Meta:
+    class Meta(object):
         ordering = ("-timestamp",)
         unique_together = ('user', 'type', 'timestamp')
 

--- a/accounts/templatetags/display_user.py
+++ b/accounts/templatetags/display_user.py
@@ -21,7 +21,6 @@
 from __future__ import absolute_import
 
 from django import template
-from django.conf import settings
 from django.contrib.auth.models import User
 
 from accounts.models import Profile

--- a/accounts/tests/test_profile.py
+++ b/accounts/tests/test_profile.py
@@ -17,6 +17,7 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import range
 import datetime
 import os
 

--- a/accounts/tests/test_spam.py
+++ b/accounts/tests/test_spam.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail

--- a/accounts/tests/test_upload.py
+++ b/accounts/tests/test_upload.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
 import os
 
 import mock
@@ -275,8 +276,8 @@ class BulkDescribe(TestCase):
         # show that info to the users. First we fake some data for the bulk object
         bulk.progress_type = 'F'
         bulk.validation_output = {
-            'lines_ok': range(5),  # NOTE: we only use the length of these lists, so we fill them with irrelevant data
-            'lines_with_errors': range(2),
+            'lines_ok': list(range(5)),  # NOTE: we only use the length of these lists, so we fill them with irrelevant data
+            'lines_with_errors': list(range(2)),
             'global_errors': [],
         }
         bulk.description_output = {

--- a/accounts/tests/test_views.py
+++ b/accounts/tests/test_views.py
@@ -21,9 +21,8 @@
 
 import datetime
 
-import mock
 from django.contrib.auth.models import User, Permission
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 
 from accounts.models import OldUsername

--- a/accounts/tests/test_views.py
+++ b/accounts/tests/test_views.py
@@ -130,10 +130,10 @@ class SimpleUserTest(TestCase):
         resp = self.client.get(reverse('accounts-download-attribution') + '?dl=csv')
         self.assertEqual(resp.status_code, 200)
         # response content as expected
-        self.assertEqual(resp.content,
-                         'Download Type,File Name,User,License\r\nP,{0},{1},{0}\r\nS,{2},{3},{4}\r\n'.format(
-                             self.pack.name, self.user.username, self.sound.original_filename, self.user.username,
-                             self.sound.license))
+        self.assertContains(resp,
+                            'Download Type,File Name,User,License\r\nP,{0},{1},{0}\r\nS,{2},{3},{4}\r\n'.format(
+                                self.pack.name, self.user.username, self.sound.original_filename, self.user.username,
+                                self.sound.license))
 
     def test_download_attribution_txt(self):
         self.client.force_login(self.user)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -20,7 +20,7 @@
 #     See AUTHORS file.
 #
 
-from django.conf.urls import url, include
+from django.conf.urls import url
 from django.contrib.auth import views as auth_views
 from utils.session_checks import login_redirect
 import messages.views as messages
@@ -111,4 +111,3 @@ urlpatterns = [
     url(r'^app_permissions/revoke_permission/(?P<client_id>[^//]+)/$', api.revoke_permission, name='revoke-permission'),
     url(r'^app_permissions/permission_granted/$', api.permission_granted, name='permission-granted'),
 ]
-

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -18,7 +18,11 @@
 #     See AUTHORS file.
 #
 
-import cStringIO
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+import io
 import csv
 import datetime
 import errno
@@ -505,11 +509,11 @@ def edit(request):
 
     def is_selected(prefix):
         if request.method == "POST":
-            for name in request.POST.keys():
+            for name in list(request.POST.keys()):
                 if name.startswith(prefix + '-'):
                     return True
             if request.FILES:
-                for name in request.FILES.keys():
+                for name in list(request.FILES.keys()):
                     if name.startswith(prefix + '-'):
                         return True
         return False
@@ -930,7 +934,7 @@ def download_attribution(request):
         filename = '%s_%s_attribution.%s' % (request.user, now, download)
         response = HttpResponse(content_type='text/%s' % content[download])
         response['Content-Disposition'] = 'attachment; filename="%s"' % filename
-        output = cStringIO.StringIO()
+        output = io.StringIO()
         if download == 'csv':
             output.write('Download Type,File Name,User,License\r\n')
             csv_writer = csv.writer(output, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
@@ -1035,7 +1039,7 @@ def accounts(request):
     most_active_users = User.objects.select_related("profile")\
         .filter(id__in=[u[1] for u in sorted(sort_list, reverse=True)[:num_active_users]])
     new_users = User.objects.select_related("profile").filter(date_joined__gte=last_time)\
-        .filter(id__in=user_rank.keys()).order_by('-date_joined')[:num_active_users+5]
+        .filter(id__in=list(user_rank.keys())).order_by('-date_joined')[:num_active_users+5]
     logged_users = User.objects.select_related("profile").filter(id__in=get_online_users())
     most_active_users_display = [[u, latest_content_type(user_rank[u.id]), user_rank[u.id]] for u in most_active_users]
     most_active_users_display = sorted(most_active_users_display,
@@ -1100,7 +1104,7 @@ def charts(request):
                                        reverse=True)
 
     # Newest active users
-    new_user_in_rank_ids = User.objects.filter(date_joined__gte=last_time, id__in=user_rank.keys())\
+    new_user_in_rank_ids = User.objects.filter(date_joined__gte=last_time, id__in=list(user_rank.keys()))\
         .values_list('id', flat=True)
     new_user_objects = {user.id: user for user in
                         User.objects.select_related("profile").filter(date_joined__gte=last_time)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -39,7 +39,6 @@ from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.views import LoginView, PasswordResetCompleteView, PasswordResetConfirmView, \
     PasswordChangeView, PasswordChangeDoneView
-from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.db import transaction

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -509,11 +509,11 @@ def edit(request):
 
     def is_selected(prefix):
         if request.method == "POST":
-            for name in list(request.POST.keys()):
+            for name in request.POST.keys():
                 if name.startswith(prefix + '-'):
                     return True
             if request.FILES:
-                for name in list(request.FILES.keys()):
+                for name in request.FILES.keys():
                     if name.startswith(prefix + '-'):
                         return True
         return False

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -940,16 +940,16 @@ def download_attribution(request):
             csv_writer = csv.writer(output, delimiter=u',', quotechar=u'"', quoting=csv.QUOTE_MINIMAL)
             for row in qs:
                 csv_writer.writerow(
-                    [row['download_type'][0].upper(), row['sound__original_filename'].encode('utf-8'),
+                    [row['download_type'][0].upper(), row['sound__original_filename'],
                      row['sound__user__username'],
-                     license_with_version(row['license__name'].encode('utf-8') or row['sound__license__name'].encode('utf-8'),
-                                          row['license__deed_url'].encode('utf-8') or row['sound__license__deed_url'].encode('utf-8'))])
+                     license_with_version(row['license__name'] or row['sound__license__name'],
+                                          row['license__deed_url'] or row['sound__license__deed_url'])])
         elif download == 'txt':
             for row in qs:
-                output.write("{0}: {1} by {2} | License: {3}\n".format(row['download_type'][0].upper(),
-                             row['sound__original_filename'].encode("utf-8"), row['sound__user__username'],
-                             license_with_version(row['license__name'].encode("utf-8") or row['sound__license__name'].encode("utf-8"),
-                                                  row['license__deed_url'].encode('utf-8') or row['sound__license__deed_url'].encode('utf-8'))))
+                output.write(u"{0}: {1} by {2} | License: {3}\n".format(row['download_type'][0].upper(),
+                             row['sound__original_filename'], row['sound__user__username'],
+                             license_with_version(row['license__name'] or row['sound__license__name'],
+                                                  row['license__deed_url'] or row['sound__license__deed_url'])))
         response.writelines(output.getvalue())
         return response
     else:

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -23,7 +23,7 @@ standard_library.install_aliases()
 from builtins import str
 from builtins import range
 import io
-import csv
+from backports import csv
 import datetime
 import errno
 import json
@@ -936,8 +936,8 @@ def download_attribution(request):
         response['Content-Disposition'] = 'attachment; filename="%s"' % filename
         output = io.StringIO()
         if download == 'csv':
-            output.write('Download Type,File Name,User,License\r\n')
-            csv_writer = csv.writer(output, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+            output.write(u'Download Type,File Name,User,License\r\n')
+            csv_writer = csv.writer(output, delimiter=u',', quotechar=u'"', quoting=csv.QUOTE_MINIMAL)
             for row in qs:
                 csv_writer.writerow(
                     [row['download_type'][0].upper(), row['sound__original_filename'].encode('utf-8'),

--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -22,11 +22,18 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import datetime
 import json
 import logging
-import urlparse
-from urllib import unquote
+import urllib.parse
+from urllib.parse import unquote
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -152,11 +159,11 @@ class FreesoundAPIViewMixin(object):
         if isinstance(response.accepted_renderer, BrowsableAPIRenderer):
             if request.get_host().startswith('www'):
                 domain = "%s://%s" % ('https' if not settings.DEBUG else 'http', Site.objects.get_current().domain)
-                return_url = urlparse.urljoin(domain, request.get_full_path())
+                return_url = urllib.parse.urljoin(domain, request.get_full_path())
                 return HttpResponseRedirect(return_url)
             if request.scheme != 'https' and not settings.DEBUG:
                 domain = "https://%s" % Site.objects.get_current().domain
-                return_url = urlparse.urljoin(domain, request.get_full_path())
+                return_url = urllib.parse.urljoin(domain, request.get_full_path())
                 return HttpResponseRedirect(return_url)
         return response
 
@@ -483,15 +490,15 @@ def get_authentication_details_form_request(request):
 
 
 def request_parameters_info_for_log_message(get_parameters):
-    return ','.join(['%s=%s' % (key, value) for key, value in get_parameters.items()])
+    return ','.join(['%s=%s' % (key, value) for key, value in list(get_parameters.items())])
 
 
 class ApiSearchPaginator(object):
     def __init__(self, results, count, num_per_page):
         self.num_per_page = num_per_page
         self.count = count
-        self.num_pages = count / num_per_page + int(count % num_per_page != 0)
-        self.page_range = range(1, self.num_pages + 1)
+        self.num_pages = old_div(count, num_per_page) + int(count % num_per_page != 0)
+        self.page_range = list(range(1, self.num_pages + 1))
         self.results = results
 
     def page(self, page_num):

--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -490,7 +490,7 @@ def get_authentication_details_form_request(request):
 
 
 def request_parameters_info_for_log_message(get_parameters):
-    return ','.join(['%s=%s' % (key, value) for key, value in list(get_parameters.items())])
+    return ','.join(['%s=%s' % (key, value) for key, value in get_parameters.items()])
 
 
 class ApiSearchPaginator(object):

--- a/apiv2/combined_search_strategies.py
+++ b/apiv2/combined_search_strategies.py
@@ -20,13 +20,19 @@
 #     See AUTHORS file.
 #
 from __future__ import absolute_import
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from past.utils import old_div
 from apiv2.forms import API_SORT_OPTIONS_MAP
 from utils.similarity_utilities import api_search as similarity_api_search
 from utils.search import SearchEngineException, get_search_engine
 from utils.search.search_sounds import parse_weights_parameter
 from similarity.client import SimilarityException
 from .exceptions import ServerErrorException, BadRequestException, NotFoundException
-from urllib import unquote
+from urllib.parse import unquote
 
 
 def merge_all(search_form, target_file=None, extra_parameters=None):
@@ -92,7 +98,7 @@ def filter_both(search_form, target_file=None, extra_parameters=None):
     if search_form.cleaned_data['target'] or target_file:
         # First search into gaia and then into solr (get all gaia results)
         gaia_ids, gaia_count, distance_to_target_data, note = get_gaia_results(search_form, target_file, page_size=gaia_page_size, max_pages=gaia_max_pages)
-        valid_ids_pages = [gaia_ids[i:i+solr_filter_id_block_size] for i in range(0, len(gaia_ids), solr_filter_id_block_size) if (i/solr_filter_id_block_size) < solr_filter_id_max_pages]
+        valid_ids_pages = [gaia_ids[i:i+solr_filter_id_block_size] for i in range(0, len(gaia_ids), solr_filter_id_block_size) if (old_div(i,solr_filter_id_block_size)) < solr_filter_id_max_pages]
         solr_ids = list()
         search_engine = get_search_engine()
         for valid_ids_page in valid_ids_pages:

--- a/apiv2/management/commands/basic_api_tests.py
+++ b/apiv2/management/commands/basic_api_tests.py
@@ -21,6 +21,7 @@
 #
 
 from __future__ import print_function
+from builtins import str
 try:
     import requests
 except:
@@ -107,7 +108,7 @@ class Command(BaseCommand):
         error = list()
 
         print('')
-        for key, items in examples.items():
+        for key, items in list(examples.items()):
             if 'Download' not in key:
                 if section:
                     if section not in key:

--- a/apiv2/management/commands/basic_api_tests.py
+++ b/apiv2/management/commands/basic_api_tests.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
         error = list()
 
         print('')
-        for key, items in list(examples.items()):
+        for key, items in examples.items():
             if 'Download' not in key:
                 if section:
                     if section not in key:

--- a/apiv2/management/commands/consolidate_api_usage_data.py
+++ b/apiv2/management/commands/consolidate_api_usage_data.py
@@ -49,7 +49,7 @@ class Command(LoggingBaseCommand):
         for i in range(0, n_days_back):
             date_filter = now - datetime.timedelta(days=i)
             monitoring_key_pattern = '{0}-{1}-{2}_*'.format(date_filter.year, date_filter.month, date_filter.day)
-            for key, count in list(cache_api_monitoring.get_many(cache_api_monitoring.keys(monitoring_key_pattern)).items()):
+            for key, count in cache_api_monitoring.get_many(cache_api_monitoring.keys(monitoring_key_pattern)).items():
                 try:
                     apiv2_client = ApiV2Client.objects.get(oauth_client__client_id=key.split('_')[1])
                     usage_history, _ = APIClientDailyUsageHistory\

--- a/apiv2/management/commands/consolidate_api_usage_data.py
+++ b/apiv2/management/commands/consolidate_api_usage_data.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
 import datetime
 import logging
 
@@ -48,7 +49,7 @@ class Command(LoggingBaseCommand):
         for i in range(0, n_days_back):
             date_filter = now - datetime.timedelta(days=i)
             monitoring_key_pattern = '{0}-{1}-{2}_*'.format(date_filter.year, date_filter.month, date_filter.day)
-            for key, count in cache_api_monitoring.get_many(cache_api_monitoring.keys(monitoring_key_pattern)).items():
+            for key, count in list(cache_api_monitoring.get_many(cache_api_monitoring.keys(monitoring_key_pattern)).items()):
                 try:
                     apiv2_client = ApiV2Client.objects.get(oauth_client__client_id=key.split('_')[1])
                     usage_history, _ = APIClientDailyUsageHistory\

--- a/apiv2/models.py
+++ b/apiv2/models.py
@@ -18,6 +18,8 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
+from builtins import object
 import datetime
 
 from django.db import models
@@ -131,6 +133,6 @@ class APIClientDailyUsageHistory(models.Model):
     number_of_requests = models.PositiveIntegerField(default=0)
     date = models.DateField()
 
-    class Meta:
+    class Meta(object):
         ordering = ("-date",)
         unique_together = ('apiv2_client', 'date')

--- a/apiv2/serializers.py
+++ b/apiv2/serializers.py
@@ -21,6 +21,10 @@
 #
 
 from __future__ import absolute_import
+from __future__ import division
+from builtins import str
+from past.utils import old_div
+from builtins import object
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -59,7 +63,7 @@ class AbstractSoundSerializer(serializers.HyperlinkedModelSerializer):
             requested_fields = self.default_fields
 
         if requested_fields == '*':  # If parameter is *, return all fields
-            requested_fields = ','.join(self.fields.keys())
+            requested_fields = ','.join(list(self.fields.keys()))
 
         if requested_fields:
             allowed = set(requested_fields.split(","))
@@ -67,7 +71,7 @@ class AbstractSoundSerializer(serializers.HyperlinkedModelSerializer):
             for field_name in existing - allowed:
                 self.fields.pop(field_name)
 
-    class Meta:
+    class Meta(object):
         model = Sound
         fields = ('id',
                   'url',
@@ -252,7 +256,7 @@ class AbstractSoundSerializer(serializers.HyperlinkedModelSerializer):
 
     avg_rating = serializers.SerializerMethodField()
     def get_avg_rating(self, obj):
-        return obj.avg_rating/2
+        return old_div(obj.avg_rating,2)
 
     comments = serializers.SerializerMethodField()
     def get_comments(self, obj):
@@ -303,7 +307,7 @@ class SoundListSerializer(AbstractSoundSerializer):
         # other analyzers' output is only accessible via analyzers_output field. This is kept like that
         # for legacy reasons.
         analyzers_output = {}
-        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
+        for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
             if 'descriptors_map' in analyzer_info:
                 query_select_name = analyzer_name.replace('-', '_')
                 analysis_data = getattr(obj, query_select_name, None)
@@ -358,7 +362,7 @@ class SoundSerializer(AbstractSoundSerializer):
         # obtained with the ac_analysis field name but all other analyzers' output is only accessible
         # via analyzers_output field. This is kept like that for legacy reasons.
         analyzers_output = {}
-        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
+        for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
             if 'descriptors_map' in analyzer_info:
                 query_select_name = analyzer_name.replace('-', '_')
                 if hasattr(obj, query_select_name):
@@ -381,7 +385,7 @@ class SoundSerializer(AbstractSoundSerializer):
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
 
-    class Meta:
+    class Meta(object):
         model = User
         fields = ('url',
                   'username',
@@ -461,7 +465,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
 
 class PackSerializer(serializers.HyperlinkedModelSerializer):
 
-    class Meta:
+    class Meta(object):
         model = Pack
         fields = ('id',
                   'url',
@@ -503,7 +507,7 @@ class PackSerializer(serializers.HyperlinkedModelSerializer):
 
 class BookmarkCategorySerializer(serializers.HyperlinkedModelSerializer):
 
-    class Meta:
+    class Meta(object):
         model = BookmarkCategory
         fields = ('id',
                   'url',
@@ -575,7 +579,7 @@ class CreateRatingSerializer(serializers.Serializer):
 
 class SoundCommentsSerializer(serializers.HyperlinkedModelSerializer):
 
-    class Meta:
+    class Meta(object):
         model = Comment
         fields = ('username',
                   'comment',

--- a/apiv2/serializers.py
+++ b/apiv2/serializers.py
@@ -63,7 +63,7 @@ class AbstractSoundSerializer(serializers.HyperlinkedModelSerializer):
             requested_fields = self.default_fields
 
         if requested_fields == '*':  # If parameter is *, return all fields
-            requested_fields = ','.join(list(self.fields.keys()))
+            requested_fields = ','.join(self.fields.keys())
 
         if requested_fields:
             allowed = set(requested_fields.split(","))
@@ -307,7 +307,7 @@ class SoundListSerializer(AbstractSoundSerializer):
         # other analyzers' output is only accessible via analyzers_output field. This is kept like that
         # for legacy reasons.
         analyzers_output = {}
-        for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
+        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
             if 'descriptors_map' in analyzer_info:
                 query_select_name = analyzer_name.replace('-', '_')
                 analysis_data = getattr(obj, query_select_name, None)
@@ -362,7 +362,7 @@ class SoundSerializer(AbstractSoundSerializer):
         # obtained with the ac_analysis field name but all other analyzers' output is only accessible
         # via analyzers_output field. This is kept like that for legacy reasons.
         analyzers_output = {}
-        for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
+        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
             if 'descriptors_map' in analyzer_info:
                 query_select_name = analyzer_name.replace('-', '_')
                 if hasattr(obj, query_select_name):

--- a/apiv2/templatetags/apiv2_templatetags.py
+++ b/apiv2/templatetags/apiv2_templatetags.py
@@ -1,6 +1,8 @@
+from future import standard_library
+standard_library.install_aliases()
 from django import template
 from django.urls import reverse
-from urllib import quote
+from urllib.parse import quote
 
 register = template.Library()
 

--- a/apiv2/tests.py
+++ b/apiv2/tests.py
@@ -396,7 +396,7 @@ class TestSoundListSerializer(TestCase):
             sounds_dict = Sound.objects.dict_ids(sound_ids=self.sids)
             with self.assertNumQueries(0):
                 dummy_request = self.factory.get(reverse('apiv2-sound-text-search'), {'fields': field_set})
-                for sound in list(sounds_dict.values()):
+                for sound in sounds_dict.values():
                     # Call serializer .data to actually get the data and potentially trigger unwanted extra queries
                     _ = SoundListSerializer(sound, context={'request': dummy_request}).data
 

--- a/apiv2/tests.py
+++ b/apiv2/tests.py
@@ -355,19 +355,19 @@ class TestSoundListSerializer(TestCase):
         # When 'fields' parameter is not used, return default ones
         dummy_request = self.factory.get(reverse('apiv2-sound-text-search'), {'fields': ''})
         serialized_sound = SoundListSerializer(list(sounds_dict.values())[0], context={'request': dummy_request}).data
-        self.assertItemsEqual(serialized_sound.keys(), DEFAULT_FIELDS_IN_SOUND_LIST.split(','))
+        self.assertItemsEqual(list(serialized_sound.keys()), DEFAULT_FIELDS_IN_SOUND_LIST.split(','))
 
         # When only some parameters are specified
         fields_parameter = 'id,username'
         dummy_request = self.factory.get(reverse('apiv2-sound-text-search'), {'fields': fields_parameter})
         serialized_sound = SoundListSerializer(list(sounds_dict.values())[0], context={'request': dummy_request}).data
-        self.assertItemsEqual(serialized_sound.keys(), fields_parameter.split(','))
+        self.assertItemsEqual(list(serialized_sound.keys()), fields_parameter.split(','))
 
         # When all parameters are specified
         fields_parameter = ','.join(SoundListSerializer.Meta.fields)
         dummy_request = self.factory.get(reverse('apiv2-sound-text-search'), {'fields': fields_parameter})
         serialized_sound = SoundListSerializer(list(sounds_dict.values())[0], context={'request': dummy_request}).data
-        self.assertItemsEqual(serialized_sound.keys(), fields_parameter.split(','))
+        self.assertItemsEqual(list(serialized_sound.keys()), fields_parameter.split(','))
 
     def test_num_queries(self):
         # Test that the serializer does not perform any extra query when serializing sounds regardless of the number
@@ -396,7 +396,7 @@ class TestSoundListSerializer(TestCase):
             sounds_dict = Sound.objects.dict_ids(sound_ids=self.sids)
             with self.assertNumQueries(0):
                 dummy_request = self.factory.get(reverse('apiv2-sound-text-search'), {'fields': field_set})
-                for sound in sounds_dict.values():
+                for sound in list(sounds_dict.values()):
                     # Call serializer .data to actually get the data and potentially trigger unwanted extra queries
                     _ = SoundListSerializer(sound, context={'request': dummy_request}).data
 
@@ -421,7 +421,7 @@ class TestSoundSerializer(TestCase):
         with self.assertNumQueries(0):
             dummy_request = self.factory.get(reverse('apiv2-sound-instance', args=[self.sound.id]))
             serialized_sound = SoundSerializer(self.sound, context={'request': dummy_request}).data
-            self.assertItemsEqual(serialized_sound.keys(), SoundSerializer.Meta.fields)
+            self.assertItemsEqual(list(serialized_sound.keys()), SoundSerializer.Meta.fields)
 
 
 class TestApiV2Client(TestCase):

--- a/apiv2/urls.py
+++ b/apiv2/urls.py
@@ -27,7 +27,7 @@
 
 
 from django.conf.urls import url, include
-from django.contrib.auth.views import LoginView, LogoutView
+from django.contrib.auth.views import LogoutView
 from apiv2 import views
 from accounts.views import login
 from accounts.forms import FsAuthenticationForm
@@ -109,5 +109,3 @@ urlpatterns = [
     url(r'^$', views.FreesoundApiV2Resources.as_view()),
     url(r'/$', views.invalid_url),
 ]
-
-

--- a/apiv2/views.py
+++ b/apiv2/views.py
@@ -299,7 +299,7 @@ class CombinedSearch(GenericAPIView):
 
         # Get search results
         extra_parameters = dict()
-        for key, value in list(request.query_params.items()):
+        for key, value in request.query_params.items():
             if key.startswith('cs_'):
                 extra_parameters[key] = int(value)
 
@@ -324,7 +324,7 @@ class CombinedSearch(GenericAPIView):
             extra_parameters.update({'debug': 1})
         extra_parameters_string = ''
         if extra_parameters:
-            for key, value in list(extra_parameters.items()):
+            for key, value in extra_parameters.items():
                 extra_parameters_string += '&%s=%s' % (key, str(value))
 
         response_data = dict()
@@ -832,7 +832,7 @@ class UploadSound(WriteRequiredGenericAPIView):
                             apiv2_client = request.auth.application.apiv2_client
 
                         sound_fields = {}
-                        for key, item in list(serializer.data.items()):
+                        for key, item in serializer.data.items():
                             sound_fields[key] = item
 
                         filename = sound_fields.get('upload_filename', audiofile.name)
@@ -898,7 +898,7 @@ class PendingUploads(OauthRequiredAPIView):
 
         # Look for sounds pending description
         file_structure, files = generate_tree(self.user.profile.locations()['uploads_dir'])
-        pending_description = [file_instance.name for file_id, file_instance in list(files.items())]
+        pending_description = [file_instance.name for file_id, file_instance in files.items()]
 
         # Look for sounds pending processing
         qs = Sound.objects.filter(user=self.user).exclude(processing_state='OK').exclude(moderation_state='OK')
@@ -917,7 +917,7 @@ class PendingUploads(OauthRequiredAPIView):
 
     def get_minimal_sound_info(self, sound, images=False, processing_state=False):
         sound_data = dict()
-        for key, value in list(SoundSerializer(sound, context=self.get_serializer_context()).data.items()):
+        for key, value in SoundSerializer(sound, context=self.get_serializer_context()).data.items():
             if key in ['id', 'name', 'tags', 'description', 'created', 'license']:
                 sound_data[key] = value
             if images:
@@ -948,7 +948,7 @@ class DescribeSound(WriteRequiredGenericAPIView):
     def post(self, request,  *args, **kwargs):
         api_logger.info(self.log_message('describe_sound'))
         file_structure, files = generate_tree(self.user.profile.locations()['uploads_dir'])
-        filenames = [file_instance.name for file_id, file_instance in list(files.items())]
+        filenames = [file_instance.name for file_id, file_instance in files.items()]
         serializer = SoundDescriptionSerializer(data=request.data, context={'not_yet_described_audio_files': filenames})
         if serializer.is_valid():
             if not settings.ALLOW_WRITE_WHEN_SESSION_BASED_AUTHENTICATION and self.auth_method_name == 'Session':
@@ -1218,7 +1218,7 @@ class AvailableAudioDescriptors(GenericAPIView):
         try:
             descriptor_names = Similarity.get_descriptor_names()
             del descriptor_names['all']
-            for key, value in list(descriptor_names.items()):
+            for key, value in descriptor_names.items():
                 descriptor_names[key] = [item[1:] for item in value]  # remove initial dot from descriptor names
 
             return Response({
@@ -1244,15 +1244,15 @@ class FreesoundApiV2Resources(GenericAPIView):
     def get(self, request,  *args, **kwargs):
         api_logger.info(self.log_message('api_root'))
         api_index = [
-            {'Search resources': OrderedDict(sorted(list(dict({
+            {'Search resources': OrderedDict(sorted(dict({
                     '01 Text Search': prepend_base(
                         reverse('apiv2-sound-text-search'), request_is_secure=request.is_secure()),
                     '02 Content Search': prepend_base(
                         reverse('apiv2-sound-content-search'), request_is_secure=request.is_secure()),
                     '03 Combined Search': prepend_base(
                         reverse('apiv2-sound-combined-search'), request_is_secure=request.is_secure()),
-                }).items()), key=lambda t: t[0]))},
-                {'Sound resources': OrderedDict(sorted(list(dict({
+                }).items(), key=lambda t: t[0]))},
+                {'Sound resources': OrderedDict(sorted(dict({
                     '01 Sound instance': prepend_base(
                         reverse('apiv2-sound-instance', args=[0]).replace('0', '<sound_id>'),
                         request_is_secure=request.is_secure()),
@@ -1278,8 +1278,8 @@ class FreesoundApiV2Resources(GenericAPIView):
                     '11 Pending uploads': prepend_base(reverse('apiv2-uploads-pending')),
                     '12 Edit sound description': prepend_base(
                         reverse('apiv2-sound-edit', args=[0]).replace('0', '<sound_id>')),
-                }).items()), key=lambda t: t[0]))},
-                {'User resources': OrderedDict(sorted(list(dict({
+                }).items(), key=lambda t: t[0]))},
+                {'User resources': OrderedDict(sorted(dict({
                     '01 User instance': prepend_base(
                         reverse('apiv2-user-instance', args=['uname']).replace('uname', '<username>'),
                         request_is_secure=request.is_secure()),
@@ -1296,8 +1296,8 @@ class FreesoundApiV2Resources(GenericAPIView):
                         reverse('apiv2-user-bookmark-category-sounds', args=['uname', 0]).replace('0', '<category_id>')
                             .replace('uname', '<username>'),
                         request_is_secure=request.is_secure()),
-                }).items()), key=lambda t: t[0]))},
-                {'Pack resources': OrderedDict(sorted(list(dict({
+                }.items()), key=lambda t: t[0]))},
+                {'Pack resources': OrderedDict(sorted(dict({
                     '01 Pack instance': prepend_base(
                         reverse('apiv2-pack-instance', args=[0]).replace('0', '<pack_id>'),
                         request_is_secure=request.is_secure()),
@@ -1306,17 +1306,17 @@ class FreesoundApiV2Resources(GenericAPIView):
                         request_is_secure=request.is_secure()),
                     '03 Download pack': prepend_base(
                         reverse('apiv2-pack-download', args=[0]).replace('0', '<pack_id>')),
-                }).items()), key=lambda t: t[0]))},
-                {'Other resources': OrderedDict(sorted(list(dict({
+                }).items(), key=lambda t: t[0]))},
+                {'Other resources': OrderedDict(sorted(dict({
                     '01 Me (information about user authenticated using oauth)': prepend_base(reverse('apiv2-me')),
                     '02 Available audio descriptors': prepend_base(reverse('apiv2-available-descriptors')),
-                }).items()), key=lambda t: t[0]))},
+                }).items(), key=lambda t: t[0]))},
             ]
 
         # Yaml format can not represent ordered dicts, so turn ordered dict to dict if these formats are requested
         if request.accepted_renderer.format in [u'yaml']:
             for element in api_index:
-                for key, ordered_dict in list(element.items()):
+                for key, ordered_dict in element.items():
                     element[key] = dict(ordered_dict)
 
         # Xml format seems to have problems with white spaces and numbers in dict keys...
@@ -1328,9 +1328,9 @@ class FreesoundApiV2Resources(GenericAPIView):
             aux_api_index = list()
             for element in api_index:
                 aux_dict_a = dict()
-                for key_a, ordered_dict in list(element.items()):
+                for key_a, ordered_dict in element.items():
                     aux_dict_b = dict()
-                    for key_b, value in list(ordered_dict.items()):
+                    for key_b, value in ordered_dict.items():
                         aux_dict_b[key_to_valid_xml(key_b)] = value
                     aux_dict_a[key_to_valid_xml(key_a)] = aux_dict_b
                 aux_api_index.append(aux_dict_a)

--- a/apiv2/views.py
+++ b/apiv2/views.py
@@ -22,12 +22,17 @@
 
 
 from __future__ import absolute_import
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from past.utils import old_div
 import datetime
 import json
 import logging
 import os
 from collections import OrderedDict
-from urllib import quote
+from urllib.parse import quote
 
 import jwt
 from django.conf import settings
@@ -213,7 +218,7 @@ class ContentSearch(GenericAPIView):
         response_data = dict()
         if self.analysis_file:
             response_data['target_analysis_file'] = '%s (%i KB)' % (self.analysis_file._name,
-                                                                    self.analysis_file._size/1024)
+                                                                    old_div(self.analysis_file._size,1024))
         response_data['count'] = paginator.count
         response_data['previous'] = None
         response_data['next'] = None
@@ -294,7 +299,7 @@ class CombinedSearch(GenericAPIView):
 
         # Get search results
         extra_parameters = dict()
-        for key, value in request.query_params.items():
+        for key, value in list(request.query_params.items()):
             if key.startswith('cs_'):
                 extra_parameters[key] = int(value)
 
@@ -319,13 +324,13 @@ class CombinedSearch(GenericAPIView):
             extra_parameters.update({'debug': 1})
         extra_parameters_string = ''
         if extra_parameters:
-            for key, value in extra_parameters.items():
+            for key, value in list(extra_parameters.items()):
                 extra_parameters_string += '&%s=%s' % (key, str(value))
 
         response_data = dict()
         if self.analysis_file:
             response_data['target_analysis_file'] = '%s (%i KB)' % (self.analysis_file._name,
-                                                                    self.analysis_file._size/1024)
+                                                                    old_div(self.analysis_file._size,1024))
 
         # Build 'more' link (only add it if we know there might be more results)
         if 'no_more_results' not in extra_parameters:
@@ -333,7 +338,7 @@ class CombinedSearch(GenericAPIView):
                 response_data['more'] = search_form.construct_link(reverse('apiv2-sound-combined-search'),
                                                                    include_page=False)
             else:
-                num_pages = count / search_form.cleaned_data['page_size'] + \
+                num_pages = old_div(count, search_form.cleaned_data['page_size']) + \
                             int(count % search_form.cleaned_data['page_size'] != 0)
                 if search_form.cleaned_data['page'] < num_pages:
                     response_data['more'] = search_form.construct_link(reverse('apiv2-sound-combined-search'),
@@ -827,7 +832,7 @@ class UploadSound(WriteRequiredGenericAPIView):
                             apiv2_client = request.auth.application.apiv2_client
 
                         sound_fields = {}
-                        for key, item in serializer.data.items():
+                        for key, item in list(serializer.data.items()):
                             sound_fields[key] = item
 
                         filename = sound_fields.get('upload_filename', audiofile.name)
@@ -893,7 +898,7 @@ class PendingUploads(OauthRequiredAPIView):
 
         # Look for sounds pending description
         file_structure, files = generate_tree(self.user.profile.locations()['uploads_dir'])
-        pending_description = [file_instance.name for file_id, file_instance in files.items()]
+        pending_description = [file_instance.name for file_id, file_instance in list(files.items())]
 
         # Look for sounds pending processing
         qs = Sound.objects.filter(user=self.user).exclude(processing_state='OK').exclude(moderation_state='OK')
@@ -912,7 +917,7 @@ class PendingUploads(OauthRequiredAPIView):
 
     def get_minimal_sound_info(self, sound, images=False, processing_state=False):
         sound_data = dict()
-        for key, value in SoundSerializer(sound, context=self.get_serializer_context()).data.items():
+        for key, value in list(SoundSerializer(sound, context=self.get_serializer_context()).data.items()):
             if key in ['id', 'name', 'tags', 'description', 'created', 'license']:
                 sound_data[key] = value
             if images:
@@ -943,7 +948,7 @@ class DescribeSound(WriteRequiredGenericAPIView):
     def post(self, request,  *args, **kwargs):
         api_logger.info(self.log_message('describe_sound'))
         file_structure, files = generate_tree(self.user.profile.locations()['uploads_dir'])
-        filenames = [file_instance.name for file_id, file_instance in files.items()]
+        filenames = [file_instance.name for file_id, file_instance in list(files.items())]
         serializer = SoundDescriptionSerializer(data=request.data, context={'not_yet_described_audio_files': filenames})
         if serializer.is_valid():
             if not settings.ALLOW_WRITE_WHEN_SESSION_BASED_AUTHENTICATION and self.auth_method_name == 'Session':
@@ -1213,7 +1218,7 @@ class AvailableAudioDescriptors(GenericAPIView):
         try:
             descriptor_names = Similarity.get_descriptor_names()
             del descriptor_names['all']
-            for key, value in descriptor_names.items():
+            for key, value in list(descriptor_names.items()):
                 descriptor_names[key] = [item[1:] for item in value]  # remove initial dot from descriptor names
 
             return Response({
@@ -1239,15 +1244,15 @@ class FreesoundApiV2Resources(GenericAPIView):
     def get(self, request,  *args, **kwargs):
         api_logger.info(self.log_message('api_root'))
         api_index = [
-            {'Search resources': OrderedDict(sorted(dict({
+            {'Search resources': OrderedDict(sorted(list(dict({
                     '01 Text Search': prepend_base(
                         reverse('apiv2-sound-text-search'), request_is_secure=request.is_secure()),
                     '02 Content Search': prepend_base(
                         reverse('apiv2-sound-content-search'), request_is_secure=request.is_secure()),
                     '03 Combined Search': prepend_base(
                         reverse('apiv2-sound-combined-search'), request_is_secure=request.is_secure()),
-                }).items(), key=lambda t: t[0]))},
-                {'Sound resources': OrderedDict(sorted(dict({
+                }).items()), key=lambda t: t[0]))},
+                {'Sound resources': OrderedDict(sorted(list(dict({
                     '01 Sound instance': prepend_base(
                         reverse('apiv2-sound-instance', args=[0]).replace('0', '<sound_id>'),
                         request_is_secure=request.is_secure()),
@@ -1273,8 +1278,8 @@ class FreesoundApiV2Resources(GenericAPIView):
                     '11 Pending uploads': prepend_base(reverse('apiv2-uploads-pending')),
                     '12 Edit sound description': prepend_base(
                         reverse('apiv2-sound-edit', args=[0]).replace('0', '<sound_id>')),
-                }).items(), key=lambda t: t[0]))},
-                {'User resources': OrderedDict(sorted(dict({
+                }).items()), key=lambda t: t[0]))},
+                {'User resources': OrderedDict(sorted(list(dict({
                     '01 User instance': prepend_base(
                         reverse('apiv2-user-instance', args=['uname']).replace('uname', '<username>'),
                         request_is_secure=request.is_secure()),
@@ -1291,8 +1296,8 @@ class FreesoundApiV2Resources(GenericAPIView):
                         reverse('apiv2-user-bookmark-category-sounds', args=['uname', 0]).replace('0', '<category_id>')
                             .replace('uname', '<username>'),
                         request_is_secure=request.is_secure()),
-                }).items(), key=lambda t: t[0]))},
-                {'Pack resources': OrderedDict(sorted(dict({
+                }).items()), key=lambda t: t[0]))},
+                {'Pack resources': OrderedDict(sorted(list(dict({
                     '01 Pack instance': prepend_base(
                         reverse('apiv2-pack-instance', args=[0]).replace('0', '<pack_id>'),
                         request_is_secure=request.is_secure()),
@@ -1301,17 +1306,17 @@ class FreesoundApiV2Resources(GenericAPIView):
                         request_is_secure=request.is_secure()),
                     '03 Download pack': prepend_base(
                         reverse('apiv2-pack-download', args=[0]).replace('0', '<pack_id>')),
-                }).items(), key=lambda t: t[0]))},
-                {'Other resources': OrderedDict(sorted(dict({
+                }).items()), key=lambda t: t[0]))},
+                {'Other resources': OrderedDict(sorted(list(dict({
                     '01 Me (information about user authenticated using oauth)': prepend_base(reverse('apiv2-me')),
                     '02 Available audio descriptors': prepend_base(reverse('apiv2-available-descriptors')),
-                }).items(), key=lambda t: t[0]))},
+                }).items()), key=lambda t: t[0]))},
             ]
 
         # Yaml format can not represent ordered dicts, so turn ordered dict to dict if these formats are requested
         if request.accepted_renderer.format in [u'yaml']:
             for element in api_index:
-                for key, ordered_dict in element.items():
+                for key, ordered_dict in list(element.items()):
                     element[key] = dict(ordered_dict)
 
         # Xml format seems to have problems with white spaces and numbers in dict keys...
@@ -1323,9 +1328,9 @@ class FreesoundApiV2Resources(GenericAPIView):
             aux_api_index = list()
             for element in api_index:
                 aux_dict_a = dict()
-                for key_a, ordered_dict in element.items():
+                for key_a, ordered_dict in list(element.items()):
                     aux_dict_b = dict()
-                    for key_b, value in ordered_dict.items():
+                    for key_b, value in list(ordered_dict.items()):
                         aux_dict_b[key_to_valid_xml(key_b)] = value
                     aux_dict_a[key_to_valid_xml(key_a)] = aux_dict_b
                 aux_api_index.append(aux_dict_a)
@@ -1478,7 +1483,7 @@ def granted_permissions(request):
     for token in tokens_raw:
         if not token.application.apiv2_client.name in token_names:
             td = (token.expires - datetime.datetime.today())
-            seconds_to_expiration_date = (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+            seconds_to_expiration_date = old_div((td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6), 10**6)
             tokens.append({
                 'client_name': token.application.apiv2_client.name,
                 'expiration_date': token.expires,
@@ -1495,7 +1500,7 @@ def granted_permissions(request):
     for grant in grants_pending_access_token_request_raw:
         if not grant.application.apiv2_client.name in grant_and_token_names:
             td = (grant.expires - datetime.datetime.today())
-            seconds_to_expiration_date = (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+            seconds_to_expiration_date = old_div((td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6), 10**6)
             if seconds_to_expiration_date > 0:
                 grants.append({
                     'client_name': grant.application.apiv2_client.name,

--- a/bookmarks/models.py
+++ b/bookmarks/models.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from django.contrib.auth.models import User
 from django.db import models
 
@@ -59,5 +60,5 @@ class Bookmark(models.Model):
         else:
             return self.sound.original_filename
 
-    class Meta:
+    class Meta(object):
         ordering = ("-created", )

--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -36,7 +36,7 @@ class BookmarksTest(TestCase):
         self.assertEqual(200, resp.status_code)
         expected_keys = ['bookmark_categories', 'current_page', 'is_owner',
                          'n_uncat', 'page', 'paginator', 'user']
-        context_keys = context.keys()
+        context_keys = list(context.keys())
         for k in expected_keys:
             self.assertIn(k, context_keys)
 
@@ -71,7 +71,7 @@ class BookmarksTest(TestCase):
         self.assertEqual(200, resp.status_code)
         expected_keys = ['bookmark_categories', 'current_page', 'is_owner',
                          'n_uncat', 'page', 'paginator', 'user']
-        context_keys = context.keys()
+        context_keys = list(context.keys())
         for k in expected_keys:
             self.assertIn(k, context_keys)
 

--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -17,7 +17,6 @@
 # Authors:
 #     See AUTHORS file.
 #
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import reverse

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -23,7 +23,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.db.models import Count
-from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
+from django.http import Http404, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 

--- a/clustering/clustering.py
+++ b/clustering/clustering.py
@@ -209,7 +209,7 @@ class ClusteringEngine(object):
         communities_centralities = [nx.algorithms.centrality.degree_centrality(subgraph) for subgraph in subgraphs]
 
         # merge and normalize in each community
-        node_community_centralities = {k: old_div(v,max(d.values())) for d in communities_centralities for k, v in list(d.items())}
+        node_community_centralities = {k: old_div(v,max(d.values())) for d in communities_centralities for k, v in d.items()}
 
         return node_community_centralities
     

--- a/clustering/features_store.py
+++ b/clustering/features_store.py
@@ -49,7 +49,7 @@ class RedisStore(object):
             return json.loads(feature)
 
     def set_features(self, d):
-        self.r.mset({k: json.dumps(v) for k, v in list(d.items())})
+        self.r.mset({k: json.dumps(v) for k, v in d.items()})
 
     def get_features(self, sound_ids):
         return self.r.mget(sound_ids)

--- a/clustering/features_store.py
+++ b/clustering/features_store.py
@@ -20,6 +20,9 @@
 
 from __future__ import absolute_import
 
+from builtins import zip
+from builtins import str
+from builtins import object
 import json
 import logging
 import os
@@ -46,7 +49,7 @@ class RedisStore(object):
             return json.loads(feature)
 
     def set_features(self, d):
-        self.r.mset({k: json.dumps(v) for k, v in d.iteritems()})
+        self.r.mset({k: json.dumps(v) for k, v in list(d.items())})
 
     def get_features(self, sound_ids):
         return self.r.mget(sound_ids)

--- a/clustering/interface.py
+++ b/clustering/interface.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 from __future__ import absolute_import
+from builtins import str
 from django.conf import settings
 from django.core.cache import caches
 

--- a/comments/models.py
+++ b/comments/models.py
@@ -22,7 +22,6 @@
 
 import sounds
 from django.contrib.auth.models import User
-from django.contrib.contenttypes import fields
 from django.db import models
 from django.db.models.signals import post_delete
 

--- a/comments/models.py
+++ b/comments/models.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 import sounds
 from django.contrib.auth.models import User
 from django.db import models
@@ -36,7 +37,7 @@ class Comment(models.Model):
     def __unicode__(self):
         return u"%s comment on %s" % (self.user, self.sound)
 
-    class Meta:
+    class Meta(object):
         ordering = ('-created', )
 
 

--- a/favorites/models.py
+++ b/favorites/models.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from django.contrib.auth.models import User
 from django.contrib.contenttypes import fields
 from django.contrib.contenttypes.models import ContentType
@@ -37,6 +38,6 @@ class Favorite(models.Model):
     def __unicode__(self):
         return u"%s favorites %s - %s" % (self.user, self.content_type, self.content_type)
     
-    class Meta:
+    class Meta(object):
         unique_together = (('user', 'content_type', 'object_id'),)
         ordering = ("-created", )

--- a/follow/follow_utils.py
+++ b/follow/follow_utils.py
@@ -20,10 +20,12 @@
 #     See AUTHORS file.
 #
 
+from future import standard_library
+standard_library.install_aliases()
 from follow.models import FollowingUserItem, FollowingQueryItem
 import sounds
 from utils.search import get_search_engine
-import urllib
+import urllib.request, urllib.parse, urllib.error
 from django.conf import settings
 
 
@@ -89,7 +91,7 @@ def get_stream_sounds(user, time_lapse, num_results_per_grup=3):
             more_count = max(0, result.num_found - num_results_per_grup)
 
             # the sorting only works if done like this!
-            more_url_params = [urllib.quote(filter_str), urllib.quote(settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST)]
+            more_url_params = [urllib.parse.quote(filter_str), urllib.parse.quote(settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST)]
 
             # this is the same link but for the email has to be "quoted"
             more_url = u"?f=" + filter_str + u"&s=" + settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST
@@ -130,7 +132,7 @@ def get_stream_sounds(user, time_lapse, num_results_per_grup=3):
             more_count = max(0, result.num_found - num_results_per_grup)
 
             # the sorting only works if done like this!
-            more_url_params = [urllib.quote(tag_filter_str), urllib.quote(settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST)]
+            more_url_params = [urllib.parse.quote(tag_filter_str), urllib.parse.quote(settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST)]
 
             # this is the same link but for the email has to be "quoted"
             more_url = u"?f=" + tag_filter_str + u"&s=" + settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST

--- a/follow/management/commands/send_stream_emails.py
+++ b/follow/management/commands/send_stream_emails.py
@@ -17,6 +17,7 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import str
 import datetime
 import json
 import logging
@@ -72,7 +73,7 @@ class Command(LoggingBaseCommand):
             week_first_day_str = week_first_day.strftime("%d %b").lstrip("0")
             week_last_day_str = week_last_day.strftime("%d %b").lstrip("0")
 
-            extra_email_subject = unicode(week_first_day_str) + u' to ' + unicode(week_last_day_str)
+            extra_email_subject = str(week_first_day_str) + u' to ' + str(week_last_day_str)
 
             # Set date range from which to get upload notifications
             time_lapse = follow_utils.build_time_lapse(week_first_day, week_last_day)

--- a/follow/models.py
+++ b/follow/models.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from django.contrib.auth.models import User
 from django.db import models
 
@@ -32,7 +33,7 @@ class FollowingUserItem(models.Model):
     def __unicode__(self):
         return u"%s following %s" % (self.user_from, self.user_to)
 
-    class Meta:
+    class Meta(object):
         verbose_name_plural = "Users"
         unique_together = ("user_from", "user_to")
 
@@ -55,6 +56,6 @@ class FollowingQueryItem(models.Model):
     def get_space_tags(self):
         return self.query
 
-    class Meta:
+    class Meta(object):
         verbose_name_plural = 'Tags'
         unique_together = ("user", "query")

--- a/follow/tests.py
+++ b/follow/tests.py
@@ -20,8 +20,6 @@
 #     See AUTHORS file.
 #
 from django.test import TestCase
-from django.test.client import Client
-from accounts.models import Profile
 from django.contrib.auth.models import User
 from follow.models import FollowingUserItem, FollowingQueryItem
 

--- a/forum/models.py
+++ b/forum/models.py
@@ -20,6 +20,9 @@
 #     See AUTHORS file.
 #
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 import logging
 
 from collections import Counter
@@ -137,7 +140,7 @@ class Thread(models.Model):
         }
         return info_to_return
 
-    class Meta:
+    class Meta(object):
         ordering = ('-status', '-last_post__created')
 
     def __unicode__(self):
@@ -210,7 +213,7 @@ class Post(models.Model):
     )
     moderation_state = models.CharField(db_index=True, max_length=2, choices=MODERATION_STATE_CHOICES, default="OK")
 
-    class Meta:
+    class Meta(object):
         ordering = ('created',)
         permissions = (
             ("can_moderate_forum", "Can moderate posts."),
@@ -336,7 +339,7 @@ class Subscription(models.Model):
     thread = models.ForeignKey(Thread)
     is_active = models.BooleanField(db_index=True, default=True)
 
-    class Meta:
+    class Meta(object):
         unique_together = ("subscriber", "thread")
 
     def __unicode__(self):

--- a/forum/templatetags/display_forum_objects.py
+++ b/forum/templatetags/display_forum_objects.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+from builtins import str
 from django import template
 
 register = template.Library()

--- a/forum/templatetags/display_forum_search_results.py
+++ b/forum/templatetags/display_forum_search_results.py
@@ -4,6 +4,7 @@ Created on Jul 1, 2011
 @author: stelios
 '''
 from __future__ import absolute_import
+from builtins import str
 from django import template
 
 register = template.Library()

--- a/forum/templatetags/smileys.py
+++ b/forum/templatetags/smileys.py
@@ -17,7 +17,7 @@ mapping = """8-) 8) cool
 :O :-O woot"""
 
 d = []
-for emoticons, name in map(lambda x: (x[:-1], x[-1]), [x.split() for x in mapping.lower().split("\n")]):
+for emoticons, name in [(x[:-1], x[-1]) for x in [x.split() for x in mapping.lower().split("\n")]]:
     for emoticon in emoticons:
         d.append((emoticon,name))
 

--- a/forum/tests.py
+++ b/forum/tests.py
@@ -17,6 +17,10 @@
 # Authors:
 #     See AUTHORS file.
 #
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
 from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.core import mail

--- a/forum/views.py
+++ b/forum/views.py
@@ -1,3 +1,4 @@
+from __future__ import division
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -17,6 +18,10 @@
 # Authors:
 #     See AUTHORS file.
 #
+from future import standard_library
+standard_library.install_aliases()
+from past.utils import old_div
+from builtins import object
 import datetime
 import re
 
@@ -193,7 +198,7 @@ def post(request, forum_name_slug, thread_id, post_id):
                              moderation_state="OK")
 
     posts_before = Post.objects.filter(thread=post.thread, moderation_state="OK", created__lt=post.created).count()
-    page = 1 + posts_before / settings.FORUM_POSTS_PER_PAGE
+    page = 1 + old_div(posts_before, settings.FORUM_POSTS_PER_PAGE)
     url = post.thread.get_absolute_url() + "?page=%d#post%d" % (page, post.id)
 
     return HttpResponseRedirect(url)

--- a/forum/views.py
+++ b/forum/views.py
@@ -19,11 +19,11 @@
 #
 import datetime
 import re
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.models import User
-from django.contrib.postgres.search import SearchVector, SearchQuery, SearchRank
 from django.http import HttpResponseRedirect, Http404, HttpResponsePermanentRedirect
 from django.shortcuts import render, get_object_or_404, redirect
 from django.template import loader

--- a/freesound/middleware.py
+++ b/freesound/middleware.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 import json
 import logging
 

--- a/freesound/middleware.py
+++ b/freesound/middleware.py
@@ -17,7 +17,6 @@
 # Authors:
 #     See AUTHORS file.
 #
-import urllib
 
 import json
 import logging
@@ -26,8 +25,8 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.contrib import messages
-from accounts.models import GdprAcceptance
 
+from accounts.models import GdprAcceptance
 from utils.onlineusers import cache_online_users
 
 web_logger = logging.getLogger('web')

--- a/general/management/commands/build_static.py
+++ b/general/management/commands/build_static.py
@@ -22,7 +22,6 @@ import os
 import logging
 
 from django.core.management.base import BaseCommand
-from django.urls import reverse
 
 
 console_logger = logging.getLogger("console")

--- a/general/management/commands/build_static.py
+++ b/general/management/commands/build_static.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         the functionality of passing Django settings as env variables below might not be used.
         """
         variables = {}
-        variables_for_command = ' '.join(['{0}={1}'.format(key, value) for key, value in list(variables.items())])
+        variables_for_command = ' '.join(['{0}={1}'.format(key, value) for key, value in variables.items()])
         build_static_command = variables_for_command + ' npm run build'
         console_logger.info('Building static files with command:\n' + build_static_command)
         os.system(build_static_command)

--- a/general/management/commands/build_static.py
+++ b/general/management/commands/build_static.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         the functionality of passing Django settings as env variables below might not be used.
         """
         variables = {}
-        variables_for_command = ' '.join(['{0}={1}'.format(key, value) for key, value in variables.items()])
+        variables_for_command = ' '.join(['{0}={1}'.format(key, value) for key, value in list(variables.items())])
         build_static_command = variables_for_command + ' npm run build'
         console_logger.info('Building static files with command:\n' + build_static_command)
         os.system(build_static_command)

--- a/general/management/commands/post_sounds_to_tagrecommendation.py
+++ b/general/management/commands/post_sounds_to_tagrecommendation.py
@@ -21,9 +21,9 @@
 from __future__ import print_function
 
 from django.core.management.base import BaseCommand
+
 from sounds.models import Sound
 from utils.tagrecommendation_utilities import get_id_of_last_indexed_sound, post_sounds_to_tagrecommendation_service
-from optparse import make_option
 
 
 class Command(BaseCommand):

--- a/general/management/commands/prune_database.py
+++ b/general/management/commands/prune_database.py
@@ -20,6 +20,7 @@
 
 from __future__ import print_function
 
+from builtins import range
 import logging
 import random
 

--- a/general/management/commands/set_first_post_in_threads.py
+++ b/general/management/commands/set_first_post_in_threads.py
@@ -18,6 +18,8 @@
 #     See AUTHORS file.
 #
 
+from future import standard_library
+standard_library.install_aliases()
 from django.core.management.base import BaseCommand
 from forum.models import Thread
 from forum.models import Post

--- a/general/management/commands/similarity_update.py
+++ b/general/management/commands/similarity_update.py
@@ -19,7 +19,6 @@
 #
 
 import logging
-import yaml
 
 from django.conf import settings
 

--- a/general/management/commands/similarity_update.py
+++ b/general/management/commands/similarity_update.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import logging
 
 from django.conf import settings

--- a/general/models.py
+++ b/general/models.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from comments.models import Comment
 from django.contrib.auth.models import User
 from django.contrib.contenttypes import fields
@@ -34,7 +35,7 @@ class SocialModel(models.Model):
     tags = fields.GenericRelation(TaggedItem)
     fans = fields.GenericRelation(Favorite)
 
-    class Meta:
+    class Meta(object):
         abstract = True
 
 class AkismetSpam(SocialModel):
@@ -86,6 +87,6 @@ class OrderedModel(models.Model):
         except ModelClass.DoesNotExist:
             pass
 
-    class Meta:
+    class Meta(object):
         ordering = ["order"]
         abstract = True

--- a/general/tasks.py
+++ b/general/tasks.py
@@ -17,6 +17,7 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import str
 import datetime
 import json
 import logging

--- a/general/templatetags/absurl.py
+++ b/general/templatetags/absurl.py
@@ -18,7 +18,9 @@
 #     See AUTHORS file.
 #
 
-import urlparse
+from future import standard_library
+standard_library.install_aliases()
+import urllib.parse
 from django.template import Library
 from django.template.defaulttags import URLNode, url
 from django.contrib.sites.models import Site
@@ -29,7 +31,7 @@ class AbsoluteURLNode(URLNode):
     def render(self, context):
         path = super(AbsoluteURLNode, self).render(context)
         domain = "https://%s" % Site.objects.get_current().domain
-        return urlparse.urljoin(domain, path)
+        return urllib.parse.urljoin(domain, path)
 
 def absurl(parser, token, node_cls=AbsoluteURLNode):
     """Just like {% url %} but ads the domain of the current site."""

--- a/general/templatetags/bw_templatetags.py
+++ b/general/templatetags/bw_templatetags.py
@@ -22,9 +22,7 @@ import math
 
 from django import template
 from django.conf import settings
-from django.template.defaultfilters import truncatewords_html
 from django.urls import reverse
-from django.utils.safestring import mark_safe
 
 from follow.follow_utils import is_user_following_tag
 from general.templatetags.paginator import show_paginator
@@ -183,4 +181,3 @@ def user_following_tags(user, tags_slash):
 @register.inclusion_tag('molecules/plausible_scripts.html', takes_context=False)
 def bw_plausible_scripts():
     return plausible_scripts()
-

--- a/general/templatetags/bw_templatetags.py
+++ b/general/templatetags/bw_templatetags.py
@@ -18,6 +18,9 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
+from builtins import zip
+from builtins import range
 import math
 
 from django import template
@@ -130,7 +133,7 @@ def bw_sound_stars(context, sound, allow_rating=None, use_request_user_rating=Fa
             'allow_rating': is_authenticated and allow_rating,
             'sound': sound,
             'update_stars_color_on_save': update_stars_color_on_save,
-            'stars_range': zip(stars_5, list(range(1, 6)))}
+            'stars_range': list(zip(stars_5, list(range(1, 6))))}
 
 
 @register.inclusion_tag('atoms/stars.html', takes_context=True)
@@ -154,7 +157,7 @@ def bw_generic_stars(context, rating_0_10):
     return {
         'allow_rating': False,
         'update_stars_color_on_save': False,
-        'stars_range': zip(stars_5, list(range(1, 6)))
+        'stars_range': list(zip(stars_5, list(range(1, 6))))
     }
 
 

--- a/general/templatetags/filter_img.py
+++ b/general/templatetags/filter_img.py
@@ -1,3 +1,4 @@
+from builtins import str
 from django import template
 from bs4 import BeautifulSoup
 

--- a/general/templatetags/maps_js_scripts.py
+++ b/general/templatetags/maps_js_scripts.py
@@ -20,7 +20,6 @@
 
 from django import template
 from django.conf import settings
-from django.utils.safestring import mark_safe
 
 register = template.Library()
 

--- a/general/templatetags/paginator.py
+++ b/general/templatetags/paginator.py
@@ -18,7 +18,11 @@
 #     See AUTHORS file.
 #
 
-import urllib
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+import urllib.request, urllib.parse, urllib.error
 from django import template
 
 register = template.Library()
@@ -54,7 +58,7 @@ def show_paginator(
 
     # although paginator objects are 0-based, we use 1-based paging
     page_numbers = [n for n in range(min_page_num, max_page_num) if n > 0 and n <= paginator.num_pages]
-    params = urllib.urlencode([(key.encode('utf-8'), value.encode('utf-8')) for (key, value) in request.GET.items()
+    params = urllib.parse.urlencode([(key.encode('utf-8'), value.encode('utf-8')) for (key, value) in list(request.GET.items())
                                if key.lower() != u"page"])
 
     if params == "":

--- a/general/templatetags/paginator.py
+++ b/general/templatetags/paginator.py
@@ -58,7 +58,7 @@ def show_paginator(
 
     # although paginator objects are 0-based, we use 1-based paging
     page_numbers = [n for n in range(min_page_num, max_page_num) if n > 0 and n <= paginator.num_pages]
-    params = urllib.parse.urlencode([(key.encode('utf-8'), value.encode('utf-8')) for (key, value) in list(request.GET.items())
+    params = urllib.parse.urlencode([(key.encode('utf-8'), value.encode('utf-8')) for (key, value) in request.GET.items()
                                if key.lower() != u"page"])
 
     if params == "":

--- a/general/templatetags/rss.py
+++ b/general/templatetags/rss.py
@@ -18,10 +18,12 @@
 #     See AUTHORS file.
 #
 
+from future import standard_library
+standard_library.install_aliases()
 from future.utils import raise_
 from django import template
 import feedparser
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 
 register = template.Library()
@@ -33,7 +35,7 @@ class RssParserNode(template.Node):
         self.var_name = var_name
 
     def render(self, context):
-        proxy = urllib2.ProxyHandler({})
+        proxy = urllib.request.ProxyHandler({})
         if self.url:
             context[self.var_name] = feedparser.parse(self.url, handlers=[proxy])
         else:

--- a/general/templatetags/rss.py
+++ b/general/templatetags/rss.py
@@ -22,7 +22,7 @@ from future.utils import raise_
 from django import template
 import feedparser
 import urllib2
-from django.conf import settings
+
 
 register = template.Library()
 

--- a/general/templatetags/util.py
+++ b/general/templatetags/util.py
@@ -1,3 +1,4 @@
+from __future__ import division
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -18,6 +19,8 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
+from past.utils import old_div
 import datetime
 import time
 
@@ -43,7 +46,7 @@ def truncate_string(value, length):
 
 @register.filter
 def duration(value):
-    duration_minutes = int(value/60)
+    duration_minutes = int(old_div(value,60))
     duration_seconds = int(value) % 60
     duration_miliseconds = int((value - int(value)) * 1000)
     return "%d:%02d.%03d" % (duration_minutes, duration_seconds, duration_miliseconds)
@@ -71,7 +74,7 @@ def chunks(l, n):
     """
     if type(l) is not list:
         l = list(l)
-    return [l[i:i + n] for i in xrange(0, len(l), n)]
+    return [l[i:i + n] for i in range(0, len(l), n)]
 
 
 @register.filter

--- a/geotags/management/commands/retrieve_geotag_names.py
+++ b/geotags/management/commands/retrieve_geotag_names.py
@@ -20,8 +20,6 @@
 
 import logging
 
-from django.conf import settings
-from django.core.cache import cache
 from django.db import transaction
 
 from geotags.models import GeoTag

--- a/geotags/models.py
+++ b/geotags/models.py
@@ -19,9 +19,7 @@
 # Authors:
 #     See AUTHORS file.
 #
-import json
 import logging
-import math
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -83,4 +81,3 @@ class GeoTag(models.Model):
                             # It is not possible to derive a name...
                             pass
                 self.save()
-

--- a/geotags/tests.py
+++ b/geotags/tests.py
@@ -33,7 +33,7 @@ class GeoTagsTests(TestCase):
     fixtures = ['licenses', 'sounds']
 
     def check_context(self, context, values):
-        for k, v in list(values.items()):
+        for k, v in values.items():
             self.assertIn(k, context)
             self.assertEqual(context[k], v)
 

--- a/geotags/tests.py
+++ b/geotags/tests.py
@@ -1,3 +1,4 @@
+from __future__ import division
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -18,6 +19,7 @@
 #     See AUTHORS file.
 #
 
+from past.utils import old_div
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
@@ -31,7 +33,7 @@ class GeoTagsTests(TestCase):
     fixtures = ['licenses', 'sounds']
 
     def check_context(self, context, values):
-        for k, v in values.items():
+        for k, v in list(values.items()):
             self.assertIn(k, context)
             self.assertEqual(context[k], v)
 
@@ -94,5 +96,5 @@ class GeoTagsTests(TestCase):
 
         resp = self.client.get(reverse('geotags-barray', kwargs={'tag': tag}))
         # Response contains 3 int32 objects per sound: id, lat and lng. Total size = 3 * 4 bytes = 12 bytes
-        n_sounds = len(resp.content) / 12
+        n_sounds = old_div(len(resp.content), 12)
         self.assertEqual(n_sounds, 2)

--- a/geotags/views.py
+++ b/geotags/views.py
@@ -49,7 +49,7 @@ def log_map_load(map_type, num_geotags, request):
 
 def generate_bytearray(sound_queryset):
     # sounds as bytearray
-    packed_sounds = io.StringIO()
+    packed_sounds = io.BytesIO()
     num_sounds_in_bytearray = 0
     for s in sound_queryset:
         if not math.isnan(s.geotag.lat) and not math.isnan(s.geotag.lon):

--- a/geotags/views.py
+++ b/geotags/views.py
@@ -18,7 +18,9 @@
 #     See AUTHORS file.
 #
 
-import cStringIO
+from future import standard_library
+standard_library.install_aliases()
+import io
 import json
 import logging
 import math
@@ -47,7 +49,7 @@ def log_map_load(map_type, num_geotags, request):
 
 def generate_bytearray(sound_queryset):
     # sounds as bytearray
-    packed_sounds = cStringIO.StringIO()
+    packed_sounds = io.StringIO()
     num_sounds_in_bytearray = 0
     for s in sound_queryset:
         if not math.isnan(s.geotag.lat) and not math.isnan(s.geotag.lon):

--- a/messages/models.py
+++ b/messages/models.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.encoding import smart_unicode
@@ -103,6 +104,6 @@ class Message(models.Model):
     def __unicode__(self):
         return u"from: [%s] to: [%s]" % (self.user_from, self.user_to)
     
-    class Meta:
+    class Meta(object):
         ordering = ('-created',)
 

--- a/messages/tests/test_message_write.py
+++ b/messages/tests/test_message_write.py
@@ -17,6 +17,7 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import range
 import json
 
 from django.contrib.auth.models import User

--- a/messages/views.py
+++ b/messages/views.py
@@ -47,7 +47,7 @@ def messages_change_state(request):
         if not using_beastwhoosh(request):
             # get all message ids in the format `cb_[number]` which have a value of 'on'
             message_ids = []
-            for key, val in list(request.POST.items()):
+            for key, val in request.POST.items():
                 if key.startswith('cb_') and val == 'on':
                     try:
                         msgid = int(key.replace('cb_', ''))

--- a/messages/views.py
+++ b/messages/views.py
@@ -47,7 +47,7 @@ def messages_change_state(request):
         if not using_beastwhoosh(request):
             # get all message ids in the format `cb_[number]` which have a value of 'on'
             message_ids = []
-            for key, val in request.POST.items():
+            for key, val in list(request.POST.items()):
                 if key.startswith('cb_') and val == 'on':
                     try:
                         msgid = int(key.replace('cb_', ''))

--- a/monitor/management/commands/generate_stats.py
+++ b/monitor/management/commands/generate_stats.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import datetime
 
 from django.contrib.auth.models import User
@@ -95,7 +96,7 @@ class Command(LoggingBaseCommand):
             'pack_downloads': {'obj': sounds.models.PackDownload.objects, 'attr': 'user_id'},
             'rate': {'obj': ratings.models.SoundRating.objects, 'attr': 'user_id'},
         }
-        for i in active_users.keys():
+        for i in list(active_users.keys()):
             qq = active_users[i]['obj'].filter(created__gt=time_span)\
                 .extra({'week': "to_char(created, 'WW-IYYY')"})\
                 .values('week').order_by()\

--- a/monitor/management/commands/generate_stats.py
+++ b/monitor/management/commands/generate_stats.py
@@ -96,7 +96,7 @@ class Command(LoggingBaseCommand):
             'pack_downloads': {'obj': sounds.models.PackDownload.objects, 'attr': 'user_id'},
             'rate': {'obj': ratings.models.SoundRating.objects, 'attr': 'user_id'},
         }
-        for i in list(active_users.keys()):
+        for i in active_users.keys():
             qq = active_users[i]['obj'].filter(created__gt=time_span)\
                 .extra({'week': "to_char(created, 'WW-IYYY')"})\
                 .values('week').order_by()\

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -83,7 +83,7 @@ def monitor_home(request):
     analyzers_data = {}  
     all_sound_ids = Sound.objects.all().values_list('id', flat=True).order_by('id')
     n_sounds = len(all_sound_ids)
-    for analyzer_name in list(settings.ANALYZERS_CONFIGURATION.keys()):
+    for analyzer_name in settings.ANALYZERS_CONFIGURATION.keys():
         ok = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="OK").count()
         sk = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="SK").count()
         fa = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="FA").count()
@@ -108,7 +108,7 @@ def monitor_home(request):
              "sounds_failed_count": sounds_failed_count,
              "sounds_ok_count": sounds_ok_count,
              "sounds_in_moderators_queue_count": sounds_in_moderators_queue_count,
-             "analyzers_data": [(key, value) for key, value in list(analyzers_data.items())],
+             "analyzers_data": [(key, value) for key, value in analyzers_data.items()],
              "queues_stats_url": reverse('queues-stats'),
     }
 

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -1,3 +1,4 @@
+from __future__ import division
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -18,6 +19,7 @@
 #     See AUTHORS file.
 #
 
+from past.utils import old_div
 import datetime
 from collections import Counter
 
@@ -81,7 +83,7 @@ def monitor_home(request):
     analyzers_data = {}  
     all_sound_ids = Sound.objects.all().values_list('id', flat=True).order_by('id')
     n_sounds = len(all_sound_ids)
-    for analyzer_name in settings.ANALYZERS_CONFIGURATION.keys():
+    for analyzer_name in list(settings.ANALYZERS_CONFIGURATION.keys()):
         ok = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="OK").count()
         sk = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="SK").count()
         fa = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="FA").count()
@@ -106,7 +108,7 @@ def monitor_home(request):
              "sounds_failed_count": sounds_failed_count,
              "sounds_ok_count": sounds_ok_count,
              "sounds_in_moderators_queue_count": sounds_in_moderators_queue_count,
-             "analyzers_data": [(key, value) for key, value in analyzers_data.items()],
+             "analyzers_data": [(key, value) for key, value in list(analyzers_data.items())],
              "queues_stats_url": reverse('queues-stats'),
     }
 
@@ -122,7 +124,7 @@ def monitor_stats(request):
 @login_required
 @user_passes_test(lambda u: u.is_staff, login_url='/')
 def moderators_stats(request):
-    time_span = datetime.datetime.now()-datetime.timedelta(6*365/12)
+    time_span = datetime.datetime.now()-datetime.timedelta(old_div(6*365,12))
     #Maybe we should user created and not modified
     user_ids = tickets.models.Ticket.objects.filter(
             status=TICKET_STATUS_CLOSED,
@@ -131,7 +133,7 @@ def moderators_stats(request):
     ).values_list("assignee_id", flat=True)
 
     counter = Counter(user_ids)
-    moderators = User.objects.filter(id__in=counter.keys())
+    moderators = User.objects.filter(id__in=list(counter.keys()))
 
     moderators = [(counter.get(m.id), m) for m in moderators.all()]
     ordered = sorted(moderators, key=lambda m: m[0], reverse=True)
@@ -227,7 +229,7 @@ def process_sounds(request):
 
 def moderator_stats_ajax(request):
     user_id = request.GET.get('user_id', None)
-    time_span = datetime.datetime.now()-datetime.timedelta(6*365/12)
+    time_span = datetime.datetime.now()-datetime.timedelta(old_div(6*365,12))
     tickets_mod = tickets.models.Ticket.objects.filter(
             assignee_id=user_id,
             status=TICKET_STATUS_CLOSED,

--- a/ratings/models.py
+++ b/ratings/models.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from django.contrib.auth.models import User
 
 from django.contrib.contenttypes.models import ContentType
@@ -41,7 +42,7 @@ class SoundRating(models.Model):
     def __unicode__(self):
         return u"%s rated %s: %d" % (self.user, self.sound, self.rating)
 
-    class Meta:
+    class Meta(object):
         unique_together = (('user', 'sound'),)
         ordering = ('-created',)
 

--- a/ratings/tests.py
+++ b/ratings/tests.py
@@ -50,7 +50,7 @@ class RatingsTestCase(TestCase):
 
         RATING_VALUE = 3
         resp = self.client.get("/people/Anton/sounds/%s/rate/%s/" % (self.sound.id, RATING_VALUE))
-        self.assertEqual(resp.content, "2")
+        self.assertContains(resp, "2")
 
         self.assertEqual(ratings.models.SoundRating.objects.count(), 2)
         r = ratings.models.SoundRating.objects.get(sound_id=self.sound.id, user_id=self.user1.id)
@@ -91,10 +91,10 @@ class RatingsTestCase(TestCase):
 
         resp = self.client.get("/people/Anton/sounds/%s/rate/%s/" % (self.sound.id, 0))
         # After doing an invalid rating, there are still none for this sound
-        self.assertEqual(resp.content, "0")
+        self.assertContains(resp, "0")
 
         resp = self.client.get("/people/Anton/sounds/%s/rate/%s/" % (self.sound.id, 6))
-        self.assertEqual(resp.content, "0")
+        self.assertContains(resp, "0")
 
     def test_delete_all_ratings(self):
         r = ratings.models.SoundRating.objects.create(sound=self.sound, user_id=self.user2.id, rating=2)

--- a/ratings/views.py
+++ b/ratings/views.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.http import Http404

--- a/ratings/views.py
+++ b/ratings/views.py
@@ -26,7 +26,6 @@ from django.shortcuts import get_object_or_404
 
 from ratings.models import SoundRating
 from sounds.models import Sound
-from utils.cache import invalidate_template_cache
 
 
 @login_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 akismet==1.0.1
 autopep8==1.5.7
+backports.csv
 beautifulsoup4==4.6.0
 bleach==3.1.5
 boto3==1.7.10

--- a/search/management/commands/post_dirty_sounds_to_search_engine.py
+++ b/search/management/commands/post_dirty_sounds_to_search_engine.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
 import logging
 
 from sounds.models import Sound

--- a/search/management/commands/reindex_search_engine_forum.py
+++ b/search/management/commands/reindex_search_engine_forum.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
 import logging
 
 from django.core.management.base import BaseCommand

--- a/search/management/commands/reindex_search_engine_sounds.py
+++ b/search/management/commands/reindex_search_engine_sounds.py
@@ -24,7 +24,7 @@ from django.core.management.base import BaseCommand
 
 from sounds.models import Sound
 from search.management.commands.post_dirty_sounds_to_search_engine import send_sounds_to_search_engine
-from utils.search.search_sounds import add_sounds_to_search_engine, delete_all_sounds_from_search_engine, delete_sounds_from_search_engine, get_all_sound_ids_from_search_engine
+from utils.search.search_sounds import delete_all_sounds_from_search_engine, delete_sounds_from_search_engine, get_all_sound_ids_from_search_engine
 
 console_logger = logging.getLogger("console")
 

--- a/search/management/commands/test_search_engine_backend.py
+++ b/search/management/commands/test_search_engine_backend.py
@@ -17,6 +17,9 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import str
+from builtins import zip
+from builtins import range
 import datetime
 import logging
 import os
@@ -340,7 +343,7 @@ class Command(BaseCommand):
             }
             results = run_sounds_query_and_save_results(search_engine, dict(facets=test_facet_options))
             assert_and_continue(len(results.facets) == 3, 'Wrong number of facets returned')
-            for facet_field, facet_options in test_facet_options.items():
+            for facet_field, facet_options in list(test_facet_options.items()):
                 assert_and_continue(facet_field in results.facets, 'Facet {} not found in facets'.format(facet_field))
                 if 'limit' in facet_options:
                     assert_and_continue(len(results.facets[facet_field]) == facet_options['limit'],
@@ -459,7 +462,7 @@ class Command(BaseCommand):
             # Test highlighting in results
             results = run_forum_query_and_save_results(search_engine, dict(textual_query="microphone"))
             assert_and_continue(results.highlighting != dict(), 'No highlighting entries returned')
-            for highlighting_content in results.highlighting.values():
+            for highlighting_content in list(results.highlighting.values()):
                 assert_and_continue('post_body' in highlighting_content, 'Highlighting data without expected fields')
 
             # Run a couple of extra queries without assessing results so that these get saved and the results can be

--- a/search/management/commands/test_search_engine_backend.py
+++ b/search/management/commands/test_search_engine_backend.py
@@ -343,7 +343,7 @@ class Command(BaseCommand):
             }
             results = run_sounds_query_and_save_results(search_engine, dict(facets=test_facet_options))
             assert_and_continue(len(results.facets) == 3, 'Wrong number of facets returned')
-            for facet_field, facet_options in list(test_facet_options.items()):
+            for facet_field, facet_options in test_facet_options.items():
                 assert_and_continue(facet_field in results.facets, 'Facet {} not found in facets'.format(facet_field))
                 if 'limit' in facet_options:
                     assert_and_continue(len(results.facets[facet_field]) == facet_options['limit'],
@@ -462,7 +462,7 @@ class Command(BaseCommand):
             # Test highlighting in results
             results = run_forum_query_and_save_results(search_engine, dict(textual_query="microphone"))
             assert_and_continue(results.highlighting != dict(), 'No highlighting entries returned')
-            for highlighting_content in list(results.highlighting.values()):
+            for highlighting_content in results.highlighting.values():
                 assert_and_continue('post_body' in highlighting_content, 'Highlighting data without expected fields')
 
             # Run a couple of extra queries without assessing results so that these get saved and the results can be

--- a/search/templatetags/search.py
+++ b/search/templatetags/search.py
@@ -1,3 +1,4 @@
+from __future__ import division
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -19,6 +20,7 @@
 #
 
 
+from past.utils import old_div
 from django import template
 from django.utils.http import urlquote_plus
 
@@ -72,7 +74,7 @@ def display_facet(context, flt, facet, facet_type, title=""):
             filtered_facet = sorted(filtered_facet, key=lambda x: x['count'], reverse=True)
             max_count = max([element['count'] for element in filtered_facet])
             for element in filtered_facet:
-                element['weight'] = (1.0 * element['count']) / max_count
+                element['weight'] = old_div((1.0 * element['count']), max_count)
 
     context.update({
         "facet": filtered_facet,

--- a/search/tests.py
+++ b/search/tests.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 from django.test import TestCase
 from django.urls import reverse
 from sounds.models import Sound

--- a/search/views.py
+++ b/search/views.py
@@ -38,7 +38,7 @@ from clustering.clustering_settings import DEFAULT_FEATURES, NUM_SOUND_EXAMPLES_
     NUM_TAGS_SHOWN_PER_CLUSTER_FACET
 from clustering.interface import cluster_sound_results, get_sound_ids_from_search_engine_query
 from forum.models import Post
-from utils.frontend_handling import render, defer_if_beastwhoosh, using_beastwhoosh
+from utils.frontend_handling import render, using_beastwhoosh
 from utils.logging_filters import get_client_ip
 from utils.ratelimit import key_for_ratelimiting, rate_per_ip
 from utils.search.search_sounds import perform_search_engine_query, search_prepare_parameters, \

--- a/search/views.py
+++ b/search/views.py
@@ -273,7 +273,7 @@ def clustering_facet(request):
 
     # extract tags for each clusters and do not use query terms for labeling clusters
     query_terms = {t.lower() for t in request.GET.get('q', '').split(' ')}
-    for sound_id, tags in list(sound_tags.items()):
+    for sound_id, tags in sound_tags.items():
         cluster_tags[partition[str(sound_id)]] += [t.lower() for t in tags if t.lower() not in query_terms]
 
     # count 3 most occuring tags

--- a/search/views.py
+++ b/search/views.py
@@ -19,6 +19,10 @@
 #     See AUTHORS file.
 #
 
+from builtins import map
+from builtins import str
+from builtins import zip
+from builtins import range
 import datetime
 import json
 import logging
@@ -263,13 +267,13 @@ def clustering_facet(request):
     partition = {sound_id: cluster_id for cluster_id, cluster in enumerate(results) for sound_id in cluster}
 
     # label clusters using most occuring tags
-    sound_instances = sounds.models.Sound.objects.bulk_query_id(map(int, partition.keys()))
+    sound_instances = sounds.models.Sound.objects.bulk_query_id(list(map(int, list(partition.keys()))))
     sound_tags = {sound.id: sound.tag_array for sound in sound_instances}
     cluster_tags = defaultdict(list)
 
     # extract tags for each clusters and do not use query terms for labeling clusters
     query_terms = {t.lower() for t in request.GET.get('q', '').split(' ')}
-    for sound_id, tags in sound_tags.iteritems():
+    for sound_id, tags in list(sound_tags.items()):
         cluster_tags[partition[str(sound_id)]] += [t.lower() for t in tags if t.lower() not in query_terms]
 
     # count 3 most occuring tags
@@ -286,7 +290,7 @@ def clustering_facet(request):
 
     # extract sound examples for each cluster
     sound_ids_examples_per_cluster = [
-        map(int, cluster_sound_ids[:NUM_SOUND_EXAMPLES_PER_CLUSTER_FACET])
+        list(map(int, cluster_sound_ids[:NUM_SOUND_EXAMPLES_PER_CLUSTER_FACET]))
         for cluster_sound_ids in results
     ]
     sound_ids_examples = [item for sublist in sound_ids_examples_per_cluster for item in sublist]
@@ -303,12 +307,12 @@ def clustering_facet(request):
     return render(request, 'search/clustering_facet.html', {
             'results': partition,
             'url_query_params_string': url_query_params_string,
-            'cluster_id_num_results_tags_sound_examples': zip(
-                range(num_clusters),
+            'cluster_id_num_results_tags_sound_examples': list(zip(
+                list(range(num_clusters)),
                 num_sounds_per_cluster,
                 most_occuring_tags_formatted,
                 sound_url_examples_per_cluster
-            ),
+            )),
     })
 
 

--- a/similarity/client/__init__.py
+++ b/similarity/client/__init__.py
@@ -66,7 +66,7 @@ def _result_or_exception(result):
     if not result['error']:
         return result['result']
     else:
-        if 'status_code' in list(result.keys()):
+        if 'status_code' in result.keys():
             raise SimilarityException(result['result'], status_code=result['status_code'])
         else:
             raise SimilarityException(result['result'], status_code=500)

--- a/similarity/client/__init__.py
+++ b/similarity/client/__init__.py
@@ -18,9 +18,13 @@
 #     See AUTHORS file.
 #
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 from django.conf import settings
 import json
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 _BASE_URL                     = 'http://%s:%i/similarity/' % (settings.SIMILARITY_ADDRESS, settings.SIMILARITY_PORT)
 _BASE_INDEXING_SERVER_URL     = 'http://%s:%i/similarity/' % (settings.SIMILARITY_ADDRESS, settings.SIMILARITY_INDEXING_SERVER_PORT)
@@ -53,7 +57,7 @@ def _get_url_as_json(url, data=None, timeout=None):
         kwargs['timeout'] = timeout
     else:
         kwargs['timeout'] = settings.SIMILARITY_TIMEOUT
-    f = urllib2.urlopen(url.replace(" ", "%20"), **kwargs)
+    f = urllib.request.urlopen(url.replace(" ", "%20"), **kwargs)
     resp = f.read()
     return json.loads(resp)
 
@@ -62,13 +66,13 @@ def _result_or_exception(result):
     if not result['error']:
         return result['result']
     else:
-        if 'status_code' in result.keys():
+        if 'status_code' in list(result.keys()):
             raise SimilarityException(result['result'], status_code=result['status_code'])
         else:
             raise SimilarityException(result['result'], status_code=500)
 
 
-class Similarity():
+class Similarity(object):
 
     @classmethod
     def search(cls, sound_id, num_results = None, preset = None, offset = None):

--- a/similarity/gaia_wrapper.py
+++ b/similarity/gaia_wrapper.py
@@ -366,7 +366,7 @@ class GaiaWrapper(object):
                         # only return descriptors if nested descriptors are statistics
                         if len(set(nested_descriptors.keys()).intersection(
                                 ['min', 'max', 'dvar2', 'dmean2', 'dmean', 'var', 'dvar', 'mean'])) > 0:
-                            for extra_name in list(nested_descriptors.keys()):
+                            for extra_name in nested_descriptors.keys():
                                 processed_descriptor_names.append('%s.%s' % (name, extra_name))
                     else:
                         # Return all nested descriptor names
@@ -495,9 +495,9 @@ class GaiaWrapper(object):
                 query = Point()
                 query.setLayout(layout)
                 try:
-                    for param in list(target.keys()):
+                    for param in target.keys():
                         # Only add numerical parameters. Non numerical ones (like key) are only used as filters
-                        if param in list(coeffs.keys()):
+                        if param in coeffs.keys():
                             feature_names.append(str(param))
                             value = target[param]
                             if coeffs:
@@ -549,7 +549,7 @@ class GaiaWrapper(object):
                         nonused_features = []
 
                         for param in feature_names:
-                            if param in list(coeffs.keys()):
+                            if param in coeffs.keys():
                                 value = get_nested_dictionary_value(param[1:].split('.'), target)
                                 if coeffs:
                                     try:

--- a/similarity/gaia_wrapper.py
+++ b/similarity/gaia_wrapper.py
@@ -20,6 +20,9 @@
 
 from __future__ import absolute_import
 
+from builtins import str
+from builtins import range
+from builtins import object
 import errno
 import logging
 import os
@@ -51,7 +54,7 @@ def create_directories(path, exist_ok=True):
             raise
 
 
-class GaiaWrapper:
+class GaiaWrapper(object):
 
     def __init__(self, indexing_only_mode=False):
         self.indexing_only_mode = indexing_only_mode
@@ -363,7 +366,7 @@ class GaiaWrapper:
                         # only return descriptors if nested descriptors are statistics
                         if len(set(nested_descriptors.keys()).intersection(
                                 ['min', 'max', 'dvar2', 'dmean2', 'dmean', 'var', 'dvar', 'mean'])) > 0:
-                            for extra_name in nested_descriptors.keys():
+                            for extra_name in list(nested_descriptors.keys()):
                                 processed_descriptor_names.append('%s.%s' % (name, extra_name))
                     else:
                         # Return all nested descriptor names
@@ -492,9 +495,9 @@ class GaiaWrapper:
                 query = Point()
                 query.setLayout(layout)
                 try:
-                    for param in target.keys():
+                    for param in list(target.keys()):
                         # Only add numerical parameters. Non numerical ones (like key) are only used as filters
-                        if param in coeffs.keys():
+                        if param in list(coeffs.keys()):
                             feature_names.append(str(param))
                             value = target[param]
                             if coeffs:
@@ -546,7 +549,7 @@ class GaiaWrapper:
                         nonused_features = []
 
                         for param in feature_names:
-                            if param in coeffs.keys():
+                            if param in list(coeffs.keys()):
                                 value = get_nested_dictionary_value(param[1:].split('.'), target)
                                 if coeffs:
                                     try:

--- a/similarity/similarity_indexing_server.py
+++ b/similarity/similarity_indexing_server.py
@@ -27,6 +27,7 @@ can be reloaded with the new index.
 
 from __future__ import absolute_import
 
+from builtins import str
 import json
 import logging
 from logging.handlers import RotatingFileHandler

--- a/similarity/similarity_server.py
+++ b/similarity/similarity_server.py
@@ -163,7 +163,7 @@ class SimilarityServer(resource.Resource):
                             return json.dumps({'error': True, 'result': target, 'status_code': BAD_REQUEST_CODE})
                         else:
                             return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
-                    if not target.items():
+                    if not list(target.items()):
                         return json.dumps({'error': True, 'result': 'Invalid target.', 'status_code': BAD_REQUEST_CODE})
                 except Exception as e:
                     return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
@@ -209,7 +209,7 @@ class SimilarityServer(resource.Resource):
             offset = int(offset[0])
 
         if target_type == 'descriptor_values' and target:
-            metric_descriptor_names = parse_metric_descriptors(','.join(target.keys()), self.gaia.descriptor_names['fixed-length'])
+            metric_descriptor_names = parse_metric_descriptors(','.join(list(target.keys())), self.gaia.descriptor_names['fixed-length'])
         else:
             metric_descriptor_names = False  # For the moment metric_descriptor_names can only be set by us
 

--- a/similarity/similarity_server.py
+++ b/similarity/similarity_server.py
@@ -163,7 +163,7 @@ class SimilarityServer(resource.Resource):
                             return json.dumps({'error': True, 'result': target, 'status_code': BAD_REQUEST_CODE})
                         else:
                             return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
-                    if not list(target.items()):
+                    if not target.items():
                         return json.dumps({'error': True, 'result': 'Invalid target.', 'status_code': BAD_REQUEST_CODE})
                 except Exception as e:
                     return json.dumps({'error': True, 'result': 'Invalid descriptor values for target.', 'status_code': BAD_REQUEST_CODE})
@@ -209,7 +209,7 @@ class SimilarityServer(resource.Resource):
             offset = int(offset[0])
 
         if target_type == 'descriptor_values' and target:
-            metric_descriptor_names = parse_metric_descriptors(','.join(list(target.keys())), self.gaia.descriptor_names['fixed-length'])
+            metric_descriptor_names = parse_metric_descriptors(','.join(target.keys()), self.gaia.descriptor_names['fixed-length'])
         else:
             metric_descriptor_names = False  # For the moment metric_descriptor_names can only be set by us
 

--- a/similarity/similarity_server_utils.py
+++ b/similarity/similarity_server_utils.py
@@ -19,6 +19,8 @@
 #
 
 
+from builtins import str
+from builtins import range
 def parse_filter(filter_string, layout_descriptor_names):
     ALLOWED_CONTENT_BASED_SEARCH_DESCRIPTORS = layout_descriptor_names
 
@@ -80,7 +82,7 @@ def parse_filter(filter_string, layout_descriptor_names):
             current_pos = filter_string.find(op,min_pos)
             min_pos = current_pos + 1
             aux_ops[current_pos] = op#.append({'op':op,'pos':current_pos})
-    keylist = aux_ops.keys()
+    keylist = list(aux_ops.keys())
     keylist.sort()
     for key in keylist:
         op = aux_ops[key]
@@ -296,7 +298,7 @@ def set_nested_dictionary_value(keys, dict, value):
         set_nested_dictionary_value(keys[1:], dict[keys[0]], value)
 
 def get_nested_descriptor_names(structured_layout, accumulated_list=[], keys=[]):
-    for key, item in structured_layout.items():
+    for key, item in list(structured_layout.items()):
         if type(item) == dict:
             keys.append(key)
             get_nested_descriptor_names(item, accumulated_list, keys)

--- a/similarity/similarity_server_utils.py
+++ b/similarity/similarity_server_utils.py
@@ -298,7 +298,7 @@ def set_nested_dictionary_value(keys, dict, value):
         set_nested_dictionary_value(keys[1:], dict[keys[0]], value)
 
 def get_nested_descriptor_names(structured_layout, accumulated_list=[], keys=[]):
-    for key, item in list(structured_layout.items()):
+    for key, item in structured_layout.items():
         if type(item) == dict:
             keys.append(key)
             get_nested_descriptor_names(item, accumulated_list, keys)

--- a/sounds/management/commands/clean_tmp_pcm_analysis_files.py
+++ b/sounds/management/commands/clean_tmp_pcm_analysis_files.py
@@ -20,12 +20,11 @@
 import datetime
 import glob
 import logging
-
 import os
-import json
 import time
 
 from django.conf import settings
+
 from utils.management_commands import LoggingBaseCommand
 
 

--- a/sounds/management/commands/create_random_sounds.py
+++ b/sounds/management/commands/create_random_sounds.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
 import datetime
 
 from django.conf import settings

--- a/sounds/management/commands/create_remix_groups.py
+++ b/sounds/management/commands/create_remix_groups.py
@@ -20,6 +20,7 @@
 
 from __future__ import division
 
+from builtins import str
 import json
 import logging
 

--- a/sounds/management/commands/orchestrate_analysis.py
+++ b/sounds/management/commands/orchestrate_analysis.py
@@ -70,7 +70,7 @@ class Command(LoggingBaseCommand):
         n_sounds = len(all_sound_ids)
         console_logger.info("{: >44} {: >11} {: >11} {: >11} {: >11} {: >11}".format(
             *['', '# ok |', '# failed |', '# skipped |', '# queued |', '# missing']))
-        for analyzer_name in list(settings.ANALYZERS_CONFIGURATION.keys()):
+        for analyzer_name in settings.ANALYZERS_CONFIGURATION.keys():
             ok = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="OK").count()
             sk = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="SK").count()
             fa = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="FA").count()
@@ -108,7 +108,7 @@ class Command(LoggingBaseCommand):
             queues_status_dict = None
             consumers_per_queue_dict = {}
 
-        for analyzer_name in list(settings.ANALYZERS_CONFIGURATION.keys()):
+        for analyzer_name in settings.ANALYZERS_CONFIGURATION.keys():
             console_logger.info(analyzer_name)
             if queues_status_dict is not None:
                 num_jobs_in_queue = queues_status_dict.get(analyzer_name, 0)
@@ -169,7 +169,7 @@ class Command(LoggingBaseCommand):
 
             if analyzer_name in data_to_log:
                 # Log ata to graylog in a way that we can make plots and show stats
-                analyzer_data_to_log = {key: value for key, value in list(data_to_log[analyzer_name].items())}
+                analyzer_data_to_log = {key: value for key, value in data_to_log[analyzer_name].items()}
                 analyzer_data_to_log.update({
                     'analyzer': analyzer_name,
                     'percentage_completed': analyzer_data_to_log['Percentage']

--- a/sounds/management/commands/orchestrate_analysis.py
+++ b/sounds/management/commands/orchestrate_analysis.py
@@ -20,7 +20,6 @@
 import datetime
 import logging
 import json
-from collections import Counter
 
 from django.conf import settings
 

--- a/sounds/management/commands/orchestrate_analysis.py
+++ b/sounds/management/commands/orchestrate_analysis.py
@@ -17,6 +17,7 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import str
 import datetime
 import logging
 import json
@@ -69,7 +70,7 @@ class Command(LoggingBaseCommand):
         n_sounds = len(all_sound_ids)
         console_logger.info("{: >44} {: >11} {: >11} {: >11} {: >11} {: >11}".format(
             *['', '# ok |', '# failed |', '# skipped |', '# queued |', '# missing']))
-        for analyzer_name in settings.ANALYZERS_CONFIGURATION.keys():
+        for analyzer_name in list(settings.ANALYZERS_CONFIGURATION.keys()):
             ok = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="OK").count()
             sk = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="SK").count()
             fa = SoundAnalysis.objects.filter(analyzer=analyzer_name, analysis_status="FA").count()
@@ -107,7 +108,7 @@ class Command(LoggingBaseCommand):
             queues_status_dict = None
             consumers_per_queue_dict = {}
 
-        for analyzer_name in settings.ANALYZERS_CONFIGURATION.keys():
+        for analyzer_name in list(settings.ANALYZERS_CONFIGURATION.keys()):
             console_logger.info(analyzer_name)
             if queues_status_dict is not None:
                 num_jobs_in_queue = queues_status_dict.get(analyzer_name, 0)
@@ -168,7 +169,7 @@ class Command(LoggingBaseCommand):
 
             if analyzer_name in data_to_log:
                 # Log ata to graylog in a way that we can make plots and show stats
-                analyzer_data_to_log = {key: value for key, value in data_to_log[analyzer_name].items()}
+                analyzer_data_to_log = {key: value for key, value in list(data_to_log[analyzer_name].items())}
                 analyzer_data_to_log.update({
                     'analyzer': analyzer_name,
                     'percentage_completed': analyzer_data_to_log['Percentage']

--- a/sounds/management/commands/update_cdn_sounds.py
+++ b/sounds/management/commands/update_cdn_sounds.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import json
 import logging
 import os

--- a/sounds/migrations/0044_auto_20220209_1136.py
+++ b/sounds/migrations/0044_auto_20220209_1136.py
@@ -16,7 +16,7 @@ def update_existing_ac_analysis_objects(apps, schema_editor):
         sa.last_analyzer_finished = sa.last_sent_to_queue
         if sa.analysis_data:
             updated_analysis_data = {}
-            for key, value in list(sa.analysis_data.items()):
+            for key, value in sa.analysis_data.items():
                 updated_analysis_data['ac_{0}'.format(key)] = value
             sa.analysis_data = updated_analysis_data
         sa.save()

--- a/sounds/migrations/0044_auto_20220209_1136.py
+++ b/sounds/migrations/0044_auto_20220209_1136.py
@@ -16,7 +16,7 @@ def update_existing_ac_analysis_objects(apps, schema_editor):
         sa.last_analyzer_finished = sa.last_sent_to_queue
         if sa.analysis_data:
             updated_analysis_data = {}
-            for key, value in sa.analysis_data.items():
+            for key, value in list(sa.analysis_data.items()):
                 updated_analysis_data['ac_{0}'.format(key)] = value
             sa.analysis_data = updated_analysis_data
         sa.save()

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -20,6 +20,12 @@
 #     See AUTHORS file.
 #
 
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
+from past.utils import old_div
 import datetime
 import glob
 import json
@@ -210,7 +216,7 @@ class BulkUploadProgress(models.Model):
         sound_ids_described_ok = []
         sound_errors = []
         if self.description_output is not None:
-            for line_no, value in self.description_output.items():
+            for line_no, value in list(self.description_output.items()):
                 if type(value) == int:
                     # Sound id, meaning a file for which a Sound object was successfully created
                     sound_ids_described_ok.append(value)
@@ -243,14 +249,14 @@ class BulkUploadProgress(models.Model):
                                                     n_sounds_failed_processing)
         progress = 0
         if self.description_output is not None:
-            progress = 100.0 * (n_sounds_published +
+            progress = old_div(100.0 * (n_sounds_published +
                                 n_sounds_moderation +
                                 n_sounds_failed_processing +
                                 n_sounds_error +
-                                n_sounds_unknown) / \
+                                n_sounds_unknown), \
                        (n_sounds_described_ok +
                         n_sounds_error +
-                        n_sounds_remaining_to_describe)
+                        n_sounds_remaining_to_describe))
             progress = int(progress)
             # NOTE: progress percentage is determined as the total number of sounds "that won't change" vs the total
             # number of sounds that should have been described and processed. Sounds that fail processing or description
@@ -288,7 +294,7 @@ class BulkUploadProgress(models.Model):
             return len(self.validation_output['lines_with_errors']) > 0
         return False
 
-    class Meta:
+    class Meta(object):
         permissions = (
             ("can_describe_in_bulk", "Can use the Bulk Describe feature."),
         )
@@ -360,7 +366,7 @@ class SoundManager(models.Manager):
         """Returns the SQL bits to add to bulk_query and bulk_query_solr so that analyzer's data is selected
         in the bulk query"""
         analyzers_select_section_parts = []
-        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
+        for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
             if 'descriptors_map' in analyzer_info:
                 analyzers_select_section_parts.append("{0}.analysis_data as {0},"
                                                       .format(analyzer_name.replace('-', '_')))
@@ -370,7 +376,7 @@ class SoundManager(models.Manager):
         """Returns the SQL bits to add to bulk_query and bulk_query_solr so that analyzer's data can be left joined
         in the bulk query"""
         analyzers_left_join_section_parts = []
-        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
+        for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
             if 'descriptors_map' in analyzer_info:
                 analyzers_left_join_section_parts.append(
                     "LEFT JOIN sounds_soundanalysis {0} ON (sound.id = {0}.sound_id AND {0}.analyzer = '{1}')"
@@ -659,7 +665,7 @@ class Sound(SocialModel):
 
     @locations_decorator()
     def locations(self):
-        id_folder = str(self.id/1000)
+        id_folder = str(old_div(self.id,1000))
         sound_user_id = self.user_id
         previews_url = settings.PREVIEWS_URL if not settings.USE_CDN_FOR_PREVIEWS else settings.CDN_PREVIEWS_URL
         displays_url = settings.DISPLAYS_URL if not settings.USE_CDN_FOR_DISPLAYS else settings.CDN_DISPLAYS_URL
@@ -819,7 +825,7 @@ class Sound(SocialModel):
     @property
     def avg_rating_0_5(self):
         # Returns the average raring, normalized from 0 tp 5
-        return self.avg_rating / 2
+        return old_div(self.avg_rating, 2)
 
     def get_absolute_url(self):
         return reverse('sound', args=[self.user.username, smart_unicode(self.id)])
@@ -1165,7 +1171,7 @@ class Sound(SocialModel):
 
     def analyze(self, analyzer=settings.FREESOUND_ESSENTIA_EXTRACTOR_NAME, force=False, verbose=True, high_priority=False):
         # Note that "high_priority" is not implemented but needs to be here for compatibility with older code
-        if analyzer not in settings.ANALYZERS_CONFIGURATION.keys():
+        if analyzer not in list(settings.ANALYZERS_CONFIGURATION.keys()):
             # If specified analyzer is not one of the analyzers configured, do nothing
             if verbose:
                 sounds_logger.info("Not sending sound {} to unknown analyzer {}".format(self.id, analyzer))
@@ -1327,7 +1333,7 @@ def on_delete_sound(sender, instance, **kwargs):
     # store count and average (for ratings). We do not store at all information about bookmarks.
 
     try:
-        data = Sound.objects.filter(pk=instance.pk).values()[0]
+        data = list(Sound.objects.filter(pk=instance.pk).values())[0]
     except IndexError:
         # The sound being deleted can't be found on the database. This might happen if a sound is being deleted
         # multiple times concurrently, and in one "thread" the sound object has already been deleted when reaching
@@ -1342,17 +1348,17 @@ def on_delete_sound(sender, instance, **kwargs):
 
     pack = None
     if instance.pack:
-        pack = Pack.objects.filter(pk=instance.pack.pk).values()[0]
+        pack = list(Pack.objects.filter(pk=instance.pack.pk).values())[0]
     data['pack'] = pack
 
     geotag = None
     if instance.geotag:
-        geotag = GeoTag.objects.filter(pk=instance.geotag.pk).values()[0]
+        geotag = list(GeoTag.objects.filter(pk=instance.geotag.pk).values())[0]
     data['geotag'] = geotag
 
     license = None
     if instance.license:
-        license = License.objects.filter(pk=instance.license.pk).values()[0]
+        license = list(License.objects.filter(pk=instance.license.pk).values())[0]
     data['license'] = license
 
     data['comments'] = list(instance.comments.values())
@@ -1531,14 +1537,14 @@ class Pack(SocialModel):
         # TODO: don't compute this realtime, store it in DB
         ratings = list(SoundRating.objects.filter(sound__pack=self).values_list('rating', flat=True))
         if ratings:
-            return 1.0*sum(ratings)/len(ratings)
+            return old_div(1.0*sum(ratings),len(ratings))
         else:
             return 0
 
     @property
     def avg_rating_0_5(self):
         # Returns the average raring, normalized from 0 tp 5
-        return self.avg_rating/2
+        return old_div(self.avg_rating,2)
 
     @property
     def num_ratings(self):
@@ -1626,7 +1632,7 @@ class Flag(models.Model):
     def __unicode__(self):
         return u"%s: %s" % (self.reason_type, self.reason[:100])
 
-    class Meta:
+    class Meta(object):
         ordering = ("-created",)
 
 
@@ -1636,7 +1642,7 @@ class Download(models.Model):
     license = models.ForeignKey(License)
     created = models.DateTimeField(db_index=True, auto_now_add=True)
 
-    class Meta:
+    class Meta(object):
         ordering = ("-created",)
         indexes = [
             models.Index(fields=['user', 'sound']),
@@ -1708,7 +1714,7 @@ class SoundLicenseHistory(models.Model):
     sound = models.ForeignKey(Sound)
     created = models.DateTimeField(db_index=True, auto_now_add=True)
 
-    class Meta:
+    class Meta(object):
         ordering = ("-created",)
 
 
@@ -1739,7 +1745,7 @@ class SoundAnalysis(models.Model):
          include analysis output but also logs. The base filepath should be complemented with the extension, which
          could be '.json' or '.yaml' (for analysis outputs) or '.log' for log file. The related files should be in
          the ANALYSIS_PATH and under a sound ID folder structure like sounds and other sound-related files."""
-        id_folder = str(self.sound_id / 1000)
+        id_folder = str(old_div(self.sound_id, 1000))
         return os.path.join(settings.ANALYSIS_PATH, id_folder, "{}-{}".format(self.sound_id, self.analyzer))
 
     def load_analysis_data_from_file_to_db(self):
@@ -1818,7 +1824,7 @@ class SoundAnalysis(models.Model):
     def __str__(self):
         return 'Analysis of sound {} with {}'.format(self.sound_id, self.analyzer)
 
-    class Meta:
+    class Meta(object):
         unique_together = (("sound", "analyzer")) # one sounds.SoundAnalysis object per sound<>analyzer combination
 
 def on_delete_sound_analysis(sender, instance, **kwargs):

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -216,7 +216,7 @@ class BulkUploadProgress(models.Model):
         sound_ids_described_ok = []
         sound_errors = []
         if self.description_output is not None:
-            for line_no, value in list(self.description_output.items()):
+            for line_no, value in self.description_output.items():
                 if type(value) == int:
                     # Sound id, meaning a file for which a Sound object was successfully created
                     sound_ids_described_ok.append(value)
@@ -366,7 +366,7 @@ class SoundManager(models.Manager):
         """Returns the SQL bits to add to bulk_query and bulk_query_solr so that analyzer's data is selected
         in the bulk query"""
         analyzers_select_section_parts = []
-        for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
+        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
             if 'descriptors_map' in analyzer_info:
                 analyzers_select_section_parts.append("{0}.analysis_data as {0},"
                                                       .format(analyzer_name.replace('-', '_')))
@@ -376,7 +376,7 @@ class SoundManager(models.Manager):
         """Returns the SQL bits to add to bulk_query and bulk_query_solr so that analyzer's data can be left joined
         in the bulk query"""
         analyzers_left_join_section_parts = []
-        for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
+        for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
             if 'descriptors_map' in analyzer_info:
                 analyzers_left_join_section_parts.append(
                     "LEFT JOIN sounds_soundanalysis {0} ON (sound.id = {0}.sound_id AND {0}.analyzer = '{1}')"
@@ -1171,7 +1171,7 @@ class Sound(SocialModel):
 
     def analyze(self, analyzer=settings.FREESOUND_ESSENTIA_EXTRACTOR_NAME, force=False, verbose=True, high_priority=False):
         # Note that "high_priority" is not implemented but needs to be here for compatibility with older code
-        if analyzer not in list(settings.ANALYZERS_CONFIGURATION.keys()):
+        if analyzer not in settings.ANALYZERS_CONFIGURATION.keys():
             # If specified analyzer is not one of the analyzers configured, do nothing
             if verbose:
                 sounds_logger.info("Not sending sound {} to unknown analyzer {}".format(self.id, analyzer))
@@ -1836,4 +1836,3 @@ def on_delete_sound_analysis(sender, instance, **kwargs):
             pass
 
 pre_delete.connect(on_delete_sound_analysis, sender=SoundAnalysis)
-

--- a/sounds/templatetags/display_remix.py
+++ b/sounds/templatetags/display_remix.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import, division
 #avoid namespace clash with 'tags' templatetag
 from django import template
 import json
-from random import randint
+
 
 register = template.Library()
 @register.inclusion_tag('sounds/display_remix.html', takes_context=True)

--- a/sounds/templatetags/display_remix.py
+++ b/sounds/templatetags/display_remix.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import, division
 #avoid namespace clash with 'tags' templatetag
+from builtins import str
 from django import template
 import json
 

--- a/sounds/templatetags/sound_signature.py
+++ b/sounds/templatetags/sound_signature.py
@@ -1,4 +1,7 @@
-import urlparse
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+import urllib.parse
 from django.urls import reverse
 from django.contrib.sites.models import Site
 from django import template
@@ -11,7 +14,7 @@ SOUND_SIGNATURE_SOUND_URL_PLACEHOLDER = "${sound_url}"
 @register.filter(name='sound_signature_replace')
 def sound_signature_replace(value, sound):
     domain = "https://%s" % Site.objects.get_current().domain
-    abs_url = urlparse.urljoin(domain, reverse('sound', args=[sound.user.username, sound.id]))
+    abs_url = urllib.parse.urljoin(domain, reverse('sound', args=[sound.user.username, sound.id]))
 
     replace = [(SOUND_SIGNATURE_SOUND_ID_PLACEHOLDER, str(sound.id)),
             (SOUND_SIGNATURE_SOUND_URL_PLACEHOLDER, abs_url)]

--- a/sounds/tests/test_manager.py
+++ b/sounds/tests/test_manager.py
@@ -35,7 +35,7 @@ class SoundManagerQueryMethods(TestCase):
                                      'num_comments', 'pack_id', 'duration', 'pack_name', 'license_id', 'license_name',
                                      'license_deed_url', 'geotag_id', 'remixgroup_id', 'tag_array'] \
                                     + [analyzer_name.replace('-', '_') for analyzer_name, analyzer_info
-                                       in list(settings.ANALYZERS_CONFIGURATION.items())
+                                       in settings.ANALYZERS_CONFIGURATION.items()
                                        if 'descriptors_map' in analyzer_info]
 
     fields_to_check_bulk_query_solr = ['username', 'user_id', 'id', 'type', 'original_filename', 'is_explicit',
@@ -44,7 +44,7 @@ class SoundManagerQueryMethods(TestCase):
                                        'bitrate', 'bitdepth', 'samplerate', 'pack_name', 'license_name', 'geotag_lat',
                                        'geotag_lon', 'is_remix', 'was_remixed', 'tag_array', 'comments_array'] \
                                       + [analyzer_name.replace('-', '_') for analyzer_name, analyzer_info
-                                         in list(settings.ANALYZERS_CONFIGURATION.items())
+                                         in settings.ANALYZERS_CONFIGURATION.items()
                                          if 'descriptors_map' in analyzer_info]
 
     def setUp(self):

--- a/sounds/tests/test_manager.py
+++ b/sounds/tests/test_manager.py
@@ -35,7 +35,7 @@ class SoundManagerQueryMethods(TestCase):
                                      'num_comments', 'pack_id', 'duration', 'pack_name', 'license_id', 'license_name',
                                      'license_deed_url', 'geotag_id', 'remixgroup_id', 'tag_array'] \
                                     + [analyzer_name.replace('-', '_') for analyzer_name, analyzer_info
-                                       in settings.ANALYZERS_CONFIGURATION.items()
+                                       in list(settings.ANALYZERS_CONFIGURATION.items())
                                        if 'descriptors_map' in analyzer_info]
 
     fields_to_check_bulk_query_solr = ['username', 'user_id', 'id', 'type', 'original_filename', 'is_explicit',
@@ -44,7 +44,7 @@ class SoundManagerQueryMethods(TestCase):
                                        'bitrate', 'bitdepth', 'samplerate', 'pack_name', 'license_name', 'geotag_lat',
                                        'geotag_lon', 'is_remix', 'was_remixed', 'tag_array', 'comments_array'] \
                                       + [analyzer_name.replace('-', '_') for analyzer_name, analyzer_info
-                                         in settings.ANALYZERS_CONFIGURATION.items()
+                                         in list(settings.ANALYZERS_CONFIGURATION.items())
                                          if 'descriptors_map' in analyzer_info]
 
     def setUp(self):

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -906,13 +906,13 @@ class SoundTemplateCacheTests(TestCase):
         )
 
     # Changing license
-    def _test_change_license(self, cache_keys, new_license, check_present):
+    def _test_change_license(self, cache_keys, new_license, expected_text, check_present):
         self._assertCacheAbsent(cache_keys)
 
         self.client.force_login(self.user)
 
         self.assertNotEqual(self.sound.license, new_license)
-        self.assertFalse(check_present())
+        self.assertNotContains(check_present(), expected_text)
         self._assertCachePresent(cache_keys)
 
         # Change license
@@ -923,13 +923,14 @@ class SoundTemplateCacheTests(TestCase):
         self._assertCacheAbsent(cache_keys)
 
         # Check that license is updated
-        self.assertTrue(check_present())
+        self.assertContains(check_present(), expected_text)
 
     def test_change_license_display(self):
         self._test_change_license(
             self._get_sound_display_cache_keys(),
             License.objects.filter(name='Attribution').first(),
-            lambda: 'images/licenses/by.png' in self._get_sound_from_home().content
+            "images/licenses/by.png",
+            self._get_sound_from_home,
         )
 
     def test_change_license_view(self):
@@ -937,7 +938,8 @@ class SoundTemplateCacheTests(TestCase):
         self._test_change_license(
             self._get_sound_view_footer_top_cache_keys(),
             license,
-            lambda: str(license.name) in self._get_sound_view().content
+            str(license.name),
+            self._get_sound_view,
         )
 
     def _test_add_remove_remixes(self, cache_keys, check_present):

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -19,7 +19,10 @@
 #
 
 from __future__ import print_function
+from __future__ import division
 
+from builtins import str
+from past.utils import old_div
 import json
 import os
 import time
@@ -239,7 +242,7 @@ class ProfileNumSoundsTestCase(TestCase):
                 'original_path', 'pack_id', 'license', 'created',
                 'original_filename', 'geotag']
 
-        json_data = ds.data.keys()
+        json_data = list(ds.data.keys())
         for k in keys:
             self.assertTrue(k in json_data)
 
@@ -670,7 +673,7 @@ class SoundTemplateCacheTests(TestCase):
         return self.client.get(reverse('accounts-home'))
 
     def _print_cache(self, cache_keys):
-        print(locmem._caches[''].keys())
+        print(list(locmem._caches[''].keys()))
         print(cache_keys)
 
     # Make sure the sound name and description are updated
@@ -1035,17 +1038,17 @@ class SoundAnalysisModel(TestCase):
         sa = SoundAnalysis.objects.create(sound=sound, analyzer="TestExtractor1", analysis_data=analysis_data,
                                           analysis_status="OK")
         self.assertEqual(sound.analyses.all().count(), 1)
-        self.assertEqual(sa.get_analysis_data().keys(), analysis_data.keys())
+        self.assertEqual(list(sa.get_analysis_data().keys()), list(analysis_data.keys()))
         self.assertEqual(sa.get_analysis_data()['descriptor1'], 0.56)
 
         # Now create an analysis object which stores output in a JSON file. Again check that get_analysis works.
         analysis_filename = '%i-TestExtractor2.json' % sound.id
-        sound_analysis_folder = os.path.join(settings.ANALYSIS_PATH, str(sound.id / 1000))
+        sound_analysis_folder = os.path.join(settings.ANALYSIS_PATH, str(old_div(sound.id, 1000)))
         create_directories(sound_analysis_folder)
         json.dump(analysis_data, open(os.path.join(sound_analysis_folder, analysis_filename), 'w'))
         sa2 = SoundAnalysis.objects.create(sound=sound, analyzer="TestExtractor2", analysis_status="OK")
         self.assertEqual(sound.analyses.all().count(), 2)
-        self.assertEqual(sa2.get_analysis_data().keys(), analysis_data.keys())
+        self.assertEqual(list(sa2.get_analysis_data().keys()), list(analysis_data.keys()))
         self.assertEqual(sa2.get_analysis_data()['descriptor1'], 0.56)
 
         # Create an analysis object which references a non-existing file. Check that get_analysis returns None.

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -1,3 +1,4 @@
+from __future__ import division
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -18,6 +19,9 @@
 #     See AUTHORS file.
 #
 
+from builtins import map
+from builtins import str
+from past.utils import old_div
 import datetime
 import json
 import logging
@@ -368,7 +372,7 @@ def sound_download(request, username, sound_id):
         cdn_filename = cache_cdn_map.get(str(sound_id), None)
         if cdn_filename is not None:
             # If USE_CDN_FOR_DOWNLOADS option is on and we find an URL for that sound in the CDN, then we redirect to that one
-            cdn_url = settings.CDN_DOWNLOADS_TEMPLATE_URL.format(int(int(sound_id)/1000), cdn_filename, sound.friendly_filename())
+            cdn_url = settings.CDN_DOWNLOADS_TEMPLATE_URL.format(int(old_div(int(sound_id),1000)), cdn_filename, sound.friendly_filename())
             return HttpResponseRedirect(cdn_url)
 
     return sendfile(*prepare_sendfile_arguments_for_sound_download(sound))
@@ -422,7 +426,7 @@ def sound_edit(request, username, sound_id):
 
     def is_selected(prefix):
         if request.method == "POST":
-            for name in request.POST.keys():
+            for name in list(request.POST.keys()):
                 if name.startswith(prefix + '-'):
                     return True
         return False

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -22,7 +22,6 @@ import datetime
 import json
 import logging
 import time
-from collections import defaultdict
 from django.views.decorators.clickjacking import xframe_options_exempt
 from operator import itemgetter
 
@@ -32,7 +31,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User, Group
 from django.core.cache import cache, caches
 from django.core.exceptions import PermissionDenied
-from django.db import connection, transaction
+from django.db import transaction
 from django.db.models.functions import Greatest
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect, Http404, \
@@ -45,9 +44,8 @@ from ratelimit.decorators import ratelimit
 
 from comments.forms import CommentForm
 from comments.models import Comment
-from donations.models import DonationsModalSettings, Donation
+from donations.models import DonationsModalSettings
 from follow import follow_utils
-from forum.models import Thread
 from forum.views import get_hot_threads
 from geotags.models import GeoTag
 from sounds.forms import DeleteSoundForm, FlagForm, SoundDescriptionForm, GeotaggingForm, NewLicenseForm, PackEditForm, \
@@ -63,7 +61,6 @@ from utils.mail import send_mail_template, send_mail_template_to_support
 from utils.nginxsendfile import sendfile, prepare_sendfile_arguments_for_sound_download
 from utils.pagination import paginate
 from utils.ratelimit import key_for_ratelimiting, rate_per_ip
-from utils.search import get_search_engine
 from utils.search.search_sounds import get_random_sound_id_from_search_engine
 from utils.similarity_utilities import get_similar_sounds
 from utils.text import remove_control_chars

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -426,7 +426,7 @@ def sound_edit(request, username, sound_id):
 
     def is_selected(prefix):
         if request.method == "POST":
-            for name in list(request.POST.keys()):
+            for name in request.POST.keys():
                 if name.startswith(prefix + '-'):
                     return True
         return False

--- a/support/views.py
+++ b/support/views.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import logging
 
 from django.conf import settings

--- a/tagrecommendation/client/__init__.py
+++ b/tagrecommendation/client/__init__.py
@@ -18,9 +18,13 @@
 #     See AUTHORS file.
 #
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 from django.conf import settings
 import json
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 _BASE_URL                     = 'http://%s:%i/tagrecommendation/' % (settings.TAGRECOMMENDATION_ADDRESS, settings.TAGRECOMMENDATION_PORT)
 _URL_RECOMMEND_TAGS           = 'recommend_tags/'
@@ -29,7 +33,7 @@ _URL_ADD_TO_INDEX             = 'add_to_index/'
 
 
 def _get_url_as_json(url):
-    f = urllib2.urlopen(url.replace(" ","%20"), timeout=settings.TAGRECOMMENDATION_TIMEOUT)
+    f = urllib.request.urlopen(url.replace(" ","%20"), timeout=settings.TAGRECOMMENDATION_TIMEOUT)
     resp = f.read()
     return json.loads(resp)
 
@@ -41,7 +45,7 @@ def _result_or_exception(result):
         raise Exception(result['result'])
 
 
-class TagRecommendation():
+class TagRecommendation(object):
 
     @classmethod
     def recommend_tags(cls, input_tags, max_number_of_tags=None):

--- a/tagrecommendation/communityBasedTagRecommendation/__init__.py
+++ b/tagrecommendation/communityBasedTagRecommendation/__init__.py
@@ -20,6 +20,7 @@
 
 from __future__ import print_function
 
+from builtins import object
 from tagRecommendation import TagRecommender
 from communityDetection import CommunityDetector
 from tagrecommendation_settings import RECOMMENDATION_DATA_DIR
@@ -27,7 +28,7 @@ from utils import loadFromJson
 from numpy import load
 
 
-class CommunityBasedTagRecommender():
+class CommunityBasedTagRecommender(object):
 
     recommenders = None
     communityDetector = None

--- a/tagrecommendation/communityDetection/__init__.py
+++ b/tagrecommendation/communityDetection/__init__.py
@@ -18,6 +18,8 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
+from builtins import object
 from sklearn.externals import joblib
 from numpy import load, where, zeros
 from utils import loadFromJson
@@ -25,7 +27,7 @@ from tagrecommendation_settings import RECOMMENDATION_DATA_DIR
 import os
 
 
-class CommunityDetector:
+class CommunityDetector(object):
     verbose = None
     clf = None
     clf_type = None
@@ -64,7 +66,7 @@ class CommunityDetector:
 
     def __repr__(self):
         return "Community Detector (%s, %i classes, %i instances, %s init) " % (self.clf_type,
-                                                                                len(self.class_name_ids.keys()),
+                                                                                len(list(self.class_name_ids.keys())),
                                                                                 self.n_training_instances,
                                                                                 self.init_method)
 
@@ -85,4 +87,4 @@ class CommunityDetector:
         instance_vector = self.load_instance_vector_from_tags(input_tags)
         cl = self.clf.predict([instance_vector])[0]
 
-        return str(self.class_name_ids[unicode(cl)])
+        return str(self.class_name_ids[str(cl)])

--- a/tagrecommendation/communityDetection/__init__.py
+++ b/tagrecommendation/communityDetection/__init__.py
@@ -66,7 +66,7 @@ class CommunityDetector(object):
 
     def __repr__(self):
         return "Community Detector (%s, %i classes, %i instances, %s init) " % (self.clf_type,
-                                                                                len(list(self.class_name_ids.keys())),
+                                                                                len(self.class_name_ids.keys()),
                                                                                 self.n_training_instances,
                                                                                 self.init_method)
 

--- a/tagrecommendation/recommendationDataProcessor/__init__.py
+++ b/tagrecommendation/recommendationDataProcessor/__init__.py
@@ -82,8 +82,8 @@ class RecommendationDataProcessor(object):
         n_original_associations = 0
         sound_ids = []
         if self.verbose:
-            print("Reading index file (%i entries)..." % len(list(index.items())), end=' ')
-        for sid, tags in list(index.items()):
+            print("Reading index file (%i entries)..." % len(index.items()), end=' ')
+        for sid, tags in index.items():
             ts += tags
             n_original_associations += len(tags)
             sound_ids.append(sid)
@@ -137,7 +137,7 @@ class RecommendationDataProcessor(object):
         res_tags_no_filt = {}
         idx = 0
         n_filtered_associations = 0
-        for sid, stags in list(index.items()):
+        for sid, stags in index.items():
             resource = sid
             user = None
             assigned_tags = stags

--- a/tagrecommendation/tagRecommendation/__init__.py
+++ b/tagrecommendation/tagRecommendation/__init__.py
@@ -20,10 +20,11 @@
 
 from __future__ import absolute_import
 
+from builtins import object
 from .heuristics import heuristics
 
 
-class TagRecommender:
+class TagRecommender(object):
     """Class that implements an object that recommends tags"""
 
     heuristic = None

--- a/tagrecommendation/tagRecommendation/tag_recommendation_utils.py
+++ b/tagrecommendation/tagRecommendation/tag_recommendation_utils.py
@@ -69,7 +69,7 @@ def aNormalizedRankSum(candidate_tags, input_tags, options):
         else:
             aggregated_candiate_tags[item['name']] = float(item['rank'])/(len(input_tags))
     aggregated_candiate_tags_list = []
-    for key in list(aggregated_candiate_tags.keys()):
+    for key in aggregated_candiate_tags.keys():
         aggregated_candiate_tags_list.append({"name":key, "rank": aggregated_candiate_tags[key]})
     aggregated_candiate_tags_list.sort(key=operator.itemgetter('rank'))
     aggregated_candiate_tags_list.reverse()

--- a/tagrecommendation/tagRecommendation/tag_recommendation_utils.py
+++ b/tagrecommendation/tagRecommendation/tag_recommendation_utils.py
@@ -69,7 +69,7 @@ def aNormalizedRankSum(candidate_tags, input_tags, options):
         else:
             aggregated_candiate_tags[item['name']] = float(item['rank'])/(len(input_tags))
     aggregated_candiate_tags_list = []
-    for key in aggregated_candiate_tags.keys():
+    for key in list(aggregated_candiate_tags.keys()):
         aggregated_candiate_tags_list.append({"name":key, "rank": aggregated_candiate_tags[key]})
     aggregated_candiate_tags_list.sort(key=operator.itemgetter('rank'))
     aggregated_candiate_tags_list.reverse()

--- a/tagrecommendation/tagrecommendation_server.py
+++ b/tagrecommendation/tagrecommendation_server.py
@@ -83,8 +83,8 @@ class TagRecommendationServer(resource.Resource):
 
         try:
             self.index = loadFromJson(tr_settings.RECOMMENDATION_DATA_DIR, 'Index.json')
-            self.index_stats['biggest_id_in_index'] = max([int(key) for key in list(self.index.keys())])
-            self.index_stats['n_sounds_in_index'] = len(list(self.index.keys()))
+            self.index_stats['biggest_id_in_index'] = max([int(key) for key in self.index.keys()])
+            self.index_stats['n_sounds_in_index'] = len(self.index.keys())
         except Exception as e:
             logger.error("Index file not present. Listening for indexing data from appservers.")
             self.index_stats['biggest_id_in_index'] = 0
@@ -141,12 +141,12 @@ class TagRecommendationServer(resource.Resource):
             stags = sound_tags[count]
             self.index[sid] = stags
 
-        if len(list(self.index.keys())) % 1000 == 0:
+        if len(self.index.keys()) % 1000 == 0:
             # Every 1000 indexed sounds, save the index
             logger.info('Saving tagrecommendation index...')
             saveToJson(tr_settings.RECOMMENDATION_DATA_DIR + 'Index.json', self.index, verbose=False)
-            self.index_stats['biggest_id_in_index'] = max([int(key) for key in list(self.index.keys())])
-            self.index_stats['n_sounds_in_index'] = len(list(self.index.keys()))
+            self.index_stats['biggest_id_in_index'] = max([int(key) for key in self.index.keys()])
+            self.index_stats['n_sounds_in_index'] = len(self.index.keys())
 
         result = {'error': False, 'result': True}
         return json.dumps(result)

--- a/tagrecommendation/tagrecommendation_server.py
+++ b/tagrecommendation/tagrecommendation_server.py
@@ -83,8 +83,8 @@ class TagRecommendationServer(resource.Resource):
 
         try:
             self.index = loadFromJson(tr_settings.RECOMMENDATION_DATA_DIR, 'Index.json')
-            self.index_stats['biggest_id_in_index'] = max([int(key) for key in self.index.keys()])
-            self.index_stats['n_sounds_in_index'] = len(self.index.keys())
+            self.index_stats['biggest_id_in_index'] = max([int(key) for key in list(self.index.keys())])
+            self.index_stats['n_sounds_in_index'] = len(list(self.index.keys()))
         except Exception as e:
             logger.error("Index file not present. Listening for indexing data from appservers.")
             self.index_stats['biggest_id_in_index'] = 0
@@ -141,12 +141,12 @@ class TagRecommendationServer(resource.Resource):
             stags = sound_tags[count]
             self.index[sid] = stags
 
-        if len(self.index.keys()) % 1000 == 0:
+        if len(list(self.index.keys())) % 1000 == 0:
             # Every 1000 indexed sounds, save the index
             logger.info('Saving tagrecommendation index...')
             saveToJson(tr_settings.RECOMMENDATION_DATA_DIR + 'Index.json', self.index, verbose=False)
-            self.index_stats['biggest_id_in_index'] = max([int(key) for key in self.index.keys()])
-            self.index_stats['n_sounds_in_index'] = len(self.index.keys())
+            self.index_stats['biggest_id_in_index'] = max([int(key) for key in list(self.index.keys())])
+            self.index_stats['n_sounds_in_index'] = len(list(self.index.keys()))
 
         result = {'error': False, 'result': True}
         return json.dumps(result)

--- a/tagrecommendation/utils.py
+++ b/tagrecommendation/utils.py
@@ -42,8 +42,8 @@ def mtx2npy(M, verbose = True):
     m = M.shape[1]
     npy = zeros((n, m) , 'float32')
     #non_zero_index = M.keys()
-    items = M.items()
-    nItems = len(M.items())
+    items = list(M.items())
+    nItems = len(list(M.items()))
     done = 0
     #for index in non_zero_index :
     for index, value in items:

--- a/tagrecommendation/utils.py
+++ b/tagrecommendation/utils.py
@@ -43,7 +43,7 @@ def mtx2npy(M, verbose = True):
     npy = zeros((n, m) , 'float32')
     #non_zero_index = M.keys()
     items = list(M.items())
-    nItems = len(list(M.items()))
+    nItems = len(M.items())
     done = 0
     #for index in non_zero_index :
     for index, value in items:

--- a/tags/models.py
+++ b/tags/models.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from django.contrib.auth.models import User
 from django.contrib.contenttypes import fields
 from django.contrib.contenttypes.models import ContentType
@@ -36,7 +37,7 @@ class Tag(models.Model):
     def get_browse_tag_url(self):
         return reverse('tags', self.name)
 
-    class Meta:
+    class Meta(object):
         ordering = ("name",)
 
 
@@ -58,7 +59,7 @@ class TaggedItem(models.Model):
     def get_absolute_url(self):
         return reverse('tag', args=[smart_unicode(self.tag.id)])
 
-    class Meta:
+    class Meta(object):
         ordering = ("-created",)
         unique_together = (('tag', 'content_type', 'object_id'),)
 

--- a/tags/templatetags/tags.py
+++ b/tags/templatetags/tags.py
@@ -32,7 +32,7 @@ def add_sizes(tags, arguments):
 
 @register.filter
 def join_tags_exclude(list, exclude):
-    return "/".join(sorted(filter(lambda x: x != exclude, list))) if list else None
+    return "/".join(sorted([x for x in list if x != exclude])) if list else None
 
 @register.filter
 def join_tags_include(list, include):

--- a/tags/tests.py
+++ b/tags/tests.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 from django.test import TestCase
 from django.urls import reverse
 

--- a/tags/tests.py
+++ b/tags/tests.py
@@ -19,9 +19,10 @@
 #
 
 from django.test import TestCase
-from django.test.client import Client
-from tags.models import FS1Tag
 from django.urls import reverse
+
+from tags.models import FS1Tag
+
 
 class OldTagLinksRedirectTestCase(TestCase):
     

--- a/tags/views.py
+++ b/tags/views.py
@@ -42,7 +42,7 @@ def tags(request, multiple_tags=None):
         multiple_tags = multiple_tags.split('/')
     else:
         multiple_tags = []
-    multiple_tags = sorted(filter(lambda x: x, multiple_tags))
+    multiple_tags = sorted([x for x in multiple_tags if x])
 
     
 

--- a/tickets/models.py
+++ b/tickets/models.py
@@ -20,6 +20,8 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
+from builtins import object
 from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.contrib.contenttypes.models import ContentType
@@ -102,7 +104,7 @@ class Ticket(models.Model):
     def __unicode__(self):
         return u"pk %s, key %s" % (self.id, self.key)
 
-    class Meta:
+    class Meta(object):
         ordering = ("-created",)
         permissions = (
             ("can_moderate", "Can moderate stuff."),
@@ -120,7 +122,7 @@ class TicketComment(models.Model):
         return u"<# Message - ticket_id: %s, ticket_key: %s>" % \
                     (self.ticket.id, self.ticket.key)
 
-    class Meta:
+    class Meta(object):
         ordering = ("-created",)
 
 

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -20,6 +20,8 @@
 
 from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import hashlib
 
 import mock

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -50,7 +50,7 @@ def _get_tc_form(request, use_post=True):
 def _get_anon_or_user_form(request, anonymous_form, user_form, use_post=True):
     if _can_view_mod_msg(request) and anonymous_form != AnonymousContactForm:
         user_form = ModeratorMessageForm
-    if len(request.POST.keys()) > 0 and use_post:
+    if len(list(request.POST.keys())) > 0 and use_post:
         if request.user.is_authenticated:
             return user_form(request.POST)
         else:
@@ -67,7 +67,7 @@ def _can_view_mod_msg(request):
 
 # TODO: copied from sound_edit view,
 def is_selected(request, prefix):
-    for name in request.POST.keys():
+    for name in list(request.POST.keys()):
         if name.startswith(prefix):
             return True
     return False

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -50,7 +50,7 @@ def _get_tc_form(request, use_post=True):
 def _get_anon_or_user_form(request, anonymous_form, user_form, use_post=True):
     if _can_view_mod_msg(request) and anonymous_form != AnonymousContactForm:
         user_form = ModeratorMessageForm
-    if len(list(request.POST.keys())) > 0 and use_post:
+    if len(request.POST.keys()) > 0 and use_post:
         if request.user.is_authenticated:
             return user_form(request.POST)
         else:
@@ -67,7 +67,7 @@ def _can_view_mod_msg(request):
 
 # TODO: copied from sound_edit view,
 def is_selected(request, prefix):
-    for name in list(request.POST.keys()):
+    for name in request.POST.keys():
         if name.startswith(prefix):
             return True
     return False

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -38,7 +38,7 @@ from sounds.models import Sound
 from tickets import TICKET_STATUS_ACCEPTED, TICKET_STATUS_CLOSED, TICKET_STATUS_DEFERRED, TICKET_STATUS_NEW, MODERATION_TEXTS
 from tickets.forms import AnonymousMessageForm, UserMessageForm, ModeratorMessageForm, AnonymousContactForm, \
     SoundStateForm, SoundModerationForm, ModerationMessageForm, UserAnnotationForm, IS_EXPLICIT_ADD_FLAG_KEY, IS_EXPLICIT_REMOVE_FLAG_KEY, IS_EXPLICIT_KEEP_USER_PREFERENCE_KEY
-from utils.cache import invalidate_template_cache, invalidate_user_template_caches
+from utils.cache import invalidate_user_template_caches
 from utils.username import redirect_if_old_username_or_404
 from utils.pagination import paginate
 

--- a/utils/audioprocessing/color_schemes.py
+++ b/utils/audioprocessing/color_schemes.py
@@ -1,3 +1,7 @@
+from __future__ import division
+from builtins import map
+from builtins import range
+from past.utils import old_div
 from PIL import ImageColor
 from functools import partial
 
@@ -11,7 +15,7 @@ def desaturate(rgb, amount):
     luminosity = sum(rgb) / 3.0
     desat = lambda color: color - amount * (color - luminosity)
 
-    return tuple(map(int, map(desat, rgb)))
+    return tuple(map(int, list(map(desat, rgb))))
 
 
 def color_from_value(value):
@@ -37,8 +41,8 @@ COLOR_SCHEMES = {
         ],
         'spec_colors': [
             (0, 0, 0),  # Background color
-            (58/4, 68/4, 65/4),
-            (80/2, 100/2, 153/2),
+            (old_div(58,4), old_div(68,4), old_div(65,4)),
+            (old_div(80,2), old_div(100,2), old_div(153,2)),
             (90, 180, 100),
             (224, 224, 44),
             (255, 60, 30),
@@ -66,15 +70,15 @@ COLOR_SCHEMES = {
         'spec_colors': [(0, 0, 0)] + [color_from_value(value/29.0) for value in range(0, 30)],
     },
     RAINFOREST_COLOR_SCHEME: {
-        'wave_colors': [(213, 217, 221)] + map(partial(desaturate, amount=0.7), [
+        'wave_colors': [(213, 217, 221)] + list(map(partial(desaturate, amount=0.7), [
                         (50, 0, 200),
                         (0, 220, 80),
                         (255, 224, 0),
-                     ]),
-        'spec_colors': [(213, 217, 221)] + map(partial(desaturate, amount=0.7), [
+                     ])),
+        'spec_colors': [(213, 217, 221)] + list(map(partial(desaturate, amount=0.7), [
                         (50, 0, 200),
                         (0, 220, 80),
                         (255, 224, 0),
-                     ]),
+                     ])),
     }
 }

--- a/utils/audioprocessing/color_schemes.py
+++ b/utils/audioprocessing/color_schemes.py
@@ -1,4 +1,4 @@
-from PIL import Image, ImageDraw, ImageColor
+from PIL import ImageColor
 from functools import partial
 
 

--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -19,7 +19,11 @@
 #
 
 from __future__ import absolute_import
+from __future__ import division
 
+from builtins import str
+from past.utils import old_div
+from builtins import object
 import os
 import signal
 import logging
@@ -244,7 +248,7 @@ class FreesoundAudioProcessor(FreesoundAudioProcessorBase):
                 if self.sound.type in settings.LOSSY_FILE_EXTENSIONS:
                     info['bitdepth'] = 0  # mp3 and ogg don't have bitdepth
                     if info['duration'] > 0:
-                        raw_bitrate = int(round(self.sound.filesize * 8 / info['duration'] / 1000))
+                        raw_bitrate = int(round(old_div(old_div(self.sound.filesize * 8, info['duration']), 1000)))
                         # Here we post-process a bit the bitrate to account for small rounding errors
                         # If we see computed bitrate is very close to a common bitrate, we quantize to that number
                         differences_with_common_bitrates = [abs(cbt - raw_bitrate) for cbt in settings.COMMON_BITRATES]

--- a/utils/audioprocessing/wav2png.py
+++ b/utils/audioprocessing/wav2png.py
@@ -21,7 +21,10 @@
 #
 
 from __future__ import print_function, absolute_import
+from __future__ import division
 
+from builtins import str
+from past.utils import old_div
 import argparse
 
 from utils.audioprocessing.processing import create_wave_images, AudioProcessingException
@@ -29,8 +32,8 @@ import sys
 
 
 def progress_callback(position, width):
-    percentage = (position*100)/width
-    if position % (width / 10) == 0:
+    percentage = old_div((position*100),width)
+    if position % (old_div(width, 10)) == 0:
         sys.stdout.write(str(percentage) + "% ")
         sys.stdout.flush()
 

--- a/utils/audioprocessing/wav2png.py
+++ b/utils/audioprocessing/wav2png.py
@@ -25,8 +25,6 @@ from __future__ import print_function, absolute_import
 import argparse
 
 from utils.audioprocessing.processing import create_wave_images, AudioProcessingException
-
-import optparse
 import sys
 
 

--- a/utils/aws.py
+++ b/utils/aws.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from django.conf import settings
 
 from boto3 import client

--- a/utils/dbtime.py
+++ b/utils/dbtime.py
@@ -18,12 +18,13 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from sounds.models import Sound
 from django.core.cache import cache
 from django.conf import settings
 from datetime import datetime
 
-class DBTime():
+class DBTime(object):
     last_time = None
 
     @staticmethod

--- a/utils/encryption.py
+++ b/utils/encryption.py
@@ -18,12 +18,15 @@
 #     See AUTHORS file.
 #
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 from django.conf import settings
 
 def encrypt(decrypted_string):
     from Crypto.Cipher import AES
     import base64
-    import urllib
+    import urllib.request, urllib.parse, urllib.error
     
     encryptor = AES.new(settings.SECRET_KEY[0:16]) #@UndefinedVariable
     
@@ -33,18 +36,18 @@ def encrypt(decrypted_string):
     encrypted_string = encryptor.encrypt(decrypted_string)
     
     # base64 encoded strings have "=" signs, quote them!
-    encoded_string = urllib.quote(base64.b64encode(encrypted_string).replace("/", ".").replace("+", "_").replace("=", "-"))
+    encoded_string = urllib.parse.quote(base64.b64encode(encrypted_string).replace("/", ".").replace("+", "_").replace("=", "-"))
     
     return encoded_string
 
 def decrypt(quoted_string):
     from Crypto.Cipher import AES
     import base64
-    import urllib
+    import urllib.request, urllib.parse, urllib.error
 
     decryptor = AES.new(settings.SECRET_KEY[0:16]) #@UndefinedVariable
     
-    encoded_string = urllib.unquote(quoted_string)
+    encoded_string = urllib.parse.unquote(quoted_string)
     
     encrypted_string = base64.b64decode(encoded_string.replace(".", "/").replace("_", "+").replace("-", "="))
     

--- a/utils/filesystem.py
+++ b/utils/filesystem.py
@@ -23,7 +23,6 @@ from __future__ import print_function
 import errno
 import hashlib
 import os
-import shutil
 import sys
 import warnings
 import zlib

--- a/utils/filesystem.py
+++ b/utils/filesystem.py
@@ -20,6 +20,9 @@
 
 from __future__ import print_function
 
+from builtins import hex
+from builtins import str
+from builtins import object
 import errno
 import hashlib
 import os
@@ -29,7 +32,7 @@ import zlib
 from tempfile import mkdtemp
 
 
-class File:
+class File(object):
 
     def __init__(self, id, name, full_path, is_dir):
         self.name = name

--- a/utils/images.py
+++ b/utils/images.py
@@ -1,3 +1,4 @@
+from __future__ import division
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -18,6 +19,7 @@
 #     See AUTHORS file.
 #
 
+from past.utils import old_div
 from PIL import Image
 
 class ImageProcessingError(Exception):
@@ -32,37 +34,37 @@ def extract_square(input_filename, output_filename, size):
     #fill out and resize the image
     if im.size[0] < size and im.size[1] < size:
         if im.size[0] < im.size[1]:
-            ratio = im.size[1] / im.size[0]
-            im = im.resize((size / ratio, size), Image.ANTIALIAS)            
+            ratio = old_div(im.size[1], im.size[0])
+            im = im.resize((old_div(size, ratio), size), Image.ANTIALIAS)            
         else: 
-            ratio = im.size[0] / im.size[1] 
-            im = im.resize((size,size / ratio), Image.ANTIALIAS)
+            ratio = old_div(im.size[0], im.size[1]) 
+            im = im.resize((size,old_div(size, ratio)), Image.ANTIALIAS)
         #fill out          
         background = Image.new("RGB", (size,size), (255, 255, 255)) # use white for empty space
-        background.paste(im, ((size - im.size[0]) / 2, (size - im.size[1]) / 2))  
+        background.paste(im, (old_div((size - im.size[0]), 2), old_div((size - im.size[1]), 2)))  
         background.save(output_filename)
         return
         
     #if one side of the image is smaller and one is bigger
     elif im.size[0] > size and im.size[1] < size:
-        ratio = im.size[0] / im.size[1]
+        ratio = old_div(im.size[0], im.size[1])
         im = im.resize((size * ratio,size), Image.ANTIALIAS)  
                      
     elif im.size[0] < size and im.size[1] > size:  
-        ratio = im.size[1] / im.size[0]
+        ratio = old_div(im.size[1], im.size[0])
         im = im.resize((size, size * ratio), Image.ANTIALIAS)
            
     if im.size[0] > im.size[1]:
         # --------
         # |      |
         # --------
-        box = (im.size[0]-im.size[1])/2, 0, im.size[0] - (im.size[0]-im.size[1])/2, im.size[1]
+        box = old_div((im.size[0]-im.size[1]),2), 0, im.size[0] - old_div((im.size[0]-im.size[1]),2), im.size[1]
     else: 
         # ____
         # |  |
         # |  |
         # |__|
-        box = 0, (im.size[1]-im.size[0])/2, im.size[0], im.size[1] - (im.size[1]-im.size[0])/2 
+        box = 0, old_div((im.size[1]-im.size[0]),2), im.size[0], im.size[1] - old_div((im.size[1]-im.size[0]),2) 
     
     im = im.crop(box)
     im.thumbnail((size, size), Image.ANTIALIAS)

--- a/utils/locations.py
+++ b/utils/locations.py
@@ -48,7 +48,7 @@ def locations_decorator(cache=True):
     return decorator
 
 def pretty_print_locations(locations, indent=0):
-    for (key, value) in list(locations.items()):
+    for (key, value) in locations.items():
         if isinstance(value, dict):
             print("  "*indent, "*", key)
             pretty_print_locations(value, indent+1)

--- a/utils/locations.py
+++ b/utils/locations.py
@@ -20,6 +20,7 @@
 
 from __future__ import print_function
 
+from builtins import object
 def locations_decorator(cache=True):
     """wraps a locations function and adds two things:
         * caching for the calculation done inside the function if cache is true
@@ -47,7 +48,7 @@ def locations_decorator(cache=True):
     return decorator
 
 def pretty_print_locations(locations, indent=0):
-    for (key, value) in locations.iteritems():
+    for (key, value) in list(locations.items()):
         if isinstance(value, dict):
             print("  "*indent, "*", key)
             pretty_print_locations(value, indent+1)

--- a/utils/logging_filters.py
+++ b/utils/logging_filters.py
@@ -61,7 +61,7 @@ class GenericDataFilter(logging.Filter):
             message = record.getMessage()
             json_part = message[message.find('(') + 1:-1]
             fields = json.loads(json_part)
-            for key, value in list(fields.items()):
+            for key, value in fields.items():
                 setattr(record, key, value)
         except (IndexError, ValueError, AttributeError):
             pass  # Message is not formatted for json parsing
@@ -77,9 +77,9 @@ class APILogsFilter(logging.Filter):
             if ':' in message:
                 message = ' '.join([item.split(':')[0] for item in message.split(' ')])
             record.api_resource = message
-            for key, value in list(json.loads(info).items()):
+            for key, value in json.loads(info).items():
                 setattr(record, key, value)
-            for key, value in list(json.loads(data).items()):
+            for key, value in json.loads(data).items():
                 setattr(record, key, value)
         except:
             pass

--- a/utils/logging_filters.py
+++ b/utils/logging_filters.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import ipaddress
 import logging
 import json
@@ -37,7 +38,7 @@ def get_client_ip(request):
     if x_forwarded_for:
         ip = x_forwarded_for.split(',')[0].strip()
         try:
-            ipaddress.ip_network(unicode(ip))
+            ipaddress.ip_network(str(ip))
         except ValueError:
             # Not a valid ip address
             ip = '-'
@@ -60,7 +61,7 @@ class GenericDataFilter(logging.Filter):
             message = record.getMessage()
             json_part = message[message.find('(') + 1:-1]
             fields = json.loads(json_part)
-            for key, value in fields.items():
+            for key, value in list(fields.items()):
                 setattr(record, key, value)
         except (IndexError, ValueError, AttributeError):
             pass  # Message is not formatted for json parsing
@@ -76,9 +77,9 @@ class APILogsFilter(logging.Filter):
             if ':' in message:
                 message = ' '.join([item.split(':')[0] for item in message.split(' ')])
             record.api_resource = message
-            for key, value in json.loads(info).items():
+            for key, value in list(json.loads(info).items()):
                 setattr(record, key, value)
-            for key, value in json.loads(data).items():
+            for key, value in list(json.loads(data).items()):
                 setattr(record, key, value)
         except:
             pass

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import logging
 import json
 

--- a/utils/management_commands.py
+++ b/utils/management_commands.py
@@ -20,7 +20,6 @@
 
 import json
 import logging
-import os
 import sys
 import time
 

--- a/utils/mirror_files.py
+++ b/utils/mirror_files.py
@@ -1,3 +1,4 @@
+from builtins import str
 from django.conf import settings
 import os
 import shutil

--- a/utils/onlineusers.py
+++ b/utils/onlineusers.py
@@ -28,7 +28,7 @@ _last_purged = datetime.now()
 
 def get_online_users():
     user_dict = cache.get(CACHE_KEY)
-    return hasattr(user_dict, 'keys') and user_dict.keys() or []
+    return hasattr(user_dict, 'keys') and list(user_dict.keys()) or []
 
 def cache_online_users(request):
         if request.user.is_anonymous:
@@ -47,7 +47,7 @@ def cache_online_users(request):
         global _last_purged
         if _last_purged + timedelta(minutes=ONLINE_MINUTES) < now:
             purge_older_than = now - timedelta(minutes=ONLINE_MINUTES)
-            for user_id, last_seen in user_dict.items():
+            for user_id, last_seen in list(user_dict.items()):
                 if last_seen < purge_older_than:
                     del(user_dict[user_id])
             _last_purged = now

--- a/utils/onlineusers.py
+++ b/utils/onlineusers.py
@@ -28,7 +28,7 @@ _last_purged = datetime.now()
 
 def get_online_users():
     user_dict = cache.get(CACHE_KEY)
-    return hasattr(user_dict, 'keys') and list(user_dict.keys()) or []
+    return hasattr(user_dict, 'keys') and user_dict.keys() or []
 
 def cache_online_users(request):
         if request.user.is_anonymous:
@@ -47,7 +47,7 @@ def cache_online_users(request):
         global _last_purged
         if _last_purged + timedelta(minutes=ONLINE_MINUTES) < now:
             purge_older_than = now - timedelta(minutes=ONLINE_MINUTES)
-            for user_id, last_seen in list(user_dict.items()):
+            for user_id, last_seen in user_dict.items():
                 if last_seen < purge_older_than:
                     del(user_dict[user_id])
             _last_purged = now

--- a/utils/paypal/wrapper.py
+++ b/utils/paypal/wrapper.py
@@ -37,9 +37,12 @@
 #   paypal.get_transaction_details(response['transactionid'])
 
 from __future__ import print_function
-import urllib, cgi
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
+import urllib.request, urllib.parse, urllib.error, cgi
 
-class Paypal:
+class Paypal(object):
     
     def __init__(self, debug=True):
         # fill these in with the API values
@@ -72,21 +75,21 @@ class Paypal:
     
     def query(self, parameters, add_urls=True):
         """for a dict of parameters, create the query-string, get the paypal URL and return the parsed dict"""
-        params = self.signature.items() + parameters.items()
+        params = list(self.signature.items()) + list(parameters.items())
         
         print(parameters)
 
         if add_urls:
-            params += self.urls.items()
+            params += list(self.urls.items())
         
         # encode the urls into a query string
-        params_string = urllib.urlencode( params )
+        params_string = urllib.parse.urlencode( params )
         
         # get the response and parse it
-        response = cgi.parse_qs(urllib.urlopen(self.API_ENDPOINT, params_string).read())
+        response = cgi.parse_qs(urllib.request.urlopen(self.API_ENDPOINT, params_string).read())
        
         # the parsed dict has a list for each value, but all Paypal replies are unique
-        return dict([(key.lower(), value[0]) for (key,value) in response.items()])
+        return dict([(key.lower(), value[0]) for (key,value) in list(response.items())])
 
 
     def set_express_checkout(self, amount):

--- a/utils/paypal/wrapper.py
+++ b/utils/paypal/wrapper.py
@@ -89,7 +89,7 @@ class Paypal(object):
         response = cgi.parse_qs(urllib.request.urlopen(self.API_ENDPOINT, params_string).read())
        
         # the parsed dict has a list for each value, but all Paypal replies are unique
-        return dict([(key.lower(), value[0]) for (key,value) in list(response.items())])
+        return dict([(key.lower(), value[0]) for (key,value) in response.items()])
 
 
     def set_express_checkout(self, amount):

--- a/utils/ratelimit.py
+++ b/utils/ratelimit.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import ipaddress
 import logging
 import random
@@ -73,7 +74,7 @@ def add_new_ip_to_block(ip):
         ip (str): IP to block. Can also specify a range as described in ipaddress.IPv4Network docs.
     """
     try:
-        ipaddress.ip_network(unicode(ip))
+        ipaddress.ip_network(str(ip))
     except ValueError as e:
         console_logger.info('The provided IP {} is not valid: {}'.format(ip, e))
         return
@@ -99,7 +100,7 @@ def ip_is_blocked(ip):
 
     """
     for ip_to_block in get_ips_to_block():
-        if ipaddress.ip_network(unicode(ip_to_block)).overlaps(ipaddress.ip_network(unicode(ip))):
+        if ipaddress.ip_network(str(ip_to_block)).overlaps(ipaddress.ip_network(str(ip))):
             return True
     return False
 

--- a/utils/search/__init__.py
+++ b/utils/search/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import division
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -18,6 +19,9 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import importlib
 
 from django.conf import settings
@@ -155,8 +159,8 @@ class SearchResultsPaginator(object):
         self.num_per_page = num_per_page
         self.results = search_results.docs
         self.count = search_results.num_found
-        self.num_pages = search_results.num_found / num_per_page + int(search_results.num_found % num_per_page != 0)
-        self.page_range = range(1, self.num_pages + 1)
+        self.num_pages = old_div(search_results.num_found, num_per_page) + int(search_results.num_found % num_per_page != 0)
+        self.page_range = list(range(1, self.num_pages + 1))
 
     def page(self, page_num):
         has_next = page_num < self.num_pages

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -148,14 +148,14 @@ def convert_sound_to_search_engine_document(sound):
     document["preview_path"] = locations["preview"]["LQ"]["mp3"]["path"]
 
     # Analyzer's output
-    for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
+    for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
         if 'descriptors_map' in analyzer_info:
             query_select_name = analyzer_name.replace('-', '_')
             analysis_data = getattr(sound, query_select_name, None)
             if analysis_data is not None:
                 # If analysis is present, index all existing analysis fields using SOLR dynamic fields depending on
                 # the value type (see SOLR_DYNAMIC_FIELDS_SUFFIX_MAP) so solr knows how to treat when filtering, etc.
-                for key, value in list(analysis_data.items()):
+                for key, value in analysis_data.items():
                     if type(value) == list:
                         # Make sure that the list is formed by strings
                         value = ['{}'.format(item) for item in value]
@@ -195,7 +195,7 @@ def add_solr_suffix_to_dynamic_fieldname(fieldname):
     to a dynamic field, leave it unchanged. See docstring in 'add_solr_suffix_to_dynamic_fieldnames_in_filter' for
     more information"""
     dynamic_fields_map = {}
-    for analyzer, analyzer_data in list(settings.ANALYZERS_CONFIGURATION.items()):
+    for analyzer, analyzer_data in settings.ANALYZERS_CONFIGURATION.items():
         if 'descriptors_map' in analyzer_data:
             descriptors_map = settings.ANALYZERS_CONFIGURATION[analyzer]['descriptors_map']
             for _, db_descriptor_key, descriptor_type in descriptors_map:
@@ -212,7 +212,7 @@ def add_solr_suffix_to_dynamic_fieldnames_in_filter(query_filter):
     fields which need to end with a specific suffi that SOLR uses to learn about the type of the field and how it
     should treat it.
     """
-    for analyzer, analyzer_data in list(settings.ANALYZERS_CONFIGURATION.items()):
+    for analyzer, analyzer_data in settings.ANALYZERS_CONFIGURATION.items():
         if 'descriptors_map' in analyzer_data:
             descriptors_map = settings.ANALYZERS_CONFIGURATION[analyzer]['descriptors_map']
             for _, db_descriptor_key, descriptor_type in descriptors_map:
@@ -233,7 +233,7 @@ def search_process_sort(sort):
     Returns:
         List[str]: list containing the sorting field names list for the search engine.
     """
-    if sort in [sort_web_name for sort_web_name, sort_field_name in list(SORT_OPTIONS_MAP.items())]:
+    if sort in [sort_web_name for sort_web_name, sort_field_name in SORT_OPTIONS_MAP.items()]:
         if sort == "avg_rating desc":
             sort = [SORT_OPTIONS_MAP[sort], "num_ratings desc"]
         elif sort == "avg_rating asc":
@@ -318,8 +318,8 @@ class FreesoundSoundJsonEncoder(json.JSONEncoder):
 class SolrQueryPySolr(SolrQuery):
 
     def as_dict(self):
-        params = {k: v for k, v in list(self.params.items()) if v is not None}
-        for k, v in list(params.items()):
+        params = {k: v for k, v in self.params.items() if v is not None}
+        for k, v in params.items():
             if type(v) == bool:
                 params[k] = json.dumps(v)
         return params
@@ -392,7 +392,7 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
         elif type(query_fields) == dict:
             # Also remove fields with weight <= 0
             query_fields = [(add_solr_suffix_to_dynamic_fieldname(FIELD_NAMES_MAP.get(field, field)), weight)
-                for field, weight in list(query_fields.items()) if weight > 0]
+                for field, weight in query_fields.items() if weight > 0]
 
         # Set main query options
         query.set_dismax_query(textual_query, query_fields=query_fields)
@@ -413,10 +413,10 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
 
         # Configure facets
         if facets is not None:
-            facet_fields = [FIELD_NAMES_MAP[field_name] for field_name, _ in list(facets.items())]
+            facet_fields = [FIELD_NAMES_MAP[field_name] for field_name, _ in facets.items()]
             query.add_facet_fields(*facet_fields)
             query.set_facet_options_default(**SOLR_SOUND_FACET_DEFAULT_OPTIONS)
-            for field_name, extra_options in list(facets.items()):
+            for field_name, extra_options in facets.items():
                 query.set_facet_options(FIELD_NAMES_MAP[field_name], **extra_options)
 
         # Configure grouping

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -82,7 +82,6 @@ SOLR_DYNAMIC_FIELDS_SUFFIX_MAP = {
     int: '_i',
     bool: '_b',
     str: '_s',
-    str: '_s',
     list: '_ls',
 }
 

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import json
 import random
 import re
@@ -81,7 +82,7 @@ SOLR_DYNAMIC_FIELDS_SUFFIX_MAP = {
     int: '_i',
     bool: '_b',
     str: '_s',
-    unicode: '_s',
+    str: '_s',
     list: '_ls',
 }
 
@@ -147,14 +148,14 @@ def convert_sound_to_search_engine_document(sound):
     document["preview_path"] = locations["preview"]["LQ"]["mp3"]["path"]
 
     # Analyzer's output
-    for analyzer_name, analyzer_info in settings.ANALYZERS_CONFIGURATION.items():
+    for analyzer_name, analyzer_info in list(settings.ANALYZERS_CONFIGURATION.items()):
         if 'descriptors_map' in analyzer_info:
             query_select_name = analyzer_name.replace('-', '_')
             analysis_data = getattr(sound, query_select_name, None)
             if analysis_data is not None:
                 # If analysis is present, index all existing analysis fields using SOLR dynamic fields depending on
                 # the value type (see SOLR_DYNAMIC_FIELDS_SUFFIX_MAP) so solr knows how to treat when filtering, etc.
-                for key, value in analysis_data.items():
+                for key, value in list(analysis_data.items()):
                     if type(value) == list:
                         # Make sure that the list is formed by strings
                         value = ['{}'.format(item) for item in value]
@@ -194,7 +195,7 @@ def add_solr_suffix_to_dynamic_fieldname(fieldname):
     to a dynamic field, leave it unchanged. See docstring in 'add_solr_suffix_to_dynamic_fieldnames_in_filter' for
     more information"""
     dynamic_fields_map = {}
-    for analyzer, analyzer_data in settings.ANALYZERS_CONFIGURATION.items():
+    for analyzer, analyzer_data in list(settings.ANALYZERS_CONFIGURATION.items()):
         if 'descriptors_map' in analyzer_data:
             descriptors_map = settings.ANALYZERS_CONFIGURATION[analyzer]['descriptors_map']
             for _, db_descriptor_key, descriptor_type in descriptors_map:
@@ -211,7 +212,7 @@ def add_solr_suffix_to_dynamic_fieldnames_in_filter(query_filter):
     fields which need to end with a specific suffi that SOLR uses to learn about the type of the field and how it
     should treat it.
     """
-    for analyzer, analyzer_data in settings.ANALYZERS_CONFIGURATION.items():
+    for analyzer, analyzer_data in list(settings.ANALYZERS_CONFIGURATION.items()):
         if 'descriptors_map' in analyzer_data:
             descriptors_map = settings.ANALYZERS_CONFIGURATION[analyzer]['descriptors_map']
             for _, db_descriptor_key, descriptor_type in descriptors_map:
@@ -232,7 +233,7 @@ def search_process_sort(sort):
     Returns:
         List[str]: list containing the sorting field names list for the search engine.
     """
-    if sort in [sort_web_name for sort_web_name, sort_field_name in SORT_OPTIONS_MAP.items()]:
+    if sort in [sort_web_name for sort_web_name, sort_field_name in list(SORT_OPTIONS_MAP.items())]:
         if sort == "avg_rating desc":
             sort = [SORT_OPTIONS_MAP[sort], "num_ratings desc"]
         elif sort == "avg_rating asc":
@@ -317,8 +318,8 @@ class FreesoundSoundJsonEncoder(json.JSONEncoder):
 class SolrQueryPySolr(SolrQuery):
 
     def as_dict(self):
-        params = {k: v for k, v in self.params.iteritems() if v is not None}
-        for k, v in params.iteritems():
+        params = {k: v for k, v in list(self.params.items()) if v is not None}
+        for k, v in list(params.items()):
             if type(v) == bool:
                 params[k] = json.dumps(v)
         return params
@@ -391,7 +392,7 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
         elif type(query_fields) == dict:
             # Also remove fields with weight <= 0
             query_fields = [(add_solr_suffix_to_dynamic_fieldname(FIELD_NAMES_MAP.get(field, field)), weight)
-                for field, weight in query_fields.items() if weight > 0]
+                for field, weight in list(query_fields.items()) if weight > 0]
 
         # Set main query options
         query.set_dismax_query(textual_query, query_fields=query_fields)
@@ -412,10 +413,10 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
 
         # Configure facets
         if facets is not None:
-            facet_fields = [FIELD_NAMES_MAP[field_name] for field_name, _ in facets.items()]
+            facet_fields = [FIELD_NAMES_MAP[field_name] for field_name, _ in list(facets.items())]
             query.add_facet_fields(*facet_fields)
             query.set_facet_options_default(**SOLR_SOUND_FACET_DEFAULT_OPTIONS)
-            for field_name, extra_options in facets.items():
+            for field_name, extra_options in list(facets.items()):
                 query.set_facet_options(FIELD_NAMES_MAP[field_name], **extra_options)
 
         # Configure grouping

--- a/utils/search/lucene_parser.py
+++ b/utils/search/lucene_parser.py
@@ -17,6 +17,9 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import map
+from builtins import chr
+from past.builtins import basestring
 import collections
 
 import pyparsing as pp
@@ -25,9 +28,9 @@ from pyparsing import pyparsing_common as ppc
 
 pp.ParserElement.enablePackrat()
 
-COLON, LBRACK, RBRACK, LBRACE, RBRACE, TILDE, CARAT = map(pp.Literal, ":[]{}~^")
-LPAR, RPAR = map(pp.Literal, "()")
-and_, or_, not_, to_ = map(pp.CaselessKeyword, "AND OR NOT TO".split())
+COLON, LBRACK, RBRACK, LBRACE, RBRACE, TILDE, CARAT = list(map(pp.Literal, ":[]{}~^"))
+LPAR, RPAR = list(map(pp.Literal, "()"))
+and_, or_, not_, to_ = list(map(pp.CaselessKeyword, "AND OR NOT TO".split()))
 keyword = and_ | or_ | not_ | to_
 
 expression = pp.Forward()

--- a/utils/search/search_forum.py
+++ b/utils/search/search_forum.py
@@ -17,6 +17,7 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import str
 import logging
 
 from utils.search import get_search_engine, SearchEngineException

--- a/utils/search/search_sounds.py
+++ b/utils/search/search_sounds.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import logging
 
 from django.conf import settings

--- a/utils/similarity_utilities.py
+++ b/utils/similarity_utilities.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import str
 import logging
 import traceback
 
@@ -134,7 +135,7 @@ def get_sounds_descriptors(sound_ids, descriptor_names, normalization=True, only
     for id in sound_ids:
         analysis_data = cache.get(hash_cache_key(cache_key % (str(id), ",".join(sorted(descriptor_names)), str(normalization))))
         if analysis_data:
-            cached_data[unicode(id)] = analysis_data
+            cached_data[str(id)] = analysis_data
             # remove id form list so it is not included in similarity request
             not_cached_sound_ids.remove(id)
     if not_cached_sound_ids:
@@ -148,7 +149,7 @@ def get_sounds_descriptors(sound_ids, descriptor_names, normalization=True, only
         returned_data = {}
 
     # save sound analysis information in cache
-    for key, item in returned_data.items():
+    for key, item in list(returned_data.items()):
         cache.set(hash_cache_key(cache_key % (key, ",".join(sorted(descriptor_names)), str(normalization))),
                   item, SIMILARITY_CACHE_TIME)
 

--- a/utils/similarity_utilities.py
+++ b/utils/similarity_utilities.py
@@ -149,7 +149,7 @@ def get_sounds_descriptors(sound_ids, descriptor_names, normalization=True, only
         returned_data = {}
 
     # save sound analysis information in cache
-    for key, item in list(returned_data.items()):
+    for key, item in returned_data.items():
         cache.set(hash_cache_key(cache_key % (key, ",".join(sorted(descriptor_names)), str(normalization))),
                   item, SIMILARITY_CACHE_TIME)
 

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -276,13 +276,13 @@ def get_csv_lines(csv_file_path):
         # Read CSV formatted file
         reader = csv.reader(open(csv_file_path, 'rU'), delimiter=',')
         header = next(reader)
-        lines = [dict(list(zip(header, row))) for row in reader]
+        lines = [dict(zip(header, row)) for row in reader]
     elif csv_file_path.endswith('.xls') or csv_file_path.endswith('.xlsx'):
         # Read from Excel format
         wb = xlrd.open_workbook(csv_file_path)
         s = wb.sheet_by_index(0)  # Get first excel sheet
         header = s.row_values(0)
-        lines = [dict(list(zip(header, row))) for row in
+        lines = [dict(zip(header, row)) for row in
                  [[xls_val_to_string(val) for val in s.row_values(i)] for i in range(1, s.nrows)]]
     else:
         header = []
@@ -427,7 +427,7 @@ def validate_input_csv_file(csv_header, csv_lines, sounds_base_dir, username=Non
                 form = SoundCSVDescriptionForm(sound_fields)
                 if not form.is_valid():
                     # If there are errors, add them to line_errors
-                    for field, errors in list(json.loads(form.errors.as_json()).items()):
+                    for field, errors in json.loads(form.errors.as_json()).items():
                         if field in ['lat', 'lon', 'zoom']:
                             line_errors['geotag'] += ' '.join([e['message'] for e in errors])
                         else:
@@ -500,7 +500,7 @@ def bulk_describe_from_csv(csv_file_path, delete_already_existing=False, force_i
         else:
             console_logger.info('Skipping the following %i lines due to invalid data' % len(lines_with_errors))
         for line in lines_with_errors:
-            errors = '; '.join(list(line['line_errors'].values()))
+            errors = '; '.join(line['line_errors'].values())
             console_logger.info('l%s: %s' % (line['line_no'], errors))
         if not force_import:
             return

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -18,6 +18,10 @@
 #     See AUTHORS file.
 #
 
+from builtins import next
+from builtins import zip
+from builtins import str
+from builtins import range
 import csv
 import json
 import logging
@@ -263,7 +267,7 @@ def get_csv_lines(csv_file_path):
     """
 
     def xls_val_to_string(val):
-        if type(val) == unicode:
+        if type(val) == str:
             return str(val.encode('utf-8'))
         else:
             return str(val)
@@ -272,13 +276,13 @@ def get_csv_lines(csv_file_path):
         # Read CSV formatted file
         reader = csv.reader(open(csv_file_path, 'rU'), delimiter=',')
         header = next(reader)
-        lines = [dict(zip(header, row)) for row in reader]
+        lines = [dict(list(zip(header, row))) for row in reader]
     elif csv_file_path.endswith('.xls') or csv_file_path.endswith('.xlsx'):
         # Read from Excel format
         wb = xlrd.open_workbook(csv_file_path)
         s = wb.sheet_by_index(0)  # Get first excel sheet
         header = s.row_values(0)
-        lines = [dict(zip(header, row)) for row in
+        lines = [dict(list(zip(header, row))) for row in
                  [[xls_val_to_string(val) for val in s.row_values(i)] for i in range(1, s.nrows)]]
     else:
         header = []
@@ -423,7 +427,7 @@ def validate_input_csv_file(csv_header, csv_lines, sounds_base_dir, username=Non
                 form = SoundCSVDescriptionForm(sound_fields)
                 if not form.is_valid():
                     # If there are errors, add them to line_errors
-                    for field, errors in json.loads(form.errors.as_json()).items():
+                    for field, errors in list(json.loads(form.errors.as_json()).items()):
                         if field in ['lat', 'lon', 'zoom']:
                             line_errors['geotag'] += ' '.join([e['message'] for e in errors])
                         else:
@@ -496,7 +500,7 @@ def bulk_describe_from_csv(csv_file_path, delete_already_existing=False, force_i
         else:
             console_logger.info('Skipping the following %i lines due to invalid data' % len(lines_with_errors))
         for line in lines_with_errors:
-            errors = '; '.join(line['line_errors'].values())
+            errors = '; '.join(list(line['line_errors'].values()))
             console_logger.info('l%s: %s' % (line['line_no'], errors))
         if not force_import:
             return

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -18,11 +18,12 @@
 #     See AUTHORS file.
 #
 
+from backports import csv
 from builtins import next
 from builtins import zip
 from builtins import str
 from builtins import range
-import csv
+from builtins import open
 import json
 import logging
 import os
@@ -274,7 +275,7 @@ def get_csv_lines(csv_file_path):
 
     if csv_file_path.endswith('.csv'):
         # Read CSV formatted file
-        reader = csv.reader(open(csv_file_path, 'rU'), delimiter=',')
+        reader = csv.reader(open(csv_file_path, 'r', newline='', encoding="utf-8"))
         header = next(reader)
         lines = [dict(zip(header, row)) for row in reader]
     elif csv_file_path.endswith('.xls') or csv_file_path.endswith('.xlsx'):

--- a/utils/tagrecommendation_utilities.py
+++ b/utils/tagrecommendation_utilities.py
@@ -19,10 +19,12 @@ from __future__ import print_function
 #     See AUTHORS file.
 #
 
+from future import standard_library
+standard_library.install_aliases()
 import json
 import logging
 import traceback
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 from hashlib import md5
 from math import ceil
 
@@ -66,7 +68,7 @@ def get_recommended_tags_view(request):
                 try:
                     tags, community = get_recommended_tags(input_tags)
                     return HttpResponse(json.dumps([tags, community]), content_type='application/javascript')
-                except urllib2.URLError as e:
+                except urllib.error.URLError as e:
                     web_logger.error('Could not get a response from the tagrecommendation service (%s)\n\t%s' % \
                                      (e, traceback.format_exc()))
                     return HttpResponseUnavailabileError()

--- a/utils/tags.py
+++ b/utils/tags.py
@@ -1,3 +1,4 @@
+from __future__ import division
 #
 # Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
 #
@@ -18,6 +19,10 @@
 #     See AUTHORS file.
 #
 
+from past.builtins import cmp
+from builtins import zip
+from builtins import range
+from past.utils import old_div
 import re
 
 def size_generator(small_size, large_size, num_items):
@@ -25,7 +30,7 @@ def size_generator(small_size, large_size, num_items):
         yield (small_size + large_size)*0.5
     else:
         for i in range(0,num_items):
-            yield (i*(large_size - small_size))/(num_items-1) + small_size;
+            yield old_div((i*(large_size - small_size)),(num_items-1)) + small_size;
 
 def annotate(dictionary, **kwargs):
     x = dictionary.copy()
@@ -52,7 +57,7 @@ def annotate_tags(tags, sort=None, small_size=0.7, large_size=1.8):
     [ {"name": "tag1", "count": 1, "size": 0.7}, {"name": "tag2", "count": 200, "size": 1.8}, {"name": "tag3", "count": 200, "size": 1.8}]
     """
     unique_counts = sorted(set(tag["count"] for tag in tags))
-    lookup = dict(zip(unique_counts, size_generator(small_size, large_size, len(unique_counts))))
+    lookup = dict(list(zip(unique_counts, size_generator(small_size, large_size, len(unique_counts)))))
     tags = [annotate(tag, size=lookup[tag["count"]]) for tag in tags]
     if sort is not None:
         if sort == "name":

--- a/utils/tags.py
+++ b/utils/tags.py
@@ -57,7 +57,7 @@ def annotate_tags(tags, sort=None, small_size=0.7, large_size=1.8):
     [ {"name": "tag1", "count": 1, "size": 0.7}, {"name": "tag2", "count": 200, "size": 1.8}, {"name": "tag3", "count": 200, "size": 1.8}]
     """
     unique_counts = sorted(set(tag["count"] for tag in tags))
-    lookup = dict(list(zip(unique_counts, size_generator(small_size, large_size, len(unique_counts)))))
+    lookup = dict(zip(unique_counts, size_generator(small_size, large_size, len(unique_counts))))
     tags = [annotate(tag, size=lookup[tag["count"]]) for tag in tags]
     if sort is not None:
         if sort == "name":

--- a/utils/test_helpers.py
+++ b/utils/test_helpers.py
@@ -18,6 +18,8 @@
 #     See AUTHORS file.
 #
 
+from builtins import next
+from builtins import range
 import os
 from functools import partial, wraps
 from itertools import count

--- a/utils/tests/test_forms.py
+++ b/utils/tests/test_forms.py
@@ -18,6 +18,7 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import range
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 

--- a/utils/tests/test_logging_filters.py
+++ b/utils/tests/test_logging_filters.py
@@ -18,12 +18,13 @@
 # Authors:
 #     See AUTHORS file.
 #
+from builtins import object
 from django.test import TestCase
 
 from utils.logging_filters import get_client_ip
 
 
-class DummyRequest:
+class DummyRequest(object):
     """A dummy request to check the X-Forwarded-For header in logging_filters.get_client_ip"""
     def __init__(self, xforwardedfor):
         self.META = {"HTTP_X_FORWARDED_FOR": xforwardedfor}

--- a/utils/tests/tests.py
+++ b/utils/tests/tests.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import range
 import datetime
 import os
 import shutil

--- a/utils/tests/tests.py
+++ b/utils/tests/tests.py
@@ -41,7 +41,7 @@ from utils.tags import clean_and_split_tags
 from utils.test_helpers import create_test_files, create_user_and_sounds, override_uploads_path_with_temp_directory, \
     override_csv_path_with_temp_directory, override_sounds_path_with_temp_directory, \
     override_previews_path_with_temp_directory, override_displays_path_with_temp_directory, \
-    override_analysis_path_with_temp_directory, override_processing_tmp_path_with_temp_directory
+    override_processing_tmp_path_with_temp_directory
 
 
 class UtilsTest(TestCase):

--- a/utils/text.py
+++ b/utils/text.py
@@ -18,10 +18,13 @@
 #     See AUTHORS file.
 #
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import chr
 import re
 import unicodedata
 from functools import partial
-from htmlentitydefs import name2codepoint
+from html.entities import name2codepoint
 
 import bleach
 from bleach.html5lib_shim import Filter
@@ -37,19 +40,19 @@ def slugify(s, entities=True, decimal=True, hexadecimal=True, instance=None, slu
 
     #  character entity reference
     if entities:
-        s = re.sub(r'&(%s);' % '|'.join(name2codepoint), lambda m: unichr(name2codepoint[m.group(1)]), s)
+        s = re.sub(r'&(%s);' % '|'.join(name2codepoint), lambda m: chr(name2codepoint[m.group(1)]), s)
 
     #  decimal character reference
     if decimal:
         try:
-            s = re.sub(r'&#(\d+);', lambda m: unichr(int(m.group(1))), s)
+            s = re.sub(r'&#(\d+);', lambda m: chr(int(m.group(1))), s)
         except:
             pass
 
     #  hexadecimal character reference
     if hexadecimal:
         try:
-            s = re.sub(r'&#x([\da-fA-F]+);', lambda m: unichr(int(m.group(1), 16)), s)
+            s = re.sub(r'&#x([\da-fA-F]+);', lambda m: chr(int(m.group(1), 16)), s)
         except:
             pass
 
@@ -115,7 +118,7 @@ class EmptyLinkFilter(Filter):
             if 'name' in token and token['name'] == 'a' and token['type'] in ['StartTag', 'EndTag']:
                 if token['type'] == 'StartTag':
                     remove_end_tag = True
-                    for attr, value in token['data'].items():
+                    for attr, value in list(token['data'].items()):
                         if attr == (None, 'href') and value != '' and is_valid_url(value):
                             remove_end_tag = False
                     if remove_end_tag:

--- a/utils/text.py
+++ b/utils/text.py
@@ -118,7 +118,7 @@ class EmptyLinkFilter(Filter):
             if 'name' in token and token['name'] == 'a' and token['type'] in ['StartTag', 'EndTag']:
                 if token['type'] == 'StartTag':
                     remove_end_tag = True
-                    for attr, value in list(token['data'].items()):
+                    for attr, value in token['data'].items():
                         if attr == (None, 'href') and value != '' and is_valid_url(value):
                             remove_end_tag = False
                     if remove_end_tag:

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from django import forms
 from wiki import models
 
@@ -26,7 +27,7 @@ class ContentForm(forms.ModelForm):
     title = forms.CharField(label='Page name', widget=forms.TextInput(attrs={'size': '100'}))
     body = forms.CharField(widget=forms.Textarea(attrs={'rows': '40', 'cols': '100'}))
 
-    class Meta:
+    class Meta(object):
         model = models.Content
         exclude = ('author', 'page', 'created')
 

--- a/wiki/models.py
+++ b/wiki/models.py
@@ -20,6 +20,7 @@
 #     See AUTHORS file.
 #
 
+from builtins import object
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.encoding import smart_unicode
@@ -45,7 +46,7 @@ class Content(models.Model):
     body = models.TextField()
     created = models.DateTimeField(db_index=True, auto_now_add=True)
     
-    class Meta:
+    class Meta(object):
         ordering = ('-created', )
         get_latest_by = 'created'
 

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -21,7 +21,8 @@
 #
 
 from django.conf.urls import url
-from django.views.generic import TemplateView, RedirectView
+from django.views.generic import RedirectView
+
 import wiki.views as wiki
 
 urlpatterns = [


### PR DESCRIPTION
**Issue(s)**
Major part of #1083 

**Description**
This PR brings compatibility with Python 3 to the codebase by introducing Python 3-style code.
The majority of the changes were done automatically by running `futurize --step2`. 
Additionally, I reverted a number of changes that were not necessary and only placed as a precaution by futurize (many calls to `list()`, see f6160cfae27e7286df97e62b8cf39854e393055c)
Finally, I introduced [backports.csv](https://pypi.org/project/backports.csv/) to get unicode support in csv writing.
Some changes to (text) data representations, and some adaptations in assert statements were necessary to fix failing tests. (3b2a5efe8bb7bb737c5cf6c5ce080c95bdb89f6a to ee63074c88c3168879f4e68e60a7a0b4d4c56195)

**Deployment steps**:
None, the code should still run with py2.
