### PR TITLE
replace home-made encryption with django cryptographic signing

### DIFF
--- a/_LICENSE/LICENSES
+++ b/_LICENSE/LICENSES
@@ -21,7 +21,6 @@ Python dependencies
 * python-beautifulsoup 3.1.0.1-2 (c) 1996-2012 Leonard Richardson. BSD "3-clause".
   www.crummy.com/software/BeautifulSoup
 * python-yaml 3.05-5 (c) 2006 Kitill Simonov. MIT License ("expat"). www.pyyaml.org
-* python-crypto 2.1.0-2. Public domain. www.dlitz.net/software/pycrypto
 * python-feedparser 4.1-14 (c) 2002-2008 Mark Pilgrim, 2010-2012 Kurt McKee. MIT License
   ("expat"). code.google.com/p/feedparser
 * python-cjson 1.0.5-4. LGPL2+. pypi.python.org/pypi/python-cjson/1.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ networkx==1.5
 numpy==1.16.6
 pillow==6.2.2
 psycopg2==2.7.7
-pycrypto==2.6.1
 PyJWT==1.4.2
 pyparsing==2.4.7
 pysolr==3.10.0b1

--- a/utils/encryption.py
+++ b/utils/encryption.py
@@ -29,7 +29,7 @@ from django.core.signing import TimestampSigner
 def sign_with_timestamp(unsigned_value):
     signer = TimestampSigner()
     value = signer.sign(unsigned_value)
-    orig_val, signed_value = value.split(":", maxsplit=1)
+    orig_val, signed_value = value.split(":", 1)
     return signed_value
 
 

--- a/utils/encryption.py
+++ b/utils/encryption.py
@@ -23,37 +23,21 @@ standard_library.install_aliases()
 from builtins import str
 from django.conf import settings
 
-def encrypt(decrypted_string):
-    from Crypto.Cipher import AES
-    import base64
-    import urllib.request, urllib.parse, urllib.error
-    
-    encryptor = AES.new(settings.SECRET_KEY[0:16]) #@UndefinedVariable
-    
-    # encrypted strings need to be len() = multiple of 16
-    decrypted_string += u' ' * ( 16 - len(decrypted_string) % 16 )
+from django.core.signing import TimestampSigner
 
-    encrypted_string = encryptor.encrypt(decrypted_string)
-    
-    # base64 encoded strings have "=" signs, quote them!
-    encoded_string = urllib.parse.quote(base64.b64encode(encrypted_string).replace("/", ".").replace("+", "_").replace("=", "-"))
-    
-    return encoded_string
 
-def decrypt(quoted_string):
-    from Crypto.Cipher import AES
-    import base64
-    import urllib.request, urllib.parse, urllib.error
+def sign_with_timestamp(unsigned_value):
+    signer = TimestampSigner()
+    value = signer.sign(unsigned_value)
+    orig_val, signed_value = value.split(":", maxsplit=1)
+    return signed_value
 
-    decryptor = AES.new(settings.SECRET_KEY[0:16]) #@UndefinedVariable
-    
-    encoded_string = urllib.parse.unquote(quoted_string)
-    
-    encrypted_string = base64.b64decode(encoded_string.replace(".", "/").replace("_", "+").replace("-", "="))
-    
-    decrypted_string = decryptor.decrypt(encrypted_string).strip()
-    
-    return decrypted_string 
+
+def unsign_with_timestamp(unsigned_value, signed_value, max_age):
+    signer = TimestampSigner()
+    value = signer.unsign(":".join((unsigned_value, signed_value)), max_age)
+    return value
+
 
 def create_hash(data, add_secret=True, limit=8):
     import hashlib


### PR DESCRIPTION
**Issue(s)**
dealing with a mix of `bytes` and `str` is different in PY3 #1083 

**Description**
Use [Django cryptographic signing](https://docs.djangoproject.com/en/1.11/topics/signing/) to construct secure links that expire.

**Deployment steps**:
Theoretically, a link created before the deployment would not work after. Since it is only valid for 10 seconds, I don't think it is an issue.
