### PR TITLE
Upgrade pyyaml to 5.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ pysolr==3.10.0b1
 pysndfile==1.4.3
 python-cjson==1.1.0
 pytz==2020.1
-PyYAML==3.11
+PyYAML==5.4.1
 redis==3.2.0
 sentry-sdk==0.14.4
 Sphinx==1.6.3

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -1794,7 +1794,7 @@ class SoundAnalysis(models.Model):
                 pass
         if os.path.exists(self.analysis_filepath_base + '.yaml'):
             try:
-                return yaml.load(open(self.analysis_filepath_base + '.yaml'), Loader=yaml.cyaml.CLoader)
+                return yaml.load(open(self.analysis_filepath_base + '.yaml'), Loader=yaml.cyaml.CFullLoader)
             except Exception:
                 pass
         return {}

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -1794,7 +1794,7 @@ class SoundAnalysis(models.Model):
                 pass
         if os.path.exists(self.analysis_filepath_base + '.yaml'):
             try:
-                return yaml.load(open(self.analysis_filepath_base + '.yaml'), Loader=yaml.cyaml.CFullLoader)
+                return yaml.load(open(self.analysis_filepath_base + '.yaml'), Loader=yaml.cyaml.CSafeLoader)
             except Exception:
                 pass
         return {}


### PR DESCRIPTION
**Issue(s)**
related to #1083 

**Description**
upgrade PyYaml for better Python 3.7 support. I upgraded to the last version that supports Python 2.7

To make the potential unsafe nature of yaml loading more explicit, PyYaml deprecated the default loader in 5.1.
I decided to explicitly use the FullLoader for now. We should switch to SafeLoader if we load untrusted input. 

**Deployment steps**:
None
