### PR TITLE
Remove python lib backports

### DIFF
--- a/accounts/tests/test_profile.py
+++ b/accounts/tests/test_profile.py
@@ -20,9 +20,9 @@
 from builtins import range
 import datetime
 import os
+from unittest import mock
 
 import freezegun
-import mock
 from dateutil.parser import parse as parse_date
 from django.conf import settings
 from django.contrib.auth.models import User, Permission

--- a/accounts/tests/test_upload.py
+++ b/accounts/tests/test_upload.py
@@ -22,8 +22,8 @@
 
 from builtins import range
 import os
+from unittest import mock
 
-import mock
 from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.core.files.uploadedfile import SimpleUploadedFile

--- a/accounts/tests/test_user.py
+++ b/accounts/tests/test_user.py
@@ -20,9 +20,8 @@
 
 import json
 import re
-from unittest import skipIf
+from unittest import skipIf, mock
 
-import mock
 from builtins import range
 from builtins import str
 from django import forms

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -23,7 +23,7 @@ standard_library.install_aliases()
 from builtins import str
 from builtins import range
 import io
-from backports import csv
+import csv
 import datetime
 import errno
 import json

--- a/donations/tests.py
+++ b/donations/tests.py
@@ -1,6 +1,6 @@
 from builtins import range
 import datetime
-import mock
+from unittest import mock
 
 from django.contrib.auth.models import User
 from django.core import mail

--- a/messages/tests/test_message_notifications.py
+++ b/messages/tests/test_message_notifications.py
@@ -17,7 +17,8 @@
 # Authors:
 #     See AUTHORS file.
 #
-import mock
+from unittest import mock
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail

--- a/monitor/tests.py
+++ b/monitor/tests.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 import requests
 from django.test import TestCase, override_settings
 from django.urls import reverse

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ freezegun==0.3.11
 future~=0.18.2
 graypy==0.2.12
 gunicorn==19.9.0
-ipaddress==1.0.23
 ipython==4.2.0
 mapbox==0.18.0
 markdown==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ gunicorn==19.9.0
 ipython==4.2.0
 mapbox==0.18.0
 markdown==2.5.1
-mock==2.0.0
 networkx==1.5
 numpy==1.16.6
 pillow==6.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 akismet==1.0.1
 autopep8==1.5.7
-backports.csv
 beautifulsoup4==4.6.0
 bleach==3.1.5
 boto3==1.7.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,8 +26,7 @@ djangorestframework-xml==1.4.0
 djangorestframework-yaml==1.0.3
 djangorestframework==3.9.4
 fabric==2.6.0
-feedparser==5.2.1; python_version < "3"
-feedparser~=6.0.10; python_version > "3"
+feedparser~=6.0.10
 freezegun==0.3.11
 future~=0.18.2
 graypy==0.2.12

--- a/search/tests.py
+++ b/search/tests.py
@@ -24,7 +24,7 @@ from django.urls import reverse
 from sounds.models import Sound
 from utils.search import SearchResults, SearchResultsPaginator
 from utils.test_helpers import create_user_and_sounds
-import mock
+from unittest import mock
 
 
 def create_fake_search_engine_results():

--- a/sounds/tests/test_random_sound.py
+++ b/sounds/tests/test_random_sound.py
@@ -19,8 +19,8 @@
 #
 
 import datetime
+from unittest import mock
 
-import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -26,9 +26,9 @@ from past.utils import old_div
 import json
 import os
 import time
+from unittest import mock
 
 import six
-import mock
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.contrib.auth.models import User

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -23,8 +23,8 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 import hashlib
+from unittest import mock
 
-import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -17,8 +17,7 @@
 # Authors:
 #     See AUTHORS file.
 #
-
-from backports import csv
+import csv
 from builtins import next
 from builtins import zip
 from builtins import str
@@ -38,8 +37,6 @@ from django.contrib.auth.models import Group
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils.text import slugify
-
-from six import PY2
 
 from geotags.models import GeoTag
 from utils.audioprocessing import get_sound_type

--- a/utils/tests/test_processing.py
+++ b/utils/tests/test_processing.py
@@ -21,8 +21,8 @@
 #
 
 import os
+from unittest import mock
 
-import mock
 from django.conf import settings
 from django.test import TestCase, override_settings
 

--- a/utils/tests/test_processing.py
+++ b/utils/tests/test_processing.py
@@ -100,9 +100,9 @@ class AudioProcessingTestCase(TestCase):
         self.assertEqual(self.sound.processing_state, "PE")
         if create_sound_file:
             create_test_files(paths=[u'{}'.format(self.sound.locations('path'))], make_valid_wav_files=True, duration=2)
-
+    
     def setUp(self):
-        user, _, sounds = create_user_and_sounds(num_sounds=1, type="mp3")  # Use mp3 so it needs converstion to PCM
+        user, _, sounds = create_user_and_sounds(num_sounds=1, type="wav")
         self.sound = sounds[0]
         self.user = user
 
@@ -144,8 +144,6 @@ class AudioProcessingTestCase(TestCase):
     @override_processing_tmp_path_with_temp_directory
     @override_sounds_path_with_temp_directory
     def test_no_need_to_convert_to_pcm(self):
-        self.sound.type = 'wav'
-        self.sound.save()
         self.pre_test()
         result = FreesoundAudioProcessor(sound_id=Sound.objects.first().id).process()
         self.sound.refresh_from_db()
@@ -177,7 +175,7 @@ class AudioProcessingTestCase(TestCase):
         self.assertEqual(self.sound.channels, 1)
         self.assertEqual(self.sound.samplerate, 44100)
         self.assertEqual(self.sound.bitrate, 0)
-        self.assertEqual(self.sound.bitdepth, 0)
+        self.assertEqual(self.sound.bitdepth, 16)
 
     @mock.patch('utils.audioprocessing.processing.convert_to_mp3', side_effect=convert_to_mp3_mock_fail)
     @override_settings(USE_PREVIEWS_WHEN_ORIGINAL_FILES_MISSING=False)
@@ -292,7 +290,7 @@ class AudioProcessingBeforeDescriptionTestCase(TestCase):
     fixtures = ['licenses']
 
     def setUp(self):
-        user, _, sounds = create_user_and_sounds(num_sounds=1, type="mp3")  # Use mp3 so it needs converstion to PCM
+        user, _, sounds = create_user_and_sounds(num_sounds=1, type="wav")
         self.sound = sounds[0]
         self.user = user
 

--- a/utils/tests/tests.py
+++ b/utils/tests/tests.py
@@ -23,7 +23,6 @@ import datetime
 import os
 import shutil
 
-import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache


### PR DESCRIPTION
**Description**
Remove usages of backported features since we can use the real thing now.

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
None