### PR TITLE
Upgrade psycopg2 to 2.7.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ mock==2.0.0
 networkx==1.5
 numpy==1.16.6
 pillow==6.2.2
-psycopg2==2.7.3.2
+psycopg2==2.7.7
 pycrypto==2.6.1
 PyJWT==1.4.2
 pyparsing==2.4.7


### PR DESCRIPTION
**Issue(s)**
related to #1083 

**Description**
As I could not install `psycopg2==2.7.3.2` with pip3, I suggest this upgrade.

This brings better py3 support (see [psycopg changelog](https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-7-7))

2.7.7 is the latest recommended version for Django 1.11 (see [Django documentation](https://docs.djangoproject.com/en/1.11/ref/databases/))

**Deployment steps**:
None
