### PR TITLE
replace assertItemsEqual with six.assertCountEqual

### DIFF
--- a/apiv2/tests.py
+++ b/apiv2/tests.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 from __future__ import absolute_import
+import six
 from django.test import TestCase, SimpleTestCase, RequestFactory
 from django.urls import reverse
 from django.conf import settings
@@ -355,19 +356,19 @@ class TestSoundListSerializer(TestCase):
         # When 'fields' parameter is not used, return default ones
         dummy_request = self.factory.get(reverse('apiv2-sound-text-search'), {'fields': ''})
         serialized_sound = SoundListSerializer(list(sounds_dict.values())[0], context={'request': dummy_request}).data
-        self.assertItemsEqual(list(serialized_sound.keys()), DEFAULT_FIELDS_IN_SOUND_LIST.split(','))
+        six.assertCountEqual(self, list(serialized_sound.keys()), DEFAULT_FIELDS_IN_SOUND_LIST.split(','))
 
         # When only some parameters are specified
         fields_parameter = 'id,username'
         dummy_request = self.factory.get(reverse('apiv2-sound-text-search'), {'fields': fields_parameter})
         serialized_sound = SoundListSerializer(list(sounds_dict.values())[0], context={'request': dummy_request}).data
-        self.assertItemsEqual(list(serialized_sound.keys()), fields_parameter.split(','))
+        six.assertCountEqual(self, list(serialized_sound.keys()), fields_parameter.split(','))
 
         # When all parameters are specified
         fields_parameter = ','.join(SoundListSerializer.Meta.fields)
         dummy_request = self.factory.get(reverse('apiv2-sound-text-search'), {'fields': fields_parameter})
         serialized_sound = SoundListSerializer(list(sounds_dict.values())[0], context={'request': dummy_request}).data
-        self.assertItemsEqual(list(serialized_sound.keys()), fields_parameter.split(','))
+        six.assertCountEqual(self, list(serialized_sound.keys()), fields_parameter.split(','))
 
     def test_num_queries(self):
         # Test that the serializer does not perform any extra query when serializing sounds regardless of the number
@@ -421,7 +422,7 @@ class TestSoundSerializer(TestCase):
         with self.assertNumQueries(0):
             dummy_request = self.factory.get(reverse('apiv2-sound-instance', args=[self.sound.id]))
             serialized_sound = SoundSerializer(self.sound, context={'request': dummy_request}).data
-            self.assertItemsEqual(list(serialized_sound.keys()), SoundSerializer.Meta.fields)
+            six.assertCountEqual(self, list(serialized_sound.keys()), SoundSerializer.Meta.fields)
 
 
 class TestApiV2Client(TestCase):

--- a/messages/tests/test_message_write.py
+++ b/messages/tests/test_message_write.py
@@ -20,6 +20,7 @@
 from builtins import range
 import json
 
+import six
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
@@ -112,9 +113,9 @@ class UsernameLookup(TestCase):
     def test_get_previously_contacted_usernames(self):
         # Check get_previously_contacted_usernames helper function returns userames of users previously contacted by
         # the sender or users who previously contacted the sender
-        self.assertItemsEqual([self.receiver3.username, self.receiver2.username, self.receiver1.username,
-                               self.sender2.username, self.sender.username],
-                              get_previously_contacted_usernames(self.sender))
+        six.assertCountEqual(self, [self.receiver3.username, self.receiver2.username, self.receiver1.username,
+                                    self.sender2.username, self.sender.username],
+                             get_previously_contacted_usernames(self.sender))
 
     def test_username_lookup_response(self):
         # Check username lookup view returns userames of users previously contacted by the sender or users who
@@ -123,9 +124,9 @@ class UsernameLookup(TestCase):
         resp = self.client.get(reverse('messages-username_lookup'))
         response_json = json.loads(resp.content)
         self.assertEqual(resp.status_code, 200)
-        self.assertItemsEqual([self.receiver3.username, self.receiver2.username, self.receiver1.username,
-                               self.sender2.username, self.sender.username],
-                              response_json)
+        six.assertCountEqual(self, [self.receiver3.username, self.receiver2.username, self.receiver1.username,
+                                    self.sender2.username, self.sender.username],
+                             response_json)
 
 
 class QuoteMessageTestCase(TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ pytz==2020.1
 PyYAML==5.4.1
 redis==3.2.0
 sentry-sdk==0.14.4
+six
 Sphinx==1.6.3
 stripe==2.28.1
 xlrd==1.1.0

--- a/sounds/tests/test_manager.py
+++ b/sounds/tests/test_manager.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+import six
 from django.conf import settings
 from django.test import TestCase
 
@@ -69,7 +70,7 @@ class SoundManagerQueryMethods(TestCase):
             self.assertEqual(Sound.objects.get(id=sound.id).original_filename, sound.original_filename)
             self.assertEqual(Sound.objects.get(id=sound.id).pack_id, sound.pack_id)
             self.assertEqual(Sound.objects.get(id=sound.id).license_id, sound.license_id)
-            self.assertItemsEqual(Sound.objects.get(id=sound.id).get_sound_tags(), sound.tag_array)
+            six.assertCountEqual(self, Sound.objects.get(id=sound.id).get_sound_tags(), sound.tag_array)
 
     def test_bulk_query_solr_num_queries(self):
 
@@ -88,7 +89,7 @@ class SoundManagerQueryMethods(TestCase):
             self.assertEqual(Sound.objects.get(id=sound.id).md5, sound.md5)
             self.assertEqual(Sound.objects.get(id=sound.id).pack_id, sound.pack_id)
             self.assertEqual(Sound.objects.get(id=sound.id).license_id, sound.license_id)
-            self.assertItemsEqual(Sound.objects.get(id=sound.id).get_sound_tags(), sound.tag_array)
+            six.assertCountEqual(self, Sound.objects.get(id=sound.id).get_sound_tags(), sound.tag_array)
 
     def test_ordered_ids(self):
 
@@ -122,7 +123,7 @@ class SoundManagerQueryMethods(TestCase):
             for i, sound in enumerate(Sound.objects.bulk_sounds_for_user(user_id=self.user.id)):
                 self.assertEqual(self.user.id, sound.user_id)
                 user_sound_ids_bulk_query.append(sound.id)
-        self.assertItemsEqual(user_sound_ids, user_sound_ids_bulk_query)
+        six.assertCountEqual(self, user_sound_ids, user_sound_ids_bulk_query)
 
     def test_bulk_sounds_for_pack(self):
 
@@ -147,7 +148,7 @@ class SoundManagerQueryMethods(TestCase):
             for i, sound in enumerate(Sound.objects.bulk_sounds_for_pack(pack_id=self.pack.id)):
                 self.assertEqual(self.user.id, sound.user_id)
                 pack_sound_ids_bulk_query.append(sound.id)
-        self.assertItemsEqual(pack_sound_ids, pack_sound_ids_bulk_query)
+        six.assertCountEqual(self, pack_sound_ids, pack_sound_ids_bulk_query)
 
 
 class PublicSoundManagerTest(TestCase):

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -27,6 +27,7 @@ import json
 import os
 import time
 
+import six
 import mock
 from bs4 import BeautifulSoup
 from django.conf import settings
@@ -178,7 +179,7 @@ class ChangeSoundOwnerTestCase(TestCase):
         # Delete original user and perform further checks
         userA.profile.delete_user(delete_user_object_from_db=True)
         sound = Sound.objects.get(id=target_sound_id)
-        self.assertItemsEqual([ti.id for ti in sound.tags.all()], target_sound_tags)
+        six.assertCountEqual(self, [ti.id for ti in sound.tags.all()], target_sound_tags)
         delete_sounds_from_search_engine.assert_has_calls([mock.call([i]) for i in remaining_sound_ids], any_order=True)
 
 


### PR DESCRIPTION
**Issue(s)**
#1083 

**Description**
In Python 3, `assertItemsEqual` is named `assertCountEqual`. six provides a compatibility layer.

https://six.readthedocs.io/index.html?highlight=assertCountEqual#six.assertCountEqual
https://docs.python.org/2.7/library/unittest.html#unittest.TestCase.assertItemsEqual


**Deployment steps**:
None
