### PR TITLE
upgrade oauth-toolkit & cors-headers; Add explicit requirement to oauthlib

### DIFF
--- a/apiv2/authentication.py
+++ b/apiv2/authentication.py
@@ -23,7 +23,7 @@
 from rest_framework import exceptions
 from rest_framework.authentication import get_authorization_header
 from rest_framework.authentication import BaseAuthentication, SessionAuthentication as DjangoRestFrameworkSessionAuthentication
-from oauth2_provider.ext.rest_framework import OAuth2Authentication as Oauth2ProviderOauth2Authentication
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication as Oauth2ProviderOauth2Authentication
 from apiv2.models import ApiV2Client
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,13 @@ celery==4.4.7
 debugpy==1.5.1
 dj-database-url==0.5.0
 django-amazon-ses==3.0.1
-django-cors-headers==2.0.2
+django-cors-headers==2.5.3
 django-debug-toolbar==1.7
 django-extensions==1.7.8
 django-modeladmin-reorder==0.3.1
 django-multiupload==0.5
-django-oauth-toolkit==0.10.0
+django-oauth-toolkit==1.1.2
+oauthlib
 django-object-actions==0.8.2
 django-ratelimit==2.0.0
 django-recaptcha==2.0.6


### PR DESCRIPTION
**Description**
for better support of django 1.11 and python3
https://django-oauth-toolkit.readthedocs.io/en/latest/changelog.html
https://github.com/adamchainz/django-cors-headers/blob/main/HISTORY.rst

**Issue(s)**
#1083 

**Deployment steps**:
Sync database
`python manage.py migrate oauth2_provider`
