### PR TITLE
upgrade celery to 4.4.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ backports.csv
 beautifulsoup4==4.6.0
 bleach==3.1.5
 boto3==1.7.10
-celery==4.1.1
+celery==4.4.7
 debugpy==1.5.1
 dj-database-url==0.5.0
 django-amazon-ses==3.0.1


### PR DESCRIPTION
**Issue(s)**
#1083 

**Description**
upgrade celery to 4.4.7; the last version that supports Django 1.11 & py2
4.2 and 4.3 brought compatibility changes with Python 3

see:
- https://docs.celeryq.dev/en/v4.2.2/whatsnew-4.2.html
- https://docs.celeryq.dev/en/v4.3.0/whatsnew-4.3.html
- https://docs.celeryq.dev/en/v4.4.7/whatsnew-4.4.html

**Deployment steps**:
None
