### PR TITLE
assertContains to hand off decoding response content (bytes) to Django

### DIFF
--- a/accounts/tests/test_profile.py
+++ b/accounts/tests/test_profile.py
@@ -193,9 +193,9 @@ class AboutFieldVisibilityTest(TestCase):
     def _check_visibility(self, username, condition):
         resp = self.client.get(reverse('account', kwargs={'username': username}))
         if condition:
-            self.assertIn(self.about, resp.content)
+            self.assertContains(resp, self.about)
         else:
-            self.assertNotIn(self.about, resp.content)
+            self.assertNotContains(resp, self.about)
 
     def _check_visible(self):
         self._check_visibility('downloader', True)

--- a/accounts/tests/test_upload.py
+++ b/accounts/tests/test_upload.py
@@ -231,7 +231,7 @@ class BulkDescribe(TestCase):
             self.client.force_login(user)
             resp = self.client.get(reverse('accounts-bulk-describe', args=[bulk.id]), follow=True)
             self.assertRedirects(resp, reverse('accounts-home'))
-            self.assertIn('Your user does not have permission to use the bulk describe', resp.content)
+            self.assertContains(resp, 'Your user does not have permission to use the bulk describe')
 
     @override_settings(BULK_UPLOAD_MIN_SOUNDS=0)
     def test_bulk_describe_state_validating(self):
@@ -240,7 +240,7 @@ class BulkDescribe(TestCase):
         bulk = BulkUploadProgress.objects.create(progress_type="N", user=user, original_csv_filename="test.csv")
         self.client.force_login(user)
         resp = self.client.get(reverse('accounts-bulk-describe', args=[bulk.id]))
-        self.assertIn('The uploaded data file has not yet been validated', resp.content)
+        self.assertContains(resp, 'The uploaded data file has not yet been validated')
 
     @mock.patch('general.tasks.bulk_describe.delay')
     @override_settings(BULK_UPLOAD_MIN_SOUNDS=0)
@@ -250,7 +250,7 @@ class BulkDescribe(TestCase):
         bulk = BulkUploadProgress.objects.create(progress_type="V", user=user, original_csv_filename="test.csv")
         self.client.force_login(user)
         resp = self.client.get(reverse('accounts-bulk-describe', args=[bulk.id]))
-        self.assertIn('Validation results of the data file', resp.content)
+        self.assertContains(resp, 'Validation results of the data file')
 
         # Test that chosing option to delete existing BulkUploadProgress really does it
         resp = self.client.post(reverse('accounts-bulk-describe', args=[bulk.id]) + '?action=delete')
@@ -270,7 +270,7 @@ class BulkDescribe(TestCase):
         bulk = BulkUploadProgress.objects.create(progress_type="S", user=user, original_csv_filename="test.csv")
         self.client.force_login(user)
         resp = self.client.get(reverse('accounts-bulk-describe', args=[bulk.id]))
-        self.assertIn('Your sounds are being described and processed', resp.content)
+        self.assertContains(resp, 'Your sounds are being described and processed')
 
         # Test that when BulkUploadProgress has finished describing items but still is processing some sounds, we
         # show that info to the users. First we fake some data for the bulk object
@@ -287,7 +287,7 @@ class BulkDescribe(TestCase):
         }
         bulk.save()
         resp = self.client.get(reverse('accounts-bulk-describe', args=[bulk.id]))
-        self.assertIn('Your sounds are being described and processed', resp.content)
+        self.assertContains(resp, 'Your sounds are being described and processed')
 
         # Test that when both description and processing have finished we show correct info to users
         for i in range(0, 5):  # First create the sound objects so BulkUploadProgress can properly compute progress
@@ -304,7 +304,7 @@ class BulkDescribe(TestCase):
             bulk.description_output[count] = sound.id  # Fill bulk.description_output with real sound IDs
         bulk.save()
         resp = self.client.get(reverse('accounts-bulk-describe', args=[bulk.id]))
-        self.assertIn('The bulk description process has finished!', resp.content)
+        self.assertContains(resp, 'The bulk description process has finished!')
 
     @override_settings(BULK_UPLOAD_MIN_SOUNDS=0)
     def test_bulk_describe_state_closed(self):
@@ -313,4 +313,4 @@ class BulkDescribe(TestCase):
         bulk = BulkUploadProgress.objects.create(progress_type="C", user=user, original_csv_filename="test.csv")
         self.client.force_login(user)
         resp = self.client.get(reverse('accounts-bulk-describe', args=[bulk.id]))
-        self.assertIn('This bulk description process is closed', resp.content)
+        self.assertContains(resp, 'This bulk description process is closed')

--- a/accounts/tests/test_user.py
+++ b/accounts/tests/test_user.py
@@ -67,7 +67,7 @@ class UserRegistrationAndActivation(TestCase):
             u'email2': [u'example@email.com']
         })
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('You must accept the terms of use', resp.content)
+        self.assertContains(resp, 'You must accept the terms of use')
         self.assertEqual(User.objects.filter(username=username).count(), 0)
         self.assertEqual(len(mail.outbox), 0)  # No email sent
 
@@ -80,7 +80,7 @@ class UserRegistrationAndActivation(TestCase):
             u'email2': [u'exampleemail.com']
         })
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('Enter a valid email', resp.content)
+        self.assertContains(resp, 'Enter a valid email')
         self.assertEqual(User.objects.filter(username=username).count(), 0)
         self.assertEqual(len(mail.outbox), 0)  # No email sent
 
@@ -93,7 +93,7 @@ class UserRegistrationAndActivation(TestCase):
             u'email2': [u'example@email.com']
         })
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('This field is required', resp.content)
+        self.assertContains(resp, 'This field is required')
         self.assertEqual(User.objects.filter(username=username).count(), 0)
         self.assertEqual(len(mail.outbox), 0)  # No email sent
 
@@ -106,7 +106,7 @@ class UserRegistrationAndActivation(TestCase):
             u'email2': [u'exampl@email.net']
         })
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('Please confirm that your email address is the same', resp.content)
+        self.assertContains(resp, 'Please confirm that your email address is the same')
         self.assertEqual(User.objects.filter(username=username).count(), 0)
         self.assertEqual(len(mail.outbox), 0)  # No email sent
 
@@ -119,7 +119,7 @@ class UserRegistrationAndActivation(TestCase):
             u'email2': [u'example@email.com']
         })
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('Registration done, activate your account', resp.content)
+        self.assertContains(resp, 'Registration done, activate your account')
         self.assertEqual(User.objects.filter(username=username).count(), 1)
         self.assertEqual(len(mail.outbox), 1)  # An email was sent!
         self.assertTrue(settings.EMAIL_SUBJECT_PREFIX in mail.outbox[0].subject)
@@ -134,7 +134,7 @@ class UserRegistrationAndActivation(TestCase):
             u'email2': [u'example@email.com']
         })
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('You cannot use this username to create an account', resp.content)
+        self.assertContains(resp, 'You cannot use this username to create an account')
         self.assertEqual(User.objects.filter(username=username).count(), 1)
         self.assertEqual(len(mail.outbox), 1)  # No new email sent
 
@@ -147,7 +147,7 @@ class UserRegistrationAndActivation(TestCase):
             u'email2': [u'example@email.com']
         })
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('You cannot use this email address to create an account', resp.content)
+        self.assertContains(resp, 'You cannot use this email address to create an account')
         self.assertEqual(User.objects.filter(username=username).count(), 1)
         self.assertEqual(len(mail.outbox), 1)  # No new email sent
 
@@ -342,7 +342,7 @@ class UserDelete(TestCase):
         self.assertRedirects(resp, reverse('front-page'))
 
         # Check loaded page contains message about user deletion
-        self.assertIn(resp.content, 'Your user account will be deleted in a few moments')
+        self.assertContains(resp, 'Your user account will be deleted in a few moments')
 
     @mock.patch('general.tasks.delete_user.delay')
     def test_user_delete_keep_sounds_using_web_form(self, submit_job):
@@ -370,7 +370,7 @@ class UserDelete(TestCase):
         self.assertRedirects(resp, reverse('front-page'))
 
         # Check loaded page contains message about user deletion
-        self.assertIn(resp.content, 'Your user account will be deleted in a few moments')
+        self.assertContains(resp, 'Your user account will be deleted in a few moments')
 
     def test_fail_user_delete_include_sounds_using_web_form(self):
         # Test delete user account form with wrong password does not delete
@@ -385,7 +385,7 @@ class UserDelete(TestCase):
             {'encrypted_link': encr_link, 'password': 'wrong_pass', 'delete_sounds': 'delete_sounds'})
 
         # Check user is reported incorrect password
-        self.assertIn('Incorrect password', resp.content)
+        self.assertContains(resp, 'Incorrect password')
 
         # Check user is not marked as anonymized
         self.assertEqual(User.objects.get(id=user.id).profile.is_anonymized_user, False)

--- a/accounts/tests/test_user.py
+++ b/accounts/tests/test_user.py
@@ -326,7 +326,9 @@ class UserDelete(TestCase):
         encr_link = form.initial['encrypted_link']
         resp = self.client.post(
             reverse('accounts-delete'),
-            {'encrypted_link': encr_link, 'password': 'testpass', 'delete_sounds': 'delete_sounds'})
+            {'encrypted_link': encr_link, 'password': 'testpass', 'delete_sounds': 'delete_sounds'},
+            follow=True,
+        )
 
         # Test job is triggered
         data = json.dumps({'user_id': user.id, 'action': DELETE_USER_DELETE_SOUNDS_ACTION_NAME,
@@ -342,7 +344,7 @@ class UserDelete(TestCase):
         self.assertRedirects(resp, reverse('front-page'))
 
         # Check loaded page contains message about user deletion
-        self.assertContains(resp, 'Your user account will be deleted in a few moments', status_code=302)
+        self.assertContains(resp, 'Your user account will be deleted in a few moments')
 
     @mock.patch('general.tasks.delete_user.delay')
     def test_user_delete_keep_sounds_using_web_form(self, submit_job):
@@ -354,7 +356,9 @@ class UserDelete(TestCase):
         encr_link = form.initial['encrypted_link']
         resp = self.client.post(
             reverse('accounts-delete'),
-            {'encrypted_link': encr_link, 'password': 'testpass', 'delete_sounds': 'only_user'})
+            {'encrypted_link': encr_link, 'password': 'testpass', 'delete_sounds': 'only_user'},
+            follow=True,
+        )
 
         # Test job is triggered
         data = json.dumps({'user_id': user.id, 'action': DELETE_USER_KEEP_SOUNDS_ACTION_NAME,
@@ -370,7 +374,7 @@ class UserDelete(TestCase):
         self.assertRedirects(resp, reverse('front-page'))
 
         # Check loaded page contains message about user deletion
-        self.assertContains(resp, 'Your user account will be deleted in a few moments', status_code=302)
+        self.assertContains(resp, 'Your user account will be deleted in a few moments')
 
     def test_fail_user_delete_include_sounds_using_web_form(self):
         # Test delete user account form with wrong password does not delete

--- a/accounts/tests/test_user.py
+++ b/accounts/tests/test_user.py
@@ -342,7 +342,7 @@ class UserDelete(TestCase):
         self.assertRedirects(resp, reverse('front-page'))
 
         # Check loaded page contains message about user deletion
-        self.assertContains(resp, 'Your user account will be deleted in a few moments')
+        self.assertContains(resp, 'Your user account will be deleted in a few moments', status_code=302)
 
     @mock.patch('general.tasks.delete_user.delay')
     def test_user_delete_keep_sounds_using_web_form(self, submit_job):
@@ -370,7 +370,7 @@ class UserDelete(TestCase):
         self.assertRedirects(resp, reverse('front-page'))
 
         # Check loaded page contains message about user deletion
-        self.assertContains(resp, 'Your user account will be deleted in a few moments')
+        self.assertContains(resp, 'Your user account will be deleted in a few moments', status_code=302)
 
     def test_fail_user_delete_include_sounds_using_web_form(self):
         # Test delete user account form with wrong password does not delete

--- a/accounts/tests/test_views.py
+++ b/accounts/tests/test_views.py
@@ -141,7 +141,7 @@ class SimpleUserTest(TestCase):
         resp = self.client.get(reverse('accounts-download-attribution') + '?dl=txt')
         self.assertEqual(resp.status_code, 200)
         # response content as expected
-        self.assertEqual(resp.content,
+        self.assertContains(resp,
                          'P: {0} by {1} | License: {0}\nS: {2} by {3} | License: {4}\n'.format(
                              self.pack.name, self.user.username, self.sound.original_filename, self.user.username,
                              self.sound.license))

--- a/geotags/tests.py
+++ b/geotags/tests.py
@@ -79,7 +79,7 @@ class GeoTagsTests(TestCase):
         sound.save()
         resp = self.client.get(reverse('geotags-infowindow', kwargs={'sound_id': sound.id}))
         self.check_context(resp.context, {'sound': sound})
-        self.assertIn('href="/people/{0}/sounds/{1}/"'.format(sound.user.username, sound.id), resp.content)
+        self.assertContains(resp, 'href="/people/{0}/sounds/{1}/"'.format(sound.user.username, sound.id))
 
     def test_browse_geotags_case_insensitive(self):
         user = User.objects.get(username='Anton')

--- a/messages/tests/test_message_write.py
+++ b/messages/tests/test_message_write.py
@@ -52,12 +52,12 @@ class RecaptchaPresenceInMessageForms(TestCase):
         # Not a spammer case, recaptcha field should NOT be shown
         self.client.force_login(user=self.no_spammer)
         resp = self.client.get(reverse('messages-new'))
-        self.assertNotIn('recaptcha', resp.content)
+        self.assertNotContains(resp, 'recaptcha')
 
         # Potential spammer (has no uploaded sounds), recaptcha field should be shown
         self.client.force_login(user=self.potential_spammer)
         resp = self.client.get(reverse('messages-new'))
-        self.assertIn('recaptcha', resp.content)
+        self.assertContains(resp, 'recaptcha')
 
     def test_captcha_presence_in_reply_message_form(self):
 
@@ -67,7 +67,7 @@ class RecaptchaPresenceInMessageForms(TestCase):
             body=MessageBody.objects.create(body='Message body'), is_sent=True, is_archived=False, is_read=False)
         self.client.force_login(user=self.no_spammer)
         resp = self.client.get(reverse('messages-new', args=[message.id]))
-        self.assertNotIn('recaptcha', resp.content)
+        self.assertNotContains(resp, 'recaptcha')
 
         # Potential spammer (has no uploaded sounds), recaptcha field should be shown
         message = Message.objects.create(
@@ -75,7 +75,7 @@ class RecaptchaPresenceInMessageForms(TestCase):
             body=MessageBody.objects.create(body='Message body'), is_sent=True, is_archived=False, is_read=False)
         self.client.force_login(user=self.potential_spammer)
         resp = self.client.get(reverse('messages-new', args=[message.id]))
-        self.assertIn('recaptcha', resp.content)
+        self.assertContains(resp, 'recaptcha')
 
 
 class UsernameLookup(TestCase):

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -998,7 +998,7 @@ class SoundTemplateCacheTests(TestCase):
         self._test_add_remove_remixes(
             self._get_sound_view_footer_top_cache_keys(),
             '<a id="remixes_link"',
-            self._get_sound_view(),
+            self._get_sound_view,
         )
 
     def _test_state_change(self, cache_keys, change_state, texts):

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -706,9 +706,8 @@ class SoundTemplateCacheTests(TestCase):
 
         # Check that the information is updated properly
         resp = self._get_sound_view()
-        self.assertEqual(resp.status_code, 200)
-        self.assertInHTML(new_description, resp.content)
-        self.assertInHTML(new_name, resp.content)
+        self.assertContains(resp, new_description, html=True)
+        self.assertContains(resp, new_name, html=True)
 
     def _get_delete_comment_url(self, html):
         soup = BeautifulSoup(html, "html.parser")
@@ -723,8 +722,7 @@ class SoundTemplateCacheTests(TestCase):
 
         # Check the initial state (0 comments)
         resp = self._get_sound_from_home()
-        self.assertInHTML('0 comments', resp.content)
-        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, '0 comments', html=True)
         self._assertCachePresent(cache_keys)
 
         # Add comment
@@ -736,7 +734,7 @@ class SoundTemplateCacheTests(TestCase):
 
         # Verify that sound display has updated number of comments
         resp = self._get_sound_from_home()
-        self.assertInHTML('1 comment', resp.content)
+        self.assertContains(resp, '1 comment', html=True)
         self._assertCachePresent(cache_keys)
 
         # Delete the comment
@@ -746,7 +744,7 @@ class SoundTemplateCacheTests(TestCase):
 
         # Verify that sound display has no comments
         resp = self._get_sound_from_home()
-        self.assertInHTML('0 comments', resp.content)
+        self.assertContains(resp, '0 comments', html=True)
 
     # Downloads are only cached in display
     @mock.patch('sounds.views.sendfile', return_value=HttpResponse('Dummy response'))
@@ -758,8 +756,7 @@ class SoundTemplateCacheTests(TestCase):
         self.client.force_login(self.user)
 
         resp = self._get_sound_from_home()
-        self.assertInHTML('0 downloads', resp.content)
-        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, '0 downloads', html=True)
         self._assertCachePresent(cache_keys)
 
         # Download
@@ -772,11 +769,11 @@ class SoundTemplateCacheTests(TestCase):
 
         # Verify that sound display has updated number of downloads
         resp = self._get_sound_from_home()
-        self.assertInHTML('1 download', resp.content)
+        self.assertContains(resp, '1 download', html=True)
 
     # Similarity link (cached in display and view)
     @mock.patch('general.management.commands.similarity_update.Similarity.add', return_value='Dummy response')
-    def _test_similarity_update(self, cache_keys, check_present, similarity_add):
+    def _test_similarity_update(self, cache_keys, expected, request_func, similarity_add):
         # Create a SoundAnalysis object with status OK so "similarity_update" command will pick it up
         SoundAnalysis.objects.create(sound=self.sound, analyzer=settings.FREESOUND_ESSENTIA_EXTRACTOR_NAME, analysis_status="OK")
         self.sound.save()
@@ -787,7 +784,7 @@ class SoundTemplateCacheTests(TestCase):
 
         # Initial check
         self.assertEqual(self.sound.similarity_state, 'PE')
-        self.assertFalse(check_present())
+        self.assertNotContains(request_func(), expected)
         self._assertCachePresent(cache_keys)
 
         # Update similarity
@@ -798,26 +795,30 @@ class SoundTemplateCacheTests(TestCase):
         # Check similarity icon
         self.sound.refresh_from_db()
         self.assertEqual(self.sound.similarity_state, 'OK')
-        self.assertTrue(check_present())
+        self.assertContains(request_func(), expected)
 
     def test_similarity_update_display(self):
         self._test_similarity_update(
             self._get_sound_display_cache_keys(),
-            lambda: '<a class="similar"' in self._get_sound_from_home().content)
+            '<a class="similar"',
+            self._get_sound_from_home,
+        )
 
     def test_similarity_update_view(self):
         self._test_similarity_update(
             self._get_sound_view_footer_top_cache_keys(),
-            lambda: '<a id="similar_sounds_link"' in self._get_sound_view().content)
+            '<a id="similar_sounds_link"',
+            self._get_sound_view,
+        )
 
     # Pack link (cached in display and view)
-    def _test_add_remove_pack(self, cache_keys, check_present):
+    def _test_add_remove_pack(self, cache_keys, text, request_func):
         self._assertCacheAbsent(cache_keys)
 
         self.client.force_login(self.user)
 
         self.assertIsNone(self.sound.pack)
-        self.assertFalse(check_present())
+        self.assertNotContains(request_func(), text)
         self._assertCachePresent(cache_keys)
 
         # Add sound to pack
@@ -831,7 +832,7 @@ class SoundTemplateCacheTests(TestCase):
         # Check pack icon
         self.sound.refresh_from_db()
         self.assertIsNotNone(self.sound.pack)
-        self.assertTrue(check_present())  # check_present should render the template
+        self.assertContains(request_func(), text)  # request_func should render the template
         self._assertCachePresent(cache_keys)
 
         # Remove sound from pack
@@ -844,28 +845,30 @@ class SoundTemplateCacheTests(TestCase):
         # Check pack icon being absent
         self.sound.refresh_from_db()
         self.assertIsNone(self.sound.pack)
-        self.assertFalse(check_present())
+        self.assertNotContains(request_func(), text)
 
     def test_add_remove_pack_display(self):
         self._test_add_remove_pack(
             self._get_sound_display_cache_keys(),
-            lambda: '<a class="pack"' in self._get_sound_from_home().content
+            '<a class="pack"',
+            self._get_sound_from_home,
         )
 
     def test_add_remove_pack_view(self):
         self._test_add_remove_pack(
             self._get_sound_view_footer_top_cache_keys(),
-            lambda: '<a id="pack_link"' in self._get_sound_view().content
+            '<a id="pack_link"',
+            self._get_sound_view,
         )
 
     # Geotag link (cached in display and view)
-    def _test_add_remove_geotag(self, cache_keys, check_present):
+    def _test_add_remove_geotag(self, cache_keys, text, request_func):
         self._assertCacheAbsent(cache_keys)
 
         self.client.force_login(self.user)
 
         self.assertIsNone(self.sound.geotag)
-        self.assertFalse(check_present())
+        self.assertNotContains(request_func(), text)
         self._assertCachePresent(cache_keys)
 
         # Add a geotag to the sound
@@ -880,7 +883,7 @@ class SoundTemplateCacheTests(TestCase):
         # Check geotag icon
         self.sound.refresh_from_db()
         self.assertIsNotNone(self.sound.geotag)
-        self.assertTrue(check_present())
+        self.assertContains(request_func(), text)
         self._assertCachePresent(cache_keys)
 
         # Remove geotag from the sound
@@ -893,18 +896,20 @@ class SoundTemplateCacheTests(TestCase):
         # Check geotag icon being absent
         self.sound.refresh_from_db()
         self.assertIsNone(self.sound.geotag)
-        self.assertFalse(check_present())
+        self.assertNotContains(request_func(), text)
 
     def test_add_remove_geotag_display(self):
         self._test_add_remove_geotag(
             self._get_sound_display_cache_keys(),
-            lambda: '<a class="geotag"' in self._get_sound_from_home().content
+            '<a class="geotag"',
+            self._get_sound_from_home,
         )
 
     def test_add_remove_geotag_view(self):
         self._test_add_remove_geotag(
             self._get_sound_view_footer_top_cache_keys(),
-            lambda: '<a id="geotag_link"' in self._get_sound_view().content
+            '<a id="geotag_link"',
+            self._get_sound_view,
         )
 
     # Changing license
@@ -944,7 +949,7 @@ class SoundTemplateCacheTests(TestCase):
             self._get_sound_view,
         )
 
-    def _test_add_remove_remixes(self, cache_keys, check_present):
+    def _test_add_remove_remixes(self, cache_keys, text, request_func):
         _, _, sounds = create_user_and_sounds(num_sounds=1, user=self.user)
         another_sound = sounds[0]
         self._assertCacheAbsent(cache_keys)
@@ -952,7 +957,7 @@ class SoundTemplateCacheTests(TestCase):
         self.client.force_login(self.user)
 
         self.assertEqual(self.sound.remix_group.count(), 0)
-        self.assertFalse(check_present())
+        self.assertNotContains(request_func(), text)
         self._assertCachePresent(cache_keys)
 
         # Indicate another sound as source
@@ -966,7 +971,7 @@ class SoundTemplateCacheTests(TestCase):
         # Check remix icon
         self.sound.refresh_from_db()
         self.assertEqual(self.sound.remix_group.count(), 1)
-        self.assertTrue(check_present())
+        self.assertContains(request_func(), text)
         self._assertCachePresent(cache_keys)
 
         # Remove remix from the sound
@@ -980,33 +985,39 @@ class SoundTemplateCacheTests(TestCase):
         # Check remix icon being absent
         self.sound.refresh_from_db()
         self.assertEqual(self.sound.remix_group.count(), 0)
-        self.assertFalse(check_present())
+        self.assertNotContains(request_func(), text)
 
     def test_add_remove_remixes_display(self):
         self._test_add_remove_remixes(
             self._get_sound_display_cache_keys(),
-            lambda: '<a class="remixes"' in self._get_sound_from_home().content
+            '<a class="remixes"',
+            self._get_sound_from_home,
         )
 
     def test_add_remove_remixes_view(self):
         self._test_add_remove_remixes(
             self._get_sound_view_footer_top_cache_keys(),
-            lambda: '<a id="remixes_link"' in self._get_sound_view().content
+            '<a id="remixes_link"',
+            self._get_sound_view(),
         )
 
-    def _test_state_change(self, cache_keys, change_state, check_present):
+    def _test_state_change(self, cache_keys, change_state, texts):
         """@:param check_present - function that checks presence of indication of not 'OK' state"""
         self.client.force_login(self.user)
 
         self._assertCacheAbsent(cache_keys)
-        self.assertTrue(check_present())
+        resp = self.client.get(self._get_sound_url('sound-display'))
+        for text in texts:
+            self.assertContains(resp, text)
         self._assertCachePresent(cache_keys)
 
         # Change processing state
         change_state()
 
         self._assertCacheAbsent(cache_keys)
-        self.assertFalse(check_present())
+        resp = self.client.get(self._get_sound_url('sound-display'))
+        for text in texts:
+            self.assertNotContains(resp, text)
         self._assertCachePresent(cache_keys)
 
     def test_processing_state_change_display(self):
@@ -1014,8 +1025,7 @@ class SoundTemplateCacheTests(TestCase):
         self._test_state_change(
             self._get_sound_display_cache_keys(),
             lambda: self.sound.change_processing_state('OK'),
-            lambda: all([text in self.client.get(self._get_sound_url('sound-display')).content
-                         for text in ['Processing state:', 'Pending']])
+            ['Processing state:', 'Pending'],
         )
 
     def test_moderation_state_change_display(self):
@@ -1023,8 +1033,7 @@ class SoundTemplateCacheTests(TestCase):
         self._test_state_change(
             self._get_sound_display_cache_keys(),
             lambda: self.sound.change_moderation_state('OK'),
-            lambda: all([text in self.client.get(self._get_sound_url('sound-display')).content
-                         for text in ['Moderation state:', 'Pending']])
+            ['Moderation state:', 'Pending'],
         )
 
 


### PR DESCRIPTION
**Issue(s)**
#1083 

**Description**
Response content is encoded in bytes. In Python3 it cannot be compared directly to strings.
Switch tests to `assertContains` as suggested in
https://docs.djangoproject.com/en/1.11/topics/python3/#httprequest-and-httpresponse-objects

**Deployment steps**:
None
