### PR TITLE
use new names for django.utils.encoding functions

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -40,7 +40,7 @@ from django.db.models import Q
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
 from django.urls import reverse
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.utils.timezone import now
 
 import tickets.models
@@ -202,7 +202,7 @@ class Profile(SocialModel):
         return self.num_sound_downloads + self.num_pack_downloads
 
     def get_absolute_url(self):
-        return reverse('account', args=[smart_unicode(self.user.username)])
+        return reverse('account', args=[smart_text(self.user.username)])
 
     @staticmethod
     def locations_static(user_id, has_avatar):

--- a/forum/models.py
+++ b/forum/models.py
@@ -33,7 +33,7 @@ from django.db.models.functions import Greatest
 from django.db.models.signals import post_delete, pre_save, post_save
 from django.dispatch import receiver
 from django.urls import reverse
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 
 import accounts
 from general.models import OrderedModel
@@ -76,7 +76,7 @@ class Forum(OrderedModel):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("forums-forum", args=[smart_unicode(self.name_slug)])
+        return reverse("forums-forum", args=[smart_text(self.name_slug)])
 
 
 class Thread(models.Model):
@@ -123,7 +123,7 @@ class Thread(models.Model):
             self.save(update_fields=['first_post'])
 
     def get_absolute_url(self):
-        return reverse("forums-thread", args=[smart_unicode(self.forum.name_slug), self.id])
+        return reverse("forums-thread", args=[smart_text(self.forum.name_slug), self.id])
 
     def is_user_subscribed(self, user):
         """A user is subscribed to a thread if a Subscription object exists that related the two of them"""
@@ -223,7 +223,7 @@ class Post(models.Model):
         return u"Post by %s in %s" % (self.author, self.thread)
 
     def get_absolute_url(self):
-        return reverse("forums-post", args=[smart_unicode(self.thread.forum.name_slug), self.thread.id, self.id])
+        return reverse("forums-post", args=[smart_text(self.thread.forum.name_slug), self.thread.id, self.id])
 
 
 @receiver(pre_save, sender=Post)
@@ -344,4 +344,3 @@ class Subscription(models.Model):
 
     def __unicode__(self):
         return u"%s subscribed to %s" % (self.subscriber, self.thread)
-F

--- a/general/templatetags/markup_freesound.py
+++ b/general/templatetags/markup_freesound.py
@@ -7,7 +7,7 @@ import markdown as markdown_package
 import re
 
 from django import template
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
 register = template.Library()
@@ -33,7 +33,7 @@ def markdown(value, arg=''):
     }
 
     md = markdown_package.Markdown(extensions=extensions, extension_configs=extension_configs)
-    html_contents = md.convert(force_unicode(value))
+    html_contents = md.convert(force_text(value))
 
     # Markdown TOC extension adds target ids to the header tags (e.g. <h2 id="xxx">), but this does not work well
     # in BW frontend because we need to offset the targets to compensate for the fixed header height, and the technique

--- a/geotags/models.py
+++ b/geotags/models.py
@@ -26,7 +26,7 @@ from django.contrib.auth.models import User
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.urls import reverse
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from mapbox import Geocoder
 
 web_logger = logging.getLogger("web")
@@ -46,7 +46,7 @@ class GeoTag(models.Model):
         return u"%s (%f,%f)" % (self.user, self.lat, self.lon)
 
     def get_absolute_url(self):
-        return reverse('geotag', args=[smart_unicode(self.id)])
+        return reverse('geotag', args=[smart_text(self.id)])
 
     def retrieve_location_information(self):
         """Use the mapbox API to retrieve information about the latitude and longitude of this geotag.

--- a/messages/models.py
+++ b/messages/models.py
@@ -23,7 +23,7 @@
 from builtins import object
 from django.contrib.auth.models import User
 from django.db import models
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 
 
 class MessageBody(models.Model):
@@ -99,11 +99,10 @@ class Message(models.Model):
     created = models.DateTimeField(db_index=True, auto_now_add=True)
     
     def get_absolute_url(self):
-        return "message", (smart_unicode(self.id),)
+        return "message", (smart_text(self.id),)
 
     def __unicode__(self):
         return u"from: [%s] to: [%s]" % (self.user_from, self.user_to)
     
     class Meta(object):
         ordering = ('-created',)
-

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -49,7 +49,7 @@ from django.db.models.signals import pre_delete, post_delete, post_save
 from django.dispatch import receiver
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.utils.functional import cached_property
 from django.utils.text import Truncator
 
@@ -828,7 +828,7 @@ class Sound(SocialModel):
         return old_div(self.avg_rating, 2)
 
     def get_absolute_url(self):
-        return reverse('sound', args=[self.user.username, smart_unicode(self.id)])
+        return reverse('sound', args=[self.user.username, smart_text(self.id)])
 
     @property
     def license_bw_icon_name(self):
@@ -1451,7 +1451,7 @@ class Pack(SocialModel):
         return self.name
 
     def get_absolute_url(self):
-        return reverse('pack', args=[self.user.username, smart_unicode(self.id)])
+        return reverse('pack', args=[self.user.username, smart_text(self.id)])
 
     class Meta(SocialModel.Meta):
         unique_together = ('user', 'name', 'is_deleted')

--- a/tags/models.py
+++ b/tags/models.py
@@ -25,7 +25,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes import fields
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.urls import reverse
 
 class Tag(models.Model):
@@ -57,7 +57,7 @@ class TaggedItem(models.Model):
         return u"%s tagged %s - %s: %s" % (self.user, self.content_type, self.content_type, self.tag)
 
     def get_absolute_url(self):
-        return reverse('tag', args=[smart_unicode(self.tag.id)])
+        return reverse('tag', args=[smart_text(self.tag.id)])
 
     class Meta(object):
         ordering = ("-created",)

--- a/tickets/models.py
+++ b/tickets/models.py
@@ -28,7 +28,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.db import models
 from django.db.models.signals import post_save
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 import uuid
 from utils.mail import send_mail_template
 
@@ -99,7 +99,7 @@ class Ticket(models.Model):
                                    user_to=self.sender)
 
     def get_absolute_url(self):
-        return reverse('ticket', args=[smart_unicode(self.key)])
+        return reverse('ticket', args=[smart_text(self.key)])
 
     def __unicode__(self):
         return u"pk %s, key %s" % (self.id, self.key)

--- a/utils/text.py
+++ b/utils/text.py
@@ -28,7 +28,7 @@ from html.entities import name2codepoint
 
 import bleach
 from bleach.html5lib_shim import Filter
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 
 from sounds.templatetags.sound_signature import SOUND_SIGNATURE_SOUND_ID_PLACEHOLDER, \
     SOUND_SIGNATURE_SOUND_URL_PLACEHOLDER
@@ -36,7 +36,7 @@ from sounds.templatetags.sound_signature import SOUND_SIGNATURE_SOUND_ID_PLACEHO
 
 def slugify(s, entities=True, decimal=True, hexadecimal=True, instance=None, slug_field='slug', filter_dict=None):
     """ slugify with character translation which translates foreign characters to regular ascii equivalents """
-    s = smart_unicode(s)
+    s = smart_text(s)
 
     #  character entity reference
     if entities:

--- a/wiki/models.py
+++ b/wiki/models.py
@@ -23,7 +23,7 @@
 from builtins import object
 from django.contrib.auth.models import User
 from django.db import models
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.urls import reverse
 
 class Page(models.Model):
@@ -36,7 +36,7 @@ class Page(models.Model):
         return Content.objects.filter(page=self).latest()
 
     def get_absolute_url(self):
-        return reverse("wiki-page", args=[smart_unicode(self.name)])
+        return reverse("wiki-page", args=[smart_text(self.name)])
 
 
 class Content(models.Model):


### PR DESCRIPTION
**Issue(s)**
#1083 

**Description**
The imports did not work in Py3 so it's best to switch to the new names.
see the [Django migration docs](https://docs.djangoproject.com/en/1.11/topics/python3/#string-handling)

**Deployment steps**:
None
