### PR TITLE
add docker build for python 3

### DIFF
--- a/docker/Dockerfile.py3.base
+++ b/docker/Dockerfile.py3.base
@@ -1,0 +1,27 @@
+ARG PYTHON
+FROM debian:10
+
+MAINTAINER Freesound support@freesound.org
+
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+                       build-essential \
+                       ca-certificates \
+                       git \
+                       gosu \
+                       pkg-config \
+                       procps \
+                       python3-dev \
+                       python3-pip \
+                       python3-setuptools \
+                       python3-wheel \
+                       wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN adduser -q --gecos "" --disabled-password fsweb
+
+COPY entrypoint.sh /usr/local/bin
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/docker/Dockerfile.workers_web
+++ b/docker/Dockerfile.workers_web
@@ -1,3 +1,5 @@
+ARG PYTHON_MAJOR_VERSION=2
+
 # --- build stereofy static binary
 
 FROM debian:10 as stereofy
@@ -11,7 +13,8 @@ RUN make clean && make
 
 # --- main Freesound docker file contents
 
-FROM freesound:2020-02
+FROM freesound:2023-01-py${PYTHON_MAJOR_VERSION}
+ARG PYTHON_MAJOR_VERSION
 
 # Install specific dependencies needed for processing, building static files and for ssh
 RUN wget -q -O - https://deb.nodesource.com/setup_14.x | bash - && apt-get update \
@@ -44,7 +47,9 @@ COPY --from=stereofy /code/stereofy /usr/local/bin
 
 # Install python dependencies
 COPY --chown=fsweb:fsweb requirements.txt /code/requirements.txt
-RUN pip install --no-cache-dir -r /code/requirements.txt
+RUN if [ ${PYTHON_MAJOR_VERSION} -eq 3 ]; then pip${PYTHON_MAJOR_VERSION} install --no-cache-dir -U pip 'setuptools<=58'; fi && \
+    pip${PYTHON_MAJOR_VERSION} install --no-cache-dir -r /code/requirements.txt
+
 
 # Copy source code
 COPY --chown=fsweb:fsweb . /code

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,5 @@
 all:
-	docker build -t freesound:2020-02 -f Dockerfile.base .
+	docker build -t freesound:2023-01-py2 -f Dockerfile.base .
+	docker build -t freesound:2023-01-py3 -f Dockerfile.py3.base .
 
 .PHONY: all


### PR DESCRIPTION

**Issue(s)**
#1083 

**Description**
Build service for Py3 with:
`docker-compose build --build-arg PYTHON_MAJOR_VERSION=3`

Share a build process for testing with Python 3 🔮

**Deployment steps**:
None (yet ✌️)
