### PR TITLE
Remove filesystem backports

### DIFF
--- a/accounts/management/commands/process_email_bounces.py
+++ b/accounts/management/commands/process_email_bounces.py
@@ -25,7 +25,6 @@ from django.db import IntegrityError
 from accounts.models import EmailBounce
 
 from utils.aws import init_client, AwsCredentialsNotConfigured
-from utils.filesystem import create_directories
 from utils.management_commands import LoggingBaseCommand
 from botocore.exceptions import EndpointConnectionError
 
@@ -59,7 +58,7 @@ def process_message(data):
 
 def create_dump_file():
     path = os.path.join(settings.DATA_PATH, 'bounced_emails')
-    create_directories(path)
+    os.makedirs(path, exist_ok=True)
     return os.path.join(path, time.strftime('%Y%m%d_%H%M') + '.json')
 
 
@@ -170,4 +169,3 @@ class Command(LoggingBaseCommand):
 
         result = {'n_mails_bounced': total_messages, 'n_bounces': total_bounces}
         self.log_end(result)
-

--- a/accounts/tests/test_upload.py
+++ b/accounts/tests/test_upload.py
@@ -33,7 +33,7 @@ from django.urls import reverse
 
 from sounds.models import License, Sound, Pack, BulkUploadProgress
 from tags.models import Tag
-from utils.filesystem import File, create_directories
+from utils.filesystem import File
 from utils.test_helpers import create_test_files, override_uploads_path_with_temp_directory, \
     override_csv_path_with_temp_directory, create_user_and_sounds, test_using_bw_ui
 
@@ -69,7 +69,7 @@ class UserUploadAndDescribeSounds(TestCase):
         user = User.objects.create_user("testuser", password="testpass")
         self.client.force_login(user)
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        create_directories(user_upload_path)
+        os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(filenames, user_upload_path)
 
         # Check that files are displayed in the template
@@ -126,7 +126,7 @@ class UserUploadAndDescribeSounds(TestCase):
         user.profile.save()
         self.client.force_login(user)
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        create_directories(user_upload_path)
+        os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(filenames, user_upload_path)
 
         # Set license and pack data in session
@@ -183,7 +183,7 @@ class UserUploadAndDescribeSounds(TestCase):
         user = User.objects.create_user("testuser", email="1@xmpl.com", password="testpass")
         self.client.force_login(user)
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        create_directories(user_upload_path)
+        os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(filenames, user_upload_path)
         _, _, sound_sources = create_user_and_sounds(
             num_sounds=3, num_packs=0, 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -80,7 +80,7 @@ from sounds.models import Sound, Pack, Download, SoundLicenseHistory, BulkUpload
 from sounds.views import edit_and_describe_sounds_helper, clear_session_edit_and_describe_data
 from utils.cache import invalidate_user_template_caches
 from utils.dbtime import DBTime
-from utils.filesystem import generate_tree, remove_directory_if_empty, create_directories
+from utils.filesystem import generate_tree, remove_directory_if_empty
 from utils.frontend_handling import render, using_beastwhoosh, redirect_if_beastwhoosh
 from utils.images import extract_square
 from utils.logging_filters import get_client_ip
@@ -586,7 +586,7 @@ def edit(request):
 @transaction.atomic()
 def handle_uploaded_image(profile, f):
     upload_logger.info("\thandling profile image upload")
-    create_directories(os.path.dirname(profile.locations("avatar.L.path")), exist_ok=True)
+    os.makedirs(os.path.dirname(profile.locations("avatar.L.path")), exist_ok=True)
 
     ext = os.path.splitext(os.path.basename(f.name))[1]
     tmp_image_path = tempfile.mktemp(suffix=ext, prefix=str(profile.user.id))
@@ -659,7 +659,7 @@ def describe(request):
         csv_form = BulkDescribeForm(request.POST, request.FILES, prefix='bulk')
         if csv_form.is_valid():
             directory = os.path.join(settings.CSV_PATH, str(request.user.id))
-            create_directories(directory, exist_ok=True)
+            os.makedirs(directory, exist_ok=True)
             extension = csv_form.cleaned_data['csv_file'].name.rsplit('.', 1)[-1].lower()
             new_csv_filename = str(uuid.uuid4()) + '.%s' % extension
             path = os.path.join(directory, new_csv_filename)
@@ -1245,7 +1245,7 @@ def account(request, username):
 def handle_uploaded_file(user_id, f):
     # Move or copy the uploaded file from the temporary folder created by Django to the /uploads path
     dest_directory = os.path.join(settings.UPLOADS_PATH, str(user_id))
-    create_directories(dest_directory, exist_ok=True)
+    os.makedirs(dest_directory, exist_ok=True)
     dest_path = os.path.join(dest_directory, os.path.basename(f.name)).encode("utf-8")
     upload_logger.info("handling file upload and saving to {}".format(dest_path))
     starttime = time.time()

--- a/general/apps.py
+++ b/general/apps.py
@@ -1,6 +1,7 @@
+import os
+
 from django.apps import AppConfig
 from django.conf import settings
-from utils.filesystem import create_directories
 
 
 class GeneralConfig(AppConfig):
@@ -11,15 +12,15 @@ class GeneralConfig(AppConfig):
         Create the folders (if not already existing) for the base data directory and all needed subdirecotries.
         This code is run here as we want to run it at Django startup.
         """
-        create_directories(settings.DATA_PATH)
-        create_directories(settings.AVATARS_PATH)
-        create_directories(settings.PREVIEWS_PATH)
-        create_directories(settings.DISPLAYS_PATH)
-        create_directories(settings.SOUNDS_PATH)
-        create_directories(settings.PACKS_PATH)
-        create_directories(settings.UPLOADS_PATH)
-        create_directories(settings.CSV_PATH)
-        create_directories(settings.ANALYSIS_PATH)
-        create_directories(settings.FILE_UPLOAD_TEMP_DIR)
-        create_directories(settings.PROCESSING_TEMP_DIR)
-        create_directories(settings.PROCESSING_BEFORE_DESCRIPTION_DIR)
+        os.makedirs(settings.DATA_PATH, exist_ok=True)
+        os.makedirs(settings.AVATARS_PATH, exist_ok=True)
+        os.makedirs(settings.PREVIEWS_PATH, exist_ok=True)
+        os.makedirs(settings.DISPLAYS_PATH, exist_ok=True)
+        os.makedirs(settings.SOUNDS_PATH, exist_ok=True)
+        os.makedirs(settings.PACKS_PATH, exist_ok=True)
+        os.makedirs(settings.UPLOADS_PATH, exist_ok=True)
+        os.makedirs(settings.CSV_PATH, exist_ok=True)
+        os.makedirs(settings.ANALYSIS_PATH, exist_ok=True)
+        os.makedirs(settings.FILE_UPLOAD_TEMP_DIR, exist_ok=True)
+        os.makedirs(settings.PROCESSING_TEMP_DIR, exist_ok=True)
+        os.makedirs(settings.PROCESSING_BEFORE_DESCRIPTION_DIR, exist_ok=True)

--- a/sounds/management.py
+++ b/sounds/management.py
@@ -26,8 +26,6 @@ from django.db.models.signals import post_syncdb
 from django.dispatch import receiver
 from django.conf import settings
 
-from utils.filesystem import create_directories
-
 
 @receiver(post_syncdb)
 def create_locations(sender, **kwargs):
@@ -39,6 +37,6 @@ def create_locations(sender, **kwargs):
                    settings.DISPLAYS_PATH,
                    settings.FILE_UPLOAD_TEMP_DIR]:
         if not os.path.isdir(folder):
-            create_directories(folder, exist_ok=True)
+            os.makedirs(folder, exist_ok=True)
         else:
             print ("Folder: '%s' already exists" % folder)

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -48,7 +48,6 @@ from sounds.models import Download, PackDownload, PackDownloadSound, SoundAnalys
 from sounds.models import Pack, Sound, License, DeletedSound
 from utils.cache import get_template_cache_key
 from utils.encryption import sign_with_timestamp
-from utils.filesystem import create_directories
 from utils.test_helpers import create_user_and_sounds, override_analysis_path_with_temp_directory, test_using_bw_ui
 
 
@@ -1100,7 +1099,7 @@ class SoundAnalysisModel(TestCase):
         # Now create an analysis object which stores output in a JSON file. Again check that get_analysis works.
         analysis_filename = '%i-TestExtractor2.json' % sound.id
         sound_analysis_folder = os.path.join(settings.ANALYSIS_PATH, str(old_div(sound.id, 1000)))
-        create_directories(sound_analysis_folder)
+        os.makedirs(sound_analysis_folder, exist_ok=True)
         json.dump(analysis_data, open(os.path.join(sound_analysis_folder, analysis_filename), 'w'))
         sa2 = SoundAnalysis.objects.create(sound=sound, analyzer="TestExtractor2", analysis_status="OK")
         self.assertEqual(sound.analyses.all().count(), 2)

--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -36,7 +36,6 @@ from django.conf import settings
 from . import color_schemes
 import utils.audioprocessing.processing as audioprocessing
 from utils.audioprocessing.processing import AudioProcessingException
-from utils.filesystem import create_directories
 from tempfile import TemporaryDirectory
 from utils.mirror_files import copy_previews_to_mirror_locations, copy_displays_to_mirror_locations
 from utils.sound_upload import get_processing_before_describe_sound_folder
@@ -276,7 +275,7 @@ class FreesoundAudioProcessor(FreesoundAudioProcessorBase):
                 # Create directory to store previews (if it does not exist)
                 # Same directory is used for all MP3 and OGG previews of a given sound so we only need to run this once
                 try:
-                    create_directories(os.path.dirname(self.sound.locations("preview.LQ.mp3.path")))
+                    os.makedirs(os.path.dirname(self.sound.locations("preview.LQ.mp3.path")), exist_ok=True)
                 except OSError:
                     self.set_failure("could not create directory for previews")
                     return False
@@ -322,7 +321,7 @@ class FreesoundAudioProcessor(FreesoundAudioProcessorBase):
                 # Create directory to store display images (if it does not exist)
                 # Same directory is used for all displays of a given sound so we only need to run this once
                 try:
-                    create_directories(os.path.dirname(self.sound.locations("display.wave.M.path")))
+                    os.makedirs(os.path.dirname(self.sound.locations("display.wave.M.path")), exist_ok=True)
                 except OSError:
                     self.set_failure("could not create directory for displays")
                     return False
@@ -371,7 +370,7 @@ class FreesoundAudioProcessorBeforeDescription(FreesoundAudioProcessorBase):
         self.output_preview_mp3 = os.path.join(self.output_folder, 'preview.mp3')
         self.output_preview_ogg = os.path.join(self.output_folder, 'preview.ogg')
         self.output_info_file = os.path.join(self.output_folder, 'info.json')
-        create_directories(os.path.dirname(self.output_preview_ogg))
+        os.makedirs(os.path.dirname(self.output_preview_ogg), exist_ok=True)
 
     def log_info(self, message):
         console_logger.info("{} - {}".format(self.audio_file_path, message))

--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -36,7 +36,8 @@ from django.conf import settings
 from . import color_schemes
 import utils.audioprocessing.processing as audioprocessing
 from utils.audioprocessing.processing import AudioProcessingException
-from utils.filesystem import create_directories, TemporaryDirectory
+from utils.filesystem import create_directories
+from tempfile import TemporaryDirectory
 from utils.mirror_files import copy_previews_to_mirror_locations, copy_displays_to_mirror_locations
 from utils.sound_upload import get_processing_before_describe_sound_folder
 

--- a/utils/filesystem.py
+++ b/utils/filesystem.py
@@ -21,17 +21,12 @@
 from __future__ import print_function
 
 from builtins import hex
-from builtins import str as new_str
-from builtins import bytes
 from builtins import object
 import errno
 import hashlib
 import os
 import shutil
-import sys
-import warnings
 import zlib
-from tempfile import mkdtemp
 
 
 class File(object):
@@ -121,90 +116,3 @@ def create_directories(path, exist_ok=True):
         # Ignore exception if directory already existing
         if exist_ok and exc.errno != errno.EEXIST:
             raise
-
-
-class TemporaryDirectory(object):
-
-    """Create and return a temporary directory.  This has the same
-    behavior as mkdtemp but can be used as a context manager.  For
-    example:
-
-        with TemporaryDirectory() as tmpdir:
-            ...
-
-    Upon exiting the context, the directory and everything contained
-    in it are removed.
-
-    This is a backport of tempfile.TemporaryDirectory() which is only available in Python 3.2+. Code has been coppied
-    from this post: https://stackoverflow.com/questions/19296146/tempfile-temporarydirectory-context-manager-in-python-2-7
-    Once migrating to Python 3, we can remove this code and use the default implementation in tempfile package.
-    """
-
-    def __init__(self, suffix="", prefix="tmp", dir=None):
-        self._closed = False
-        self.name = None  # Handle mkdtemp raising an exception
-        self.name = mkdtemp(suffix, prefix, dir)
-
-    def __repr__(self):
-        return "<{} {!r}>".format(self.__class__.__name__, self.name)
-
-    def __enter__(self):
-        return self.name
-
-    def cleanup(self, _warn=False):
-        if self.name and not self._closed:
-            try:
-                self._rmtree(self.name)
-            except (TypeError, AttributeError) as ex:
-                # Issue #10188: Emit a warning on stderr
-                # if the directory could not be cleaned
-                # up due to missing globals
-                if "None" not in new_str(ex):
-                    raise
-                print("ERROR: {!r} while cleaning up {!r}".format(ex, self, ),
-                      file=sys.stderr)
-                return
-            self._closed = True
-            if _warn:
-                self._warn("Implicitly cleaning up {!r}".format(self),
-                           ResourceWarning)
-
-    def __exit__(self, exc, value, tb):
-        self.cleanup()
-
-    def __del__(self):
-        # Issue a ResourceWarning if implicit cleanup needed
-        self.cleanup(_warn=True)
-
-    # XXX (ncoghlan): The following code attempts to make
-    # this class tolerant of the module nulling out process
-    # that happens during CPython interpreter shutdown
-    # Alas, it doesn't actually manage it. See issue #10188
-    _listdir = staticmethod(os.listdir)
-    _path_join = staticmethod(os.path.join)
-    _isdir = staticmethod(os.path.isdir)
-    _islink = staticmethod(os.path.islink)
-    _remove = staticmethod(os.remove)
-    _rmdir = staticmethod(os.rmdir)
-    _warn = warnings.warn
-
-    def _rmtree(self, path):
-        # Essentially a stripped down version of shutil.rmtree.  We can't
-        # use globals because they may be None'ed out at shutdown.
-        for name in self._listdir(path):
-            fullname = self._path_join(path, name)
-            try:
-                isdir = self._isdir(fullname) and not self._islink(fullname)
-            except OSError:
-                isdir = False
-            if isdir:
-                self._rmtree(fullname)
-            else:
-                try:
-                    self._remove(fullname)
-                except OSError:
-                    pass
-        try:
-            self._rmdir(path)
-        except OSError:
-            pass

--- a/utils/filesystem.py
+++ b/utils/filesystem.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 from builtins import hex
 from builtins import object
-import errno
 import hashlib
 import os
 import shutil
@@ -100,19 +99,3 @@ def remove_directory(path):
 def remove_directory_if_empty(path):
     if not os.listdir(path):
         os.rmdir(path)
-
-
-def create_directories(path, exist_ok=True):
-    """
-    Creates directory at the specified path, including all intermediate-level directories needed to contain it.
-    NOTE: after migrating to Python3, this util function can be entirely replaced by calling
-    "os.makedirs(path, exist_ok=True)".
-    :param str path: path of the direcotry to create
-    :param bool exist_ok: if set to True, exceptions won't be raised if the target direcotry already exists
-    """
-    try:
-        os.makedirs(path)
-    except OSError as exc:
-        # Ignore exception if directory already existing
-        if exist_ok and exc.errno != errno.EEXIST:
-            raise

--- a/utils/mirror_files.py
+++ b/utils/mirror_files.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import subprocess
 import logging
-from utils.filesystem import remove_directory_if_empty, create_directories
+from utils.filesystem import remove_directory_if_empty
 
 web_logger = logging.getLogger('web')
 
@@ -24,7 +24,7 @@ def copy_files(source_destination_tuples):
                 web_logger.error('Failed copying %s (%s: %s)' % (source_path, str(e), e.output))
         else:
             # The destioantion path is a local volume
-            create_directories(os.path.dirname(destination_path), exist_ok=True)
+            os.makedirs(os.path.dirname(destination_path), exist_ok=True)
             try:
                 shutil.copy2(source_path, destination_path)
                 if settings.LOG_START_AND_END_COPYING_FILES:

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -44,7 +44,7 @@ from six import PY2
 from geotags.models import GeoTag
 from utils.audioprocessing import get_sound_type
 from utils.cache import invalidate_user_template_caches
-from utils.filesystem import md5file, remove_directory_if_empty, create_directories, remove_directory
+from utils.filesystem import md5file, remove_directory_if_empty, remove_directory
 from utils.mirror_files import copy_sound_to_mirror_locations, remove_empty_user_directory_from_mirror_locations, \
     remove_uploaded_file_from_mirror_locations
 from utils.text import remove_control_chars
@@ -183,7 +183,7 @@ def create_sound(user,
     sound.base_filename_slug = "%d__%s__%s" % (sound.id, slugify(sound.user.username), slugify(orig))
     new_original_path = sound.locations("path")
     if sound.original_path != new_original_path:
-        create_directories(os.path.dirname(new_original_path), exist_ok=True)
+        os.makedirs(os.path.dirname(new_original_path), exist_ok=True)
         try:
             shutil.move(sound.original_path, new_original_path)
 
@@ -554,7 +554,7 @@ def bulk_describe_from_csv(csv_file_path, delete_already_existing=False, force_i
 
         # Move sounds to the user upload directory (if sounds are not already there)
         user_uploads_directory = user.profile.locations()['uploads_dir']
-        create_directories(user_uploads_directory, exist_ok=True)
+        os.makedirs(user_uploads_directory, exist_ok=True)
         src_path = os.path.join(sounds_base_dir, line_cleaned['audio_filename'])
         dest_path = os.path.join(user_uploads_directory, os.path.basename(line_cleaned['audio_filename']))
         if src_path != dest_path:

--- a/utils/test_helpers.py
+++ b/utils/test_helpers.py
@@ -32,7 +32,8 @@ from django.contrib.auth.models import User
 from django.test.utils import override_settings
 
 from sounds.models import Sound, Pack, License
-from utils.filesystem import create_directories, TemporaryDirectory
+from utils.filesystem import create_directories
+from tempfile import TemporaryDirectory
 from utils.tags import clean_and_split_tags
 
 

--- a/utils/test_helpers.py
+++ b/utils/test_helpers.py
@@ -32,7 +32,6 @@ from django.contrib.auth.models import User
 from django.test.utils import override_settings
 
 from sounds.models import Sound, Pack, License
-from utils.filesystem import create_directories
 from tempfile import TemporaryDirectory
 from utils.tags import clean_and_split_tags
 
@@ -51,7 +50,7 @@ def create_test_files(filenames=None, directory=None, paths=None, n_bytes=1024, 
         paths = [os.path.join(directory, filename) for filename in filenames]
         
     for path in paths:
-        create_directories(os.path.dirname(path))
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         if not make_valid_wav_files:
             f = open(path, 'wb')
             f.write(os.urandom(n_bytes))

--- a/utils/tests/test_processing.py
+++ b/utils/tests/test_processing.py
@@ -29,7 +29,6 @@ from django.test import TestCase, override_settings
 from sounds.models import Sound
 from utils.audioprocessing.freesound_audio_processing import FreesoundAudioProcessor, FreesoundAudioProcessorBeforeDescription
 from utils.audioprocessing.processing import AudioProcessingException
-from utils.filesystem import TemporaryDirectory
 from utils.sound_upload import get_processing_before_describe_sound_folder
 from utils.test_helpers import create_test_files, create_user_and_sounds, \
     override_sounds_path_with_temp_directory, override_uploads_path_with_temp_directory, \

--- a/utils/tests/tests.py
+++ b/utils/tests/tests.py
@@ -35,7 +35,6 @@ from donations.models import Donation, DonationsModalSettings
 from sounds.models import Sound, Pack, License, Download
 from utils.audioprocessing.freesound_audio_processing import FreesoundAudioProcessor
 from utils.audioprocessing.processing import AudioProcessingException
-from utils.filesystem import create_directories
 from utils.sound_upload import get_csv_lines, validate_input_csv_file, bulk_describe_from_csv, create_sound, \
     NoAudioException, AlreadyExistsException
 from utils.tags import clean_and_split_tags
@@ -70,7 +69,7 @@ class UtilsTest(TestCase):
         filenames = ['file1.wav', 'file2.wav']
         user = User.objects.create_user("testuser", password="testpass")
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        create_directories(user_upload_path)
+        os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(filenames, user_upload_path)
         shutil.copyfile(user_upload_path + filenames[0], user_upload_path + "copy.wav")
         license = License.objects.all()[0]
@@ -272,12 +271,12 @@ class BulkDescribeUtils(TestCase):
         # Create user uploads folder and test audio files
         user = User.objects.create_user("testuser", password="testpass")
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        create_directories(user_upload_path)
+        os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(['file1.wav', 'file2.wav', 'file3.wav', 'file4.wav', 'file5.wav'], user_upload_path)
 
         # Create CSV files folder with descriptions
         csv_file_base_path = settings.CSV_PATH + '/%i/' % user.id
-        create_directories(csv_file_base_path)
+        os.makedirs(csv_file_base_path, exist_ok=True)
 
         # Test CSV with all lines and metadata ok
         csv_file_path = self.create_file_with_lines('test_descriptions.csv', [
@@ -397,12 +396,12 @@ class BulkDescribeUtils(TestCase):
         # Create user uploads folder and test audio files
         user = User.objects.create_user("testuser", password="testpass")
         user_upload_path = settings.UPLOADS_PATH + '/%i/' % user.id
-        create_directories(user_upload_path)
+        os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(['file1.wav', 'file2.wav', 'file3.wav', 'file4.wav', 'file5.wav'], user_upload_path)
 
         # Create CSV files folder with descriptions
         csv_file_base_path = settings.CSV_PATH + '/%i/' % user.id
-        create_directories(csv_file_base_path)
+        os.makedirs(csv_file_base_path, exist_ok=True)
 
         # Create Test CSV with some lines ok and some wrong lines
         csv_file_path = self.create_file_with_lines('test_descriptions.csv', [


### PR DESCRIPTION
**Description**
Removing helper function / class since we run Python 3 now

This is the first PR in a series to remove compatibility code supporting Py2/Py3

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
None