### PR TITLE
use django default_token_generator instead of self-made token for account activation

### DIFF
--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -89,7 +89,7 @@ class FsClientIdGenerator(BaseHashGenerator):
 def get_view_description(cls, html=False):
     description = ''
     if getattr(cls, 'get_description', None):
-        cache_key = create_hash(cls.get_view_name(), add_secret=False, limit=32)
+        cache_key = create_hash(cls.get_view_name(), limit=32)
         cached_description = cache.get(cache_key)
         if not cached_description:
             description = cls.get_description()

--- a/clustering/interface.py
+++ b/clustering/interface.py
@@ -110,4 +110,4 @@ def cluster_sound_results(request, features=DEFAULT_FEATURES):
 
 
 def hash_cache_key(key):
-    return create_hash(key, add_secret=False, limit=32)
+    return create_hash(key, limit=32)

--- a/templates/accounts/activate.html
+++ b/templates/accounts/activate.html
@@ -14,7 +14,8 @@
     {% endif %}
 
     {% if decode_error %}
-    <p>We're sorry but we can't find that activation key in the database. Try copy-pasting the link that we sent you instead of clicking it...</p>
+    <p>We're sorry, but we can't find that activation key in the database. It might have expired.</p>
+    <p>Have you tried to log in? You can also try copy-pasting the link that we sent you instead of clicking it...</p>
     {% endif %}
 {% endif %}
 {% endblock %}

--- a/templates/accounts/email_activation.txt
+++ b/templates/accounts/email_activation.txt
@@ -11,5 +11,7 @@ In order to activate your Freesound account, please click this link:
 
 {% absurl 'accounts-activate' username hash %}
 
+The link is only valid for {{ settings.PASSWORD_RESET_TIMEOUT_DAYS }} days.
+
 If for some reason this fails, try copy-pasting the complete link into you browser. Some mail clients break up long lines, or do strange things to URLs!
 {% endblock %}

--- a/utils/encryption.py
+++ b/utils/encryption.py
@@ -21,7 +21,7 @@
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str
-from django.conf import settings
+import hashlib
 
 from django.core.signing import TimestampSigner
 
@@ -39,11 +39,6 @@ def unsign_with_timestamp(unsigned_value, signed_value, max_age):
     return value
 
 
-def create_hash(data, add_secret=True, limit=8):
-    import hashlib
-    m = hashlib.md5()
-    if add_secret:
-        m.update(str(data) + settings.SECRET_KEY)
-    else:
-        m.update(str(data))
+def create_hash(data, limit=8):
+    m = hashlib.md5(str(data).encode())
     return m.hexdigest()[0:limit]

--- a/utils/similarity_utilities.py
+++ b/utils/similarity_utilities.py
@@ -167,4 +167,4 @@ def delete_sound_from_gaia(sound_id):
 
 
 def hash_cache_key(key):
-    return create_hash(key, add_secret=False, limit=32)
+    return create_hash(key, limit=32)


### PR DESCRIPTION
**Issue(s)**
Closes #1644 

**Description**
use django default_token_generator instead of self-made token

this changes the behaviour of the app since now a token will expire
while before a token was valid "forever"

**Deployment steps**:
This will impact users that started a sign up before the deployment and want to finish it in the new deployment. 
