### PR TITLE
Replace slugify with Django slugify

### DIFF
--- a/forum/models.py
+++ b/forum/models.py
@@ -40,7 +40,7 @@ from general.models import OrderedModel
 from utils.cache import invalidate_template_cache
 from utils.search import SearchEngineException, get_search_engine
 from utils.search.search_forum import delete_posts_from_search_engine
-from utils.text import slugify
+from django.utils.text import slugify
 
 web_logger = logging.getLogger('web')
 

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -51,7 +51,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.encoding import smart_text
 from django.utils.functional import cached_property
-from django.utils.text import Truncator
+from django.utils.text import Truncator, slugify
 
 import accounts.models
 from apiv2.models import ApiV2Client
@@ -71,7 +71,6 @@ from utils.search import get_search_engine, SearchEngineException
 from utils.search.search_sounds import delete_sounds_from_search_engine
 from utils.similarity_utilities import delete_sound_from_gaia
 from utils.sound_upload import get_csv_lines, validate_input_csv_file, bulk_describe_from_csv
-from utils.text import slugify
 
 web_logger = logging.getLogger('web')
 sounds_logger = logging.getLogger('sounds')
@@ -1459,7 +1458,7 @@ class Pack(SocialModel):
 
     def friendly_filename(self):
         name_slug = slugify(self.name)
-        username_slug =  slugify(self.user.username)
+        username_slug = slugify(self.user.username)
         return "%d__%s__%s.zip" % (self.id, username_slug, name_slug)
 
     def process(self):

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -35,6 +35,7 @@ from django.apps import apps
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import User
 from django.urls import reverse
+from django.utils.text import slugify
 
 from geotags.models import GeoTag
 from utils.audioprocessing import get_sound_type
@@ -42,7 +43,7 @@ from utils.cache import invalidate_user_template_caches
 from utils.filesystem import md5file, remove_directory_if_empty, create_directories
 from utils.mirror_files import copy_sound_to_mirror_locations, remove_empty_user_directory_from_mirror_locations, \
     remove_uploaded_file_from_mirror_locations
-from utils.text import slugify, remove_control_chars
+from utils.text import remove_control_chars
 
 console_logger = logging.getLogger('console')
 sounds_logger = logging.getLogger('sounds')

--- a/utils/tests/test_text.py
+++ b/utils/tests/test_text.py
@@ -19,9 +19,11 @@
 #     See AUTHORS file.
 #
 
+from __future__ import unicode_literals
+
 from django.test import TestCase
 
-from utils.text import clean_html, is_shouting, text_may_be_spam, remove_control_chars
+from utils.text import clean_html, is_shouting, text_may_be_spam, remove_control_chars, slugify
 
 
 class TextUtilTest(TestCase):
@@ -62,6 +64,35 @@ class TextUtilTest(TestCase):
         self.assertEqual(remove_control_chars(text), "text with \n newline")
         text = "text with control\x08char"
         self.assertEqual(remove_control_chars(text), "text with controlchar")
+
+
+class SlugifyTest(TestCase):
+
+    def test_slugify(self):
+        self.assertEqual("voice-gong", slugify("voice-gong"))
+        self.assertEqual("voice-gong", slugify("voice---gong"))
+        self.assertEqual("voice-gong", slugify("---voice---gong--"))
+        self.assertEqual("abcabcabc", slugify("abcABCabc"))
+
+        expected = "roomy-remix-of-otherperson-s-freesound-12345"
+        result = slugify("roomy remix of otherperson's freesound #12345")
+        self.assertEqual(expected, result)
+        result = slugify("roomy remix of otherperson&#x27;s freesound #12345")
+        self.assertEqual(expected, result)
+
+        self.assertEqual("glass-a-ff", slugify("Glass A# ff"))
+        self.assertEqual(
+            "gesprekken-stoel-kraak-lachen-bij-tim",
+            slugify("gesprekken stoel kraak lachen bij tim")
+        )
+        self.assertEqual(
+            "der-gerauschedetektiv-wav",
+            slugify("Der Geräuschedetektiv.wav")
+        )
+        self.assertEqual(
+            "tham-c-019",
+            slugify("Tham_C_019")
+        )
 
 
 class CleanHtmlTest(TestCase):

--- a/utils/tests/test_text.py
+++ b/utils/tests/test_text.py
@@ -23,7 +23,7 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 
-from utils.text import clean_html, is_shouting, text_may_be_spam, remove_control_chars, slugify
+from utils.text import clean_html, is_shouting, text_may_be_spam, remove_control_chars
 
 
 class TextUtilTest(TestCase):
@@ -64,35 +64,6 @@ class TextUtilTest(TestCase):
         self.assertEqual(remove_control_chars(text), "text with \n newline")
         text = "text with control\x08char"
         self.assertEqual(remove_control_chars(text), "text with controlchar")
-
-
-class SlugifyTest(TestCase):
-
-    def test_slugify(self):
-        self.assertEqual("voice-gong", slugify("voice-gong"))
-        self.assertEqual("voice-gong", slugify("voice---gong"))
-        self.assertEqual("voice-gong", slugify("---voice---gong--"))
-        self.assertEqual("abcabcabc", slugify("abcABCabc"))
-
-        expected = "roomy-remix-of-otherperson-s-freesound-12345"
-        result = slugify("roomy remix of otherperson's freesound #12345")
-        self.assertEqual(expected, result)
-        result = slugify("roomy remix of otherperson&#x27;s freesound #12345")
-        self.assertEqual(expected, result)
-
-        self.assertEqual("glass-a-ff", slugify("Glass A# ff"))
-        self.assertEqual(
-            "gesprekken-stoel-kraak-lachen-bij-tim",
-            slugify("gesprekken stoel kraak lachen bij tim")
-        )
-        self.assertEqual(
-            "der-gerauschedetektiv-wav",
-            slugify("Der Geräuschedetektiv.wav")
-        )
-        self.assertEqual(
-            "tham-c-019",
-            slugify("Tham_C_019")
-        )
 
 
 class CleanHtmlTest(TestCase):

--- a/utils/text.py
+++ b/utils/text.py
@@ -20,52 +20,14 @@
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import chr
 import re
-import unicodedata
 from functools import partial
-from html.entities import name2codepoint
 
 import bleach
 from bleach.html5lib_shim import Filter
-from django.utils.encoding import smart_text
 
 from sounds.templatetags.sound_signature import SOUND_SIGNATURE_SOUND_ID_PLACEHOLDER, \
     SOUND_SIGNATURE_SOUND_URL_PLACEHOLDER
-
-
-
-def slugify(s):
-    """ slugify with character translation which translates foreign characters to regular ascii equivalents """
-    s = smart_text(s)
-
-    #  character entity reference
-    s = re.sub(r'&(%s);' % '|'.join(name2codepoint), lambda m: chr(name2codepoint[m.group(1)]), s)
-
-    #  decimal character reference
-    try:
-        s = re.sub(r'&#(\d+);', lambda m: chr(int(m.group(1))), s)
-    except:
-        pass
-
-    #  hexadecimal character reference
-    try:
-        s = re.sub(r'&#x([\da-fA-F]+);', lambda m: chr(int(m.group(1), 16)), s)
-    except:
-        pass
-
-    #  translate
-    s = unicodedata.normalize('NFKD', s).encode('ascii', 'ignore')
-
-    #  replace unwanted characters
-    s = re.sub(r'[^-a-z0-9]+', '-', s.lower())
-
-    #  remove redundant -
-    s = re.sub('-{2,}', '-', s).strip('-')
-
-    slug = s
-
-    return slug.lower()
 
 
 def shout_percentage(string):

--- a/utils/text.py
+++ b/utils/text.py
@@ -34,27 +34,25 @@ from sounds.templatetags.sound_signature import SOUND_SIGNATURE_SOUND_ID_PLACEHO
     SOUND_SIGNATURE_SOUND_URL_PLACEHOLDER
 
 
-def slugify(s, entities=True, decimal=True, hexadecimal=True, instance=None, slug_field='slug', filter_dict=None):
+
+def slugify(s):
     """ slugify with character translation which translates foreign characters to regular ascii equivalents """
     s = smart_text(s)
 
     #  character entity reference
-    if entities:
-        s = re.sub(r'&(%s);' % '|'.join(name2codepoint), lambda m: chr(name2codepoint[m.group(1)]), s)
+    s = re.sub(r'&(%s);' % '|'.join(name2codepoint), lambda m: chr(name2codepoint[m.group(1)]), s)
 
     #  decimal character reference
-    if decimal:
-        try:
-            s = re.sub(r'&#(\d+);', lambda m: chr(int(m.group(1))), s)
-        except:
-            pass
+    try:
+        s = re.sub(r'&#(\d+);', lambda m: chr(int(m.group(1))), s)
+    except:
+        pass
 
     #  hexadecimal character reference
-    if hexadecimal:
-        try:
-            s = re.sub(r'&#x([\da-fA-F]+);', lambda m: chr(int(m.group(1), 16)), s)
-        except:
-            pass
+    try:
+        s = re.sub(r'&#x([\da-fA-F]+);', lambda m: chr(int(m.group(1), 16)), s)
+    except:
+        pass
 
     #  translate
     s = unicodedata.normalize('NFKD', s).encode('ascii', 'ignore')
@@ -66,19 +64,6 @@ def slugify(s, entities=True, decimal=True, hexadecimal=True, instance=None, slu
     s = re.sub('-{2,}', '-', s).strip('-')
 
     slug = s
-
-    if instance:
-        def get_query():
-            query = instance.__class__.objects.filter(**{slug_field: slug})
-            if filter_dict:
-                query = query.filter(**filter_dict)
-            if instance.pk:
-                query = query.exclude(pk=instance.pk)
-            return query
-        counter = 1
-        while get_query():
-            slug = "%s-%s" % (s, counter)
-            counter += 1
 
     return slug.lower()
 


### PR DESCRIPTION
**Issue(s)**
#1083 

**Description**
Our own `slugify` was introduced before Django introduced its own. Now with the change of str/bytes separation in Py3 it might be easier to switch to Django `utils.text.slugify`

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
