### PR TITLE
add unicode_literals to top of *settings.py files

### DIFF
--- a/freesound/local_settings.example.py
+++ b/freesound/local_settings.example.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import os
 
 DEBUG = True

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import datetime
 import logging.config


### PR DESCRIPTION
**Issue(s)**
FREESOUND-WEB-12V

**Description**
this should make the majority of paths used in the application unicode

**Deployment steps**:
update `local_settings.py` accordingly
