### PR TITLE
fix incorrectly removed parenthesis

### DIFF
--- a/apiv2/views.py
+++ b/apiv2/views.py
@@ -1296,7 +1296,7 @@ class FreesoundApiV2Resources(GenericAPIView):
                         reverse('apiv2-user-bookmark-category-sounds', args=['uname', 0]).replace('0', '<category_id>')
                             .replace('uname', '<username>'),
                         request_is_secure=request.is_secure()),
-                }.items()), key=lambda t: t[0]))},
+                }).items(), key=lambda t: t[0]))},
                 {'Pack resources': OrderedDict(sorted(dict({
                     '01 Pack instance': prepend_base(
                         reverse('apiv2-pack-instance', args=[0]).replace('0', '<pack_id>'),


### PR DESCRIPTION
**Issue(s)**
FREESOUND-WEB-12T

**Description**
in f6160cfae27e7286df97e62b8cf39854e393055c I accidentally removed the wrong parenthesis
**Deployment steps**:
None
