### PR TITLE
Use flynt to auto convert more non f-strings

### DIFF
--- a/_docs/api/add_examples_to_api_docs_source_files.py
+++ b/_docs/api/add_examples_to_api_docs_source_files.py
@@ -8,19 +8,19 @@ def get_formatted_examples_for_view(view_name):
     try:
         data = examples[view_name]
     except:
-        print('Could not find examples for view %s' % view_name)
+        print(f'Could not find examples for view {view_name}')
         return ''
 
     output = ''
     for description, elements in data:
-        output += '\n\n%s:\n\n' % description
+        output += f'\n\n{description}:\n\n'
         output += '::\n\n'
         for element in elements:
             if element[0:5] == 'apiv2':
                 output += '  {}{}\n'.format(base_url, urllib.parse.quote(element, safe='?/=&",:()'))
                 #output += '  curl -H "Authorization: Token {{token}}" \'%s%s\'\n' % (base_url, element)
             else:
-                output += '  %s\n' % (element % base_url[:-1].replace('http:', 'https:'))
+                output += f"  {element % base_url[:-1].replace('http:', 'https:')}\n"
 
     return output
 

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -578,7 +578,7 @@ class FsPasswordResetForm(forms.Form):
         """
         UserModel = get_user_model()
         active_users = UserModel._default_manager.filter(Q(**{
-                '%s__iexact' % UserModel.get_email_field_name(): username_or_email,
+                f'{UserModel.get_email_field_name()}__iexact': username_or_email,
                 'is_active': True,
             }) | Q(**{
                 'username__iexact': username_or_email,

--- a/accounts/management/commands/clean_old_tmp_upload_files.py
+++ b/accounts/management/commands/clean_old_tmp_upload_files.py
@@ -33,5 +33,5 @@ class Command(BaseCommand):
             f_mod_date = datetime.datetime.fromtimestamp(os.path.getmtime(settings.FILE_UPLOAD_TEMP_DIR + f))
             now = datetime.datetime.now()
             if (now - f_mod_date).total_seconds() > 3600*24:
-                print("Deleting %s" % f)
+                print(f"Deleting {f}")
                 os.remove(settings.FILE_UPLOAD_TEMP_DIR + f)

--- a/accounts/migrations/0010_auto_20170510_0945.py
+++ b/accounts/migrations/0010_auto_20170510_0945.py
@@ -7,7 +7,7 @@ def replace_empty_email_addresses(apps, schema_editor):
     User = apps.get_model("auth", "User")
     users = User.objects.filter(email="")
     for user in users:
-        user.email = 'noemail+%s@freesound.org' % user.username
+        user.email = f'noemail+{user.username}@freesound.org'
         user.save()
 
 

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -490,8 +490,8 @@ class Profile(SocialModel):
                 # If user object is not to be deleted from DB we need to anonymize it and remove sounds if requested
 
                 # Remove personal data from the user
-                self.user.username = 'deleted_user_%s' % self.user.id
-                self.user.email = 'deleted_user_%s@freesound.org' % self.user.id
+                self.user.username = f'deleted_user_{self.user.id}'
+                self.user.email = f'deleted_user_{self.user.id}@freesound.org'
                 self.has_avatar = False
                 self.is_anonymized_user = True
                 self.user.set_unusable_password()

--- a/accounts/tests/test_user.py
+++ b/accounts/tests/test_user.py
@@ -213,7 +213,7 @@ class UserDelete(TestCase):
         user.profile.delete_user()
         self.assertEqual(User.objects.get(id=user.id).profile.is_anonymized_user, True)
 
-        self.assertEqual(user.username, "deleted_user_%s" % user.id)
+        self.assertEqual(user.username, f"deleted_user_{user.id}")
         self.assertEqual(user.profile.about, '')
         self.assertEqual(user.profile.home_page, '')
         self.assertEqual(user.profile.signature, '')
@@ -240,7 +240,7 @@ class UserDelete(TestCase):
         user.profile.delete_user(remove_sounds=True)
 
         self.assertEqual(User.objects.get(id=user.id).profile.is_anonymized_user, True)
-        self.assertEqual(user.username, "deleted_user_%s" % user.id)
+        self.assertEqual(user.username, f"deleted_user_{user.id}")
         self.assertEqual(user.profile.about, '')
         self.assertEqual(user.profile.home_page, '')
         self.assertEqual(user.profile.signature, '')
@@ -636,11 +636,11 @@ class UserEmailsUniqueTestCase(TestCase):
         # not changed, he is still redirected to the duplicate email cleanup page
         resp = self.client.post(reverse('login'),
                                 {'username': self.user_b, 'password': '12345', 'next': reverse('messages')})
-        self.assertRedirects(resp, reverse('accounts-multi-email-cleanup') + '?next=%s' % reverse('messages'))
+        self.assertRedirects(resp, reverse('accounts-multi-email-cleanup') + f"?next={reverse('messages')}")
         resp = self.client.get(reverse('logout'))
         resp = self.client.post(reverse('login'),
                                 {'username': self.user_c, 'password': '12345', 'next': reverse('messages')})
-        self.assertRedirects(resp, reverse('accounts-multi-email-cleanup') + '?next=%s' % reverse('messages'))
+        self.assertRedirects(resp, reverse('accounts-multi-email-cleanup') + f"?next={reverse('messages')}")
 
     def test_fix_email_issues_with_secondary_user_email_change(self):
         # user_c changes his email and tries to login, redirect should go to email cleanup page and from there
@@ -650,7 +650,7 @@ class UserEmailsUniqueTestCase(TestCase):
         resp = self.client.post(reverse('login'), follow=True,
                                 data={'username': self.user_c, 'password': '12345', 'next': reverse('messages')})
         self.assertEqual(resp.redirect_chain[0][0],
-                          reverse('accounts-multi-email-cleanup') + '?next=%s' % reverse('messages'))
+                          reverse('accounts-multi-email-cleanup') + f"?next={reverse('messages')}")
         self.assertEqual(resp.redirect_chain[1][0], reverse('messages'))
 
         # Also check that related SameUser objects have been removed
@@ -677,7 +677,7 @@ class UserEmailsUniqueTestCase(TestCase):
         resp = self.client.post(reverse('login'), follow=True,
                                 data={'username': self.user_b, 'password': '12345', 'next': reverse('messages')})
         self.assertEqual(resp.redirect_chain[0][0],
-                          reverse('accounts-multi-email-cleanup') + '?next=%s' % reverse('messages'))
+                          reverse('accounts-multi-email-cleanup') + f"?next={reverse('messages')}")
         self.assertEqual(resp.redirect_chain[1][0], reverse('messages'))
 
         # Check that user_c email was changed
@@ -709,7 +709,7 @@ class UserEmailsUniqueTestCase(TestCase):
         resp = self.client.post(reverse('login'), follow=True,
                                 data={'username': self.user_b, 'password': '12345', 'next': reverse('messages')})
         self.assertEqual(resp.redirect_chain[0][0],
-                          reverse('accounts-multi-email-cleanup') + '?next=%s' % reverse('messages'))
+                          reverse('accounts-multi-email-cleanup') + f"?next={reverse('messages')}")
         self.assertEqual(resp.redirect_chain[1][0], reverse('messages'))
 
         # Check that user_c email was not changed

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -107,7 +107,7 @@ def ratelimited_error(request, exception):
         path = request.path
     if not path.endswith('/'):
         path += '/'
-    volatile_logger.info('Rate limited IP ({})'.format(json.dumps({'ip': get_client_ip(request), 'path': path})))
+    volatile_logger.info(f"Rate limited IP ({json.dumps({'ip': get_client_ip(request), 'path': path})})")
     return render(request, '429.html', status=429)
 
 
@@ -129,7 +129,7 @@ def login(request, template_name, authentication_form):
             redirect_url = reverse("accounts-multi-email-cleanup")
             next_param = request.POST.get('next', None)
             if next_param:
-                redirect_url += '?next=%s' % next_param
+                redirect_url += f'?next={next_param}'
             return HttpResponseRedirect(redirect_url)
         else:
             return response
@@ -336,7 +336,7 @@ def registration(request):
     if using_beastwhoosh(request):
         # In beastwhoosh we don't have a dedicated registration page, redirect to front-page and auto-open the
         # registration modal
-        return HttpResponseRedirect('{}?registration=1'.format(reverse('front-page')))
+        return HttpResponseRedirect(f"{reverse('front-page')}?registration=1")
     else:
         return render(request, 'accounts/registration.html', {'form': form})
 
@@ -657,7 +657,7 @@ def describe(request):
             directory = os.path.join(settings.CSV_PATH, str(request.user.id))
             os.makedirs(directory, exist_ok=True)
             extension = csv_form.cleaned_data['csv_file'].name.rsplit('.', 1)[-1].lower()
-            new_csv_filename = str(uuid.uuid4()) + '.%s' % extension
+            new_csv_filename = str(uuid.uuid4()) + f'.{extension}'
             path = os.path.join(directory, new_csv_filename)
             destination = open(path, 'wb')
 
@@ -847,7 +847,7 @@ def describe_sounds(request):
             except utils.sound_upload.NoAudioException:
                 # If for some reason audio file does not exist, skip creating this sound
                 messages.add_message(request, messages.ERROR,
-                                     'Something went wrong with accessing the file %s.' % forms[i]['description'].cleaned_data['name'])
+                                     f"Something went wrong with accessing the file {forms[i]['description'].cleaned_data['name']}.")
             except utils.sound_upload.AlreadyExistsException as e:
                 messages.add_message(request, messages.WARNING, str(e))
             except utils.sound_upload.CantMoveException as e:
@@ -944,8 +944,8 @@ def download_attribution(request):
     if download in ['csv', 'txt']:
         now = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
         filename = f'{request.user}_{now}_attribution.{download}'
-        response = HttpResponse(content_type='text/%s' % content[download])
-        response['Content-Disposition'] = 'attachment; filename="%s"' % filename
+        response = HttpResponse(content_type=f'text/{content[download]}')
+        response['Content-Disposition'] = f'attachment; filename="{filename}"'
         output = io.StringIO()
         if download == 'csv':
             output.write('Download Type,File Name,User,License\r\n')

--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -150,11 +150,11 @@ class FreesoundAPIViewMixin:
 
         if isinstance(response.accepted_renderer, BrowsableAPIRenderer):
             if request.get_host().startswith('www'):
-                domain = "{}://{}".format('https' if not settings.DEBUG else 'http', Site.objects.get_current().domain)
+                domain = f"{'https' if not settings.DEBUG else 'http'}://{Site.objects.get_current().domain}"
                 return_url = urllib.parse.urljoin(domain, request.get_full_path())
                 return HttpResponseRedirect(return_url)
             if request.scheme != 'https' and not settings.DEBUG:
-                domain = "https://%s" % Site.objects.get_current().domain
+                domain = f"https://{Site.objects.get_current().domain}"
                 return_url = urllib.parse.urljoin(domain, request.get_full_path())
                 return HttpResponseRedirect(return_url)
         return response
@@ -325,7 +325,7 @@ def api_search(
             elif e.status_code == 404:
                 raise NotFoundException(msg=str(e), resource=resource)
             else:
-                raise ServerErrorException(msg='Similarity server error: %s' % str(e), resource=resource)
+                raise ServerErrorException(msg=f'Similarity server error: {str(e)}', resource=resource)
         except Exception as e:
             raise ServerErrorException(
                 msg='The similarity server could not be reached or some unexpected error occurred.', resource=resource)
@@ -364,7 +364,7 @@ def api_search(
             if search_form.cleaned_data['filter'] is not None:
                 raise BadRequestException(msg='Search server error: %s (please check that your filter syntax and field '
                                               'names are correct)' % str(e), resource=resource)
-            raise BadRequestException(msg='Search server error: %s' % str(e), resource=resource)
+            raise BadRequestException(msg=f'Search server error: {str(e)}', resource=resource)
         except Exception as e:
             print(e)
             raise ServerErrorException(
@@ -541,7 +541,7 @@ def get_formatted_examples_for_view(view_name, url_name, max=10):
             else:
                 # This is only apiv2 oauth examples
                 url = prepend_base('', dynamic_resolve=False, use_https=True)
-                output += '<span class="pln">%s</span><br>' % (element % url)
+                output += f'<span class="pln">{element % url}</span><br>'
             count += 1
 
     output += '</pre></div>'

--- a/apiv2/combined_search_strategies.py
+++ b/apiv2/combined_search_strategies.py
@@ -303,7 +303,7 @@ def get_gaia_results(search_form, target_file, page_size, max_pages, start_page=
         elif e.status_code == 404:
             raise NotFoundException(msg=str(e))
         else:
-            raise ServerErrorException(msg='Similarity server error: %s' % str(e))
+            raise ServerErrorException(msg=f'Similarity server error: {str(e)}')
     except Exception as e:
         raise ServerErrorException(msg='The similarity server could not be reached or some unexpected error occurred.')
 
@@ -319,7 +319,7 @@ def get_solr_results(search_form, page_size, max_pages, start_page=1, valid_ids=
         # Update solr filter to only return results in valid ids
         ids_filter = 'id:(' + ' OR '.join([str(item) for item in valid_ids]) + ')'
         if query_filter:
-            query_filter += ' %s' % ids_filter
+            query_filter += f' {ids_filter}'
         else:
             query_filter = ids_filter
 
@@ -353,7 +353,7 @@ def get_solr_results(search_form, page_size, max_pages, start_page=1, valid_ids=
             n_page_requests += 1
 
     except SearchEngineException as e:
-        raise ServerErrorException(msg='Search server error: %s' % str(e))
+        raise ServerErrorException(msg=f'Search server error: {str(e)}')
     except Exception as e:
         raise ServerErrorException(msg='The search server could not be reached or some unexpected error occurred.')
     return solr_ids, solr_count

--- a/apiv2/forms.py
+++ b/apiv2/forms.py
@@ -169,40 +169,40 @@ class SoundCombinedSearchFormAPI(forms.Form):
     def construct_link(self, base_url, page=None, filt=None, group_by_pack=None, include_page=True):
         link = "?"
         if self.cleaned_data['query'] is not None:
-            link += '&query=%s' % my_quote(self.cleaned_data['query'])
+            link += f"&query={my_quote(self.cleaned_data['query'])}"
         if not filt:
             if self.cleaned_data['filter']:
-                link += '&filter=%s' % my_quote(self.cleaned_data['filter'])
+                link += f"&filter={my_quote(self.cleaned_data['filter'])}"
         else:
-            link += '&filter=%s' % my_quote(filt)
+            link += f'&filter={my_quote(filt)}'
         if self.cleaned_data['weights'] is not None:
-            link += '&weights=%s' % self.cleaned_data['weights']
+            link += f"&weights={self.cleaned_data['weights']}"
         if self.original_url_sort_value and not self.original_url_sort_value == SEARCH_SOUNDS_SORT_DEFAULT_API.split(' ')[0]:
-            link += '&sort=%s' % self.original_url_sort_value
+            link += f'&sort={self.original_url_sort_value}'
         if self.cleaned_data['descriptors_filter']:
-                link += '&descriptors_filter=%s' % self.cleaned_data['descriptors_filter']
+                link += f"&descriptors_filter={self.cleaned_data['descriptors_filter']}"
         if self.cleaned_data['target']:
-                link += '&target=%s' % self.cleaned_data['target']
+                link += f"&target={self.cleaned_data['target']}"
         if include_page:
             if not page:
                 if self.cleaned_data['page'] and self.cleaned_data['page'] != 1:
-                    link += '&page=%s' % self.cleaned_data['page']
+                    link += f"&page={self.cleaned_data['page']}"
             else:
-                link += '&page=%s' % str(page)
+                link += f'&page={str(page)}'
         if self.cleaned_data['page_size'] and \
                 not self.cleaned_data['page_size'] == settings.APIV2['PAGE_SIZE']:
-            link += '&page_size=%s' % str(self.cleaned_data['page_size'])
+            link += f"&page_size={str(self.cleaned_data['page_size'])}"
         if self.cleaned_data['fields']:
-            link += '&fields=%s' % my_quote(self.cleaned_data['fields'])
+            link += f"&fields={my_quote(self.cleaned_data['fields'])}"
         if self.cleaned_data['descriptors']:
-            link += '&descriptors=%s' % self.cleaned_data['descriptors']
+            link += f"&descriptors={self.cleaned_data['descriptors']}"
         if self.cleaned_data['normalized']:
-            link += '&normalized=%s' % self.cleaned_data['normalized']
+            link += f"&normalized={self.cleaned_data['normalized']}"
         if not group_by_pack:
             if self.cleaned_data['group_by_pack']:
-                link += '&group_by_pack=%s' % self.cleaned_data['group_by_pack']
+                link += f"&group_by_pack={self.cleaned_data['group_by_pack']}"
         else:
-            link += '&group_by_pack=%s' % group_by_pack
+            link += f'&group_by_pack={group_by_pack}'
         return f"https://{Site.objects.get_current().domain}{base_url}{link}"
 
 

--- a/apiv2/management/commands/basic_api_tests.py
+++ b/apiv2/management/commands/basic_api_tests.py
@@ -49,7 +49,7 @@ def api_request(full_url, type='GET', post_data=None, auth='token', token=None):
         data = json.dumps(post_data)
 
     if auth == 'token':
-        headers = {'Authorization': 'Token %s' % token }
+        headers = {'Authorization': f'Token {token}' }
 
     if type == 'GET':
         r = requests.get(url, params=params, headers=headers)
@@ -89,7 +89,7 @@ class Command(BaseCommand):
         section = options['section']
 
         if not base_url:
-            base_url = "https://%s/" % Site.objects.get_current().domain
+            base_url = f"https://{Site.objects.get_current().domain}/"
 
         test_client = None
         if not token:
@@ -110,14 +110,14 @@ class Command(BaseCommand):
                     if section not in key:
                         continue
 
-                print('Testing %s' % key)
+                print(f'Testing {key}')
                 print('--------------------------------------')
 
                 for desc, urls in items:
                     for url in urls:
                         if url[0:4] != 'curl':
                             prepended_url = base_url + url
-                            print('- %s' % prepended_url, end=' ')
+                            print(f'- {prepended_url}', end=' ')
                             try:
                                 r = api_request(prepended_url, token=token)
                                 if r.status_code == 200:
@@ -127,16 +127,16 @@ class Command(BaseCommand):
                                     print('FAIL! (%i)' % r.status_code)
                                     failed.append((prepended_url, r.status_code))
                             except Exception as e:
-                                print('ERROR (%s)' % str(e))
+                                print(f'ERROR ({str(e)})')
                                 error.append(prepended_url)
 
                 print('')
 
         print('\nRUNNING TESTS FINISHED:')
-        print('\t%i tests completed successfully' % len(ok))
+        print(f'\t{len(ok)} tests completed successfully')
         if error:
-            print('\t%i tests gave errors (connection, etc...)' % len(error))
-        print('\t%i tests failed' % len(failed))
+            print(f'\t{len(error)} tests gave errors (connection, etc...)')
+        print(f'\t{len(failed)} tests failed')
         for url, status_code in failed:
             print('\t\t- %s (%i)' % (url, status_code))
 

--- a/apiv2/models.py
+++ b/apiv2/models.py
@@ -51,7 +51,7 @@ class ApiV2Client(models.Model):
     throttling_level = models.IntegerField(default=1)
 
     def __str__(self):
-        return "credentials for developer %s" % self.user.username
+        return f"credentials for developer {self.user.username}"
 
     def save(self, *args, **kwargs):
 

--- a/apiv2/tests.py
+++ b/apiv2/tests.py
@@ -168,7 +168,7 @@ class TestAPI(TestCase):
         sound.change_moderation_state("OK")
 
         headers = {
-            'HTTP_AUTHORIZATION': 'Token %s' % c.key,
+            'HTTP_AUTHORIZATION': f'Token {c.key}',
             'HTTP_ORIGIN': 'https://www.google.com'
         }
         resp = self.client.options(reverse('apiv2-sound-instance',
@@ -190,7 +190,7 @@ class TestAPI(TestCase):
         sound.change_moderation_state("OK")
 
         headers = {
-            'HTTP_AUTHORIZATION': 'Token %s' % c.key,
+            'HTTP_AUTHORIZATION': f'Token {c.key}',
         }
         # make query that can't be decoded
         resp = self.client.options("/apiv2/search/text/?query=ambient&filter=tag:(rain%20OR%CAfe)", secure=True, **headers)
@@ -202,7 +202,7 @@ class TestAPI(TestCase):
                         url="https://freesound.com", name="test")
         c.save()
         headers = {
-            'HTTP_AUTHORIZATION': 'Token %s' % c.key,
+            'HTTP_AUTHORIZATION': f'Token {c.key}',
         }
         resp = self.client.get("/apiv2/", secure=True, **headers)
         self.assertEqual(resp.status_code, 200)

--- a/apiv2/throttling.py
+++ b/apiv2/throttling.py
@@ -66,7 +66,7 @@ class ClientBasedThrottlingBurst(SimpleRateThrottle):
             self.num_requests, self.duration = self.parse_rate(rate)
             passes_throttle = super().allow_request(request, view)
             if not passes_throttle:
-                msg = "Request was throttled because of exceeding a request limit rate (%s)" % rate
+                msg = f"Request was throttled because of exceeding a request limit rate ({rate})"
                 if client_throttle_level == 0:
                     # Prevent returning a absurd message like "exceeding a request limit rate (0/minute)"
                     msg = "Request was throttled because the ApiV2 credential has been suspended"
@@ -126,7 +126,7 @@ class ClientBasedThrottlingSustained(SimpleRateThrottle):
             self.num_requests, self.duration = self.parse_rate(rate)
             passes_throttle = super().allow_request(request, view)
             if not passes_throttle:
-                msg = "Request was throttled because of exceeding a request limit rate (%s)" % rate
+                msg = f"Request was throttled because of exceeding a request limit rate ({rate})"
                 if client_throttle_level == 0:
                     # Prevent returning a absurd message like "exceeding a request limit rate (0/minute)"
                     msg = "Request was throttled because the ApiV2 credential has been suspended"
@@ -218,7 +218,7 @@ class IpBasedThrottling(SimpleRateThrottle):
                     passes_throttle = self.throttle_success()
 
             if not passes_throttle:
-                msg = "Request was throttled because of exceeding the concurrent ip limit rate (%s)" % rate
+                msg = f"Request was throttled because of exceeding the concurrent ip limit rate ({rate})"
                 if client_throttle_level == 0:
                     # Prevent returning a absurd message like "exceeding a request limit rate (0/minute)"
                     msg = "Request was throttled because the ApiV2 credential has been suspended"

--- a/apiv2/views.py
+++ b/apiv2/views.py
@@ -340,7 +340,7 @@ class CombinedSearch(GenericAPIView):
                 else:
                     response_data['more'] = None
             if extra_parameters_string:
-                response_data['more'] += '%s' % extra_parameters_string
+                response_data['more'] += f'{extra_parameters_string}'
         else:
             response_data['more'] = None
 
@@ -581,7 +581,7 @@ class UserInstance(RetrieveAPIView):
     queryset = User.objects.filter(is_active=True)
 
     def get(self, request,  *args, **kwargs):
-        api_logger.info(self.log_message('user:%s instance' % (self.kwargs['username'])))
+        api_logger.info(self.log_message(f"user:{self.kwargs['username']} instance"))
         return super().get(request, *args, **kwargs)
 
 
@@ -597,7 +597,7 @@ class UserSounds(ListAPIView):
                   get_formatted_examples_for_view('UserSounds', 'apiv2-user-sound-list', max=5))
 
     def get(self, request,  *args, **kwargs):
-        api_logger.info(self.log_message('user:%s sounds' % (self.kwargs['username'])))
+        api_logger.info(self.log_message(f"user:{self.kwargs['username']} sounds"))
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self):
@@ -624,7 +624,7 @@ class UserPacks(ListAPIView):
                   get_formatted_examples_for_view('UserPacks', 'apiv2-user-packs', max=5))
 
     def get(self, request,  *args, **kwargs):
-        api_logger.info(self.log_message('user:%s packs' % (self.kwargs['username'])))
+        api_logger.info(self.log_message(f"user:{self.kwargs['username']} packs"))
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self):
@@ -649,7 +649,7 @@ class UserBookmarkCategories(ListAPIView):
                   get_formatted_examples_for_view('UserBookmarkCategories', 'apiv2-user-bookmark-categories', max=5))
 
     def get(self, request,  *args, **kwargs):
-        api_logger.info(self.log_message('user:%s bookmark_categories' % (self.kwargs['username'])))
+        api_logger.info(self.log_message(f"user:{self.kwargs['username']} bookmark_categories"))
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self):
@@ -985,11 +985,11 @@ class EditSoundDescription(WriteRequiredGenericAPIView):
             raise UnauthorizedException(msg='Not authorized. The sound you\'re trying to edit is not owned by '
                                             'the OAuth2 logged in user.', resource=self)
 
-        api_logger.info(self.log_message('sound:%s edit_description' % sound_id))
+        api_logger.info(self.log_message(f'sound:{sound_id} edit_description'))
         serializer = EditSoundDescriptionSerializer(data=request.data)
         if serializer.is_valid():
             if not settings.ALLOW_WRITE_WHEN_SESSION_BASED_AUTHENTICATION and self.auth_method_name == 'Session':
-                return Response(data={'detail': 'Description of sound %s successfully edited.' % sound_id,
+                return Response(data={'detail': f'Description of sound {sound_id} successfully edited.',
                                       'note': 'Description of sound %s has not been saved in the database as '
                                               'browseable API is only for testing purposes.' % sound_id},
                                 status=status.HTTP_200_OK)
@@ -1032,7 +1032,7 @@ class EditSoundDescription(WriteRequiredGenericAPIView):
                 # Invalidate caches
                 sound.invalidate_template_caches()
 
-                return Response(data={'detail': 'Description of sound %s successfully edited.' % sound_id},
+                return Response(data={'detail': f'Description of sound {sound_id} successfully edited.'},
                                 status=status.HTTP_200_OK)
         else:
             return Response({'detail': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
@@ -1054,11 +1054,11 @@ class BookmarkSound(WriteRequiredGenericAPIView):
             sound = Sound.objects.get(id=sound_id, moderation_state="OK", processing_state="OK")
         except Sound.DoesNotExist:
             raise NotFoundException(resource=self)
-        api_logger.info(self.log_message('sound:%s create_bookmark' % sound_id))
+        api_logger.info(self.log_message(f'sound:{sound_id} create_bookmark'))
         serializer = CreateBookmarkSerializer(data=request.data)
         if serializer.is_valid():
             if not settings.ALLOW_WRITE_WHEN_SESSION_BASED_AUTHENTICATION and self.auth_method_name == 'Session':
-                return Response(data={'detail': 'Successfully bookmarked sound %s.' % sound_id,
+                return Response(data={'detail': f'Successfully bookmarked sound {sound_id}.',
                                       'note': 'This bookmark has not been saved in the database as browseable API is '
                                               'only for testing purposes.'},
                                 status=status.HTTP_201_CREATED)
@@ -1071,7 +1071,7 @@ class BookmarkSound(WriteRequiredGenericAPIView):
                 else:
                     bookmark = Bookmark(user=self.user, name=name, sound_id=sound_id)
                 bookmark.save()
-                return Response(data={'detail': 'Successfully bookmarked sound %s.' % sound_id},
+                return Response(data={'detail': f'Successfully bookmarked sound {sound_id}.'},
                                 status=status.HTTP_201_CREATED)
         else:
             return Response({'detail': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
@@ -1093,12 +1093,12 @@ class RateSound(WriteRequiredGenericAPIView):
             sound = Sound.objects.get(id=sound_id, moderation_state="OK", processing_state="OK")
         except Sound.DoesNotExist:
             raise NotFoundException(resource=self)
-        api_logger.info(self.log_message('sound:%s create_rating' % sound_id))
+        api_logger.info(self.log_message(f'sound:{sound_id} create_rating'))
         serializer = CreateRatingSerializer(data=request.data)
         if serializer.is_valid():
             try:
                 if not settings.ALLOW_WRITE_WHEN_SESSION_BASED_AUTHENTICATION and self.auth_method_name == 'Session':
-                    return Response(data={'detail': 'Successfully rated sound %s.' % sound_id,
+                    return Response(data={'detail': f'Successfully rated sound {sound_id}.',
                                           'note': 'This rating has not been saved in the database as browseable API '
                                                   'is only for testing purposes.'},
                                     status=status.HTTP_201_CREATED)
@@ -1106,10 +1106,10 @@ class RateSound(WriteRequiredGenericAPIView):
                     SoundRating.objects.create(
                         user=self.user, sound_id=sound_id, rating=int(request.data['rating']) * 2)
                     Sound.objects.filter(id=sound_id).update(is_index_dirty=True)
-                    return Response(data={'detail': 'Successfully rated sound %s.' % sound_id},
+                    return Response(data={'detail': f'Successfully rated sound {sound_id}.'},
                                     status=status.HTTP_201_CREATED)
             except IntegrityError:
-                raise ConflictException(msg='User has already rated sound %s' % sound_id, resource=self)
+                raise ConflictException(msg=f'User has already rated sound {sound_id}', resource=self)
             except:
                 raise ServerErrorException(resource=self)
         else:
@@ -1132,17 +1132,17 @@ class CommentSound(WriteRequiredGenericAPIView):
             sound = Sound.objects.get(id=sound_id, moderation_state="OK", processing_state="OK")
         except Sound.DoesNotExist:
             raise NotFoundException(resource=self)
-        api_logger.info(self.log_message('sound:%s create_comment' % sound_id))
+        api_logger.info(self.log_message(f'sound:{sound_id} create_comment'))
         serializer = CreateCommentSerializer(data=request.data)
         if serializer.is_valid():
             if not settings.ALLOW_WRITE_WHEN_SESSION_BASED_AUTHENTICATION and self.auth_method_name == 'Session':
-                return Response(data={'detail': 'Successfully commented sound %s.' % sound_id,
+                return Response(data={'detail': f'Successfully commented sound {sound_id}.',
                                       'note': 'This comment has not been saved in the database as browseable API is '
                                               'only for testing purposes.'},
                                 status=status.HTTP_201_CREATED)
             else:
                 sound.add_comment(self.user, request.data['comment'])
-                return Response(data={'detail': 'Successfully commented sound %s.' % sound_id},
+                return Response(data={'detail': f'Successfully commented sound {sound_id}.'},
                                 status=status.HTTP_201_CREATED)
         else:
             return Response({'detail': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
@@ -1394,7 +1394,7 @@ def edit_api_credential(request, key):
             client.description = form.cleaned_data['description']
             client.accepted_tos = form.cleaned_data['accepted_tos']
             client.save()
-            messages.add_message(request, messages.INFO, "Credentials with name %s have been updated." % client.name)
+            messages.add_message(request, messages.INFO, f"Credentials with name {client.name} have been updated.")
             return HttpResponseRedirect(reverse("apiv2-apply"))
     else:
         form = ApiV2ClientForm(initial={'name': client.name,
@@ -1457,7 +1457,7 @@ def delete_api_credential(request, key):
         client.delete()
     except ApiV2Client.DoesNotExist:
         pass
-    messages.add_message(request, messages.INFO, "Credentials with name %s have been deleted." % name)
+    messages.add_message(request, messages.INFO, f"Credentials with name {name} have been deleted.")
     return HttpResponseRedirect(reverse("apiv2-apply"))
 
 

--- a/bookmarks/models.py
+++ b/bookmarks/models.py
@@ -29,7 +29,7 @@ class BookmarkCategory(models.Model):
     name = models.CharField(max_length=128, default="")
     
     def __str__(self):
-        return "%s" % self.name
+        return f"{self.name}"
 
 
 class Bookmark(models.Model):
@@ -40,7 +40,7 @@ class Bookmark(models.Model):
     created = models.DateTimeField(db_index=True, auto_now_add=True)
     
     def __str__(self):
-        return "Bookmark: %s" % self.name
+        return f"Bookmark: {self.name}"
 
     @property
     def category_name_or_uncategorized(self):

--- a/clustering/clustering.py
+++ b/clustering/clustering.py
@@ -250,7 +250,7 @@ class ClusteringEngine(object):
             }
             with open(os.path.join(
                 clust_settings.SAVE_RESULTS_FOLDER, 
-                '{}.json'.format(query_params)
+                f'{query_params}.json'
             ), 'w') as f:
                 json.dump(result, f)
 

--- a/clustering/interface.py
+++ b/clustering/interface.py
@@ -78,8 +78,8 @@ def cluster_sound_results(request, features=DEFAULT_FEATURES):
     query_params['query_filter'] = extra_vars['filter_query_non_facets']
     cache_key = 'cluster-results-{textual_query}-{query_filter}-{sort}-{group_by_pack}'\
         .format(**query_params).replace(' ', '')
-    cache_key += '-{}'.format(str(query_params['query_fields']))
-    cache_key += '-{}'.format(features)
+    cache_key += f"-{str(query_params['query_fields'])}"
+    cache_key += f'-{features}'
     cache_key_hashed = hash_cache_key(cache_key)
 
     # check if result is in cache

--- a/donations/management/commands/check_missing_donations.py
+++ b/donations/management/commands/check_missing_donations.py
@@ -103,7 +103,7 @@ class Command(LoggingBaseCommand):
                             donation_data['created'] = raw_rsp['L_TIMESTAMP%d' % i][0]
                             if 'user' in donation_data:
                                 donation_data['user'] = donation_data['user'].username  # Only log username in graylog
-                            commands_logger.info('Created donation object (%s)' % json.dumps(donation_data))
+                            commands_logger.info(f'Created donation object ({json.dumps(donation_data)})')
 
             start = start + one_day
             params['STARTDATE'] = start

--- a/donations/views.py
+++ b/donations/views.py
@@ -72,7 +72,7 @@ def _save_donation(encoded_data, email, amount, currency, transaction_id, source
         del log_data['user']  # Don't want to serialize user
         del log_data['campaign']  # Don't want to serialize campaign
         log_data['amount_float'] = float(log_data['amount'])
-        web_logger.info('Recevied donation (%s)' % json.dumps(log_data))
+        web_logger.info(f'Recevied donation ({json.dumps(log_data)})')
     return True
 
 
@@ -171,7 +171,7 @@ def donation_session_stripe(request):
         if form.is_valid():
             email_to = request.user.email if request.user.is_authenticated() else None
             amount = form.cleaned_data['amount']
-            domain = "https://%s" % Site.objects.get_current().domain
+            domain = f"https://{Site.objects.get_current().domain}"
             return_url_success = urllib.parse.urljoin(domain, reverse('donation-success'))
             return_url_success += f'?token={form.encoded_data}'
             return_url_cancel = urllib.parse.urljoin(domain, reverse('donate'))
@@ -207,7 +207,7 @@ def donation_session_paypal(request):
         form = FormToUse(request.POST, user=request.user)
         if form.is_valid():
             amount = form.cleaned_data['amount']
-            domain = "https://%s" % Site.objects.get_current().domain
+            domain = f"https://{Site.objects.get_current().domain}"
             return_url = urllib.parse.urljoin(domain, reverse('donation-complete-paypal'))
             data = {"url": settings.PAYPAL_VALIDATION_URL,
                     "params": {

--- a/follow/management/commands/send_stream_emails.py
+++ b/follow/management/commands/send_stream_emails.py
@@ -83,12 +83,12 @@ class Command(LoggingBaseCommand):
                 users_sounds, tags_sounds = follow_utils.get_stream_sounds(user, time_lapse)
             except Exception as e:
                 # If error occur do not send the email
-                console_logger.info("could not get new sounds data for {}".format(username.encode('utf-8')))
+                console_logger.info(f"could not get new sounds data for {username.encode('utf-8')}")
                 profile.save()  # Save last_attempt_of_sending_stream_email
                 continue
 
             if not users_sounds and not tags_sounds:
-                console_logger.info("no news sounds for {}".format(username.encode('utf-8')))
+                console_logger.info(f"no news sounds for {username.encode('utf-8')}")
                 profile.save()  # Save last_attempt_of_sending_stream_email
                 continue
 

--- a/follow/views.py
+++ b/follow/views.py
@@ -62,7 +62,7 @@ def following_users(request, username):
         paginator = paginate(request, following, settings.FOLLOW_ITEMS_PER_PAGE)
         tvars.update(paginator)
         tvars.update({
-            'next_path': reverse('account', args=[username]) + '?following={}'.format(paginator['current_page']),
+            'next_path': reverse('account', args=[username]) + f"?following={paginator['current_page']}",
             'follow_page': 'following'
         })
         return render(request, 'accounts/modal_follow.html', tvars)
@@ -99,7 +99,7 @@ def followers(request, username):
         paginator = paginate(request, followers, settings.FOLLOW_ITEMS_PER_PAGE)
         tvars.update(paginator)
         tvars.update({
-            'next_path': reverse('account', args=[username]) + '?followers={}'.format(paginator['current_page']),
+            'next_path': reverse('account', args=[username]) + f"?followers={paginator['current_page']}",
             'follow_page': 'followers'
         })
         return render(request, 'accounts/modal_follow.html', tvars)
@@ -136,7 +136,7 @@ def following_tags(request, username):
         paginator = paginate(request, following_tags, settings.FOLLOW_ITEMS_PER_PAGE)
         tvars.update(paginator)
         tvars.update({
-            'next_path': reverse('account', args=[username]) + '?followingTags={}'.format(paginator['current_page']),
+            'next_path': reverse('account', args=[username]) + f"?followingTags={paginator['current_page']}",
             'follow_page': 'tags' # Used in BW
         })
         return render(request, 'accounts/modal_follow.html', tvars)

--- a/forum/tests.py
+++ b/forum/tests.py
@@ -429,7 +429,7 @@ class ForumPageResponses(TestCase):
         resp = self.client.post(reverse('forums-post-edit', args=[post.id]), data={
             'body': ['Edited post body']
         })
-        self.assertRedirects(resp, '{}?next={}'.format(reverse('login'), reverse('forums-post-edit', args=[post.id])))
+        self.assertRedirects(resp, f"{reverse('login')}?next={reverse('forums-post-edit', args=[post.id])}")
 
         # Assert logged in user which is not author of post can't edit post
         user2 = User.objects.create_user(username='testuser2', email='email2@example.com', password='12345')
@@ -455,7 +455,7 @@ class ForumPageResponses(TestCase):
 
         # Assert non-logged in user can't delete post
         resp = self.client.get(reverse('forums-post-delete', args=[post.id]))
-        self.assertRedirects(resp, '{}?next={}'.format(reverse('login'), reverse('forums-post-delete', args=[post.id])))
+        self.assertRedirects(resp, f"{reverse('login')}?next={reverse('forums-post-delete', args=[post.id])}")
 
         # Assert logged in user which is not author of post can't delete post
         user2 = User.objects.create_user(username='testuser2', email='email2@example.com', password='12345')
@@ -475,7 +475,7 @@ class ForumPageResponses(TestCase):
 
         # Assert non-logged in user can't delete post
         resp = self.client.post(reverse('forums-post-delete-confirm', args=[post.id]))
-        self.assertRedirects(resp, '{}?next={}'.format(reverse('login'), reverse('forums-post-delete-confirm', args=[post.id])))
+        self.assertRedirects(resp, f"{reverse('login')}?next={reverse('forums-post-delete-confirm', args=[post.id])}")
 
         # Assert logged in user which is not author of post can't delete post
         user2 = User.objects.create_user(username='testuser2', email='email2@example.com', password='12345')
@@ -529,7 +529,7 @@ class ForumPageResponses(TestCase):
 
         # Assert non-logged in user can't subscribe
         resp = self.client.get(reverse('forums-thread-subscribe', args=[forum.name_slug, thread.id]))
-        self.assertRedirects(resp, '{}?next={}'.format(reverse('login'), reverse('forums-thread-subscribe', args=[forum.name_slug, thread.id])))
+        self.assertRedirects(resp, f"{reverse('login')}?next={reverse('forums-thread-subscribe', args=[forum.name_slug, thread.id])}")
 
         # Assert logged in user can subscribe
         user2 = User.objects.create_user(username='testuser2', email='email2@example.com', password='12345')

--- a/general/management/commands/create_front_page_caches.py
+++ b/general/management/commands/create_front_page_caches.py
@@ -97,7 +97,7 @@ class Command(LoggingBaseCommand):
                 .values('user_id').annotate(total_donations=Sum('amount')) \
                 .order_by('-total_donations')[0]
             top_donor_user_id = top_donor_user_data['user_id']
-            top_donor_donation_amount = '{:.2f} eur'.format(top_donor_user_data['total_donations'])
+            top_donor_donation_amount = f"{top_donor_user_data['total_donations']:.2f} eur"
         except IndexError:
             top_donor_user_id = None
             top_donor_donation_amount = None

--- a/general/management/commands/report_index_statuses.py
+++ b/general/management/commands/report_index_statuses.py
@@ -72,24 +72,24 @@ class Command(LoggingBaseCommand):
 
         messages = []
         messages.append("\nNumber of sounds per index:\n--------------------------")
-        messages.append("Solr index\t\t%i" % len(solr_ids))
-        messages.append("Gaia index\t\t%i" % len(gaia_ids))
-        messages.append("Freesound\t\t%i  (moderated and processed)" % len(fs_mp))
-        messages.append("Freesound\t\t%i  (moderated, processed and analyzed)" % len(fs_mpa))
+        messages.append(f"Solr index\t\t{len(solr_ids)}")
+        messages.append(f"Gaia index\t\t{len(gaia_ids)}")
+        messages.append(f"Freesound\t\t{len(fs_mp)}  (moderated and processed)")
+        messages.append(f"Freesound\t\t{len(fs_mpa)}  (moderated, processed and analyzed)")
         messages.append("\n\n***************\nSOLR INDEX\n***************\n")
-        messages.append("Sounds in solr but not in fs:\t%i" % len(in_solr_not_in_fs))
-        messages.append("Sounds in fs but not in solr:\t%i" % len(in_fs_not_in_solr))
+        messages.append(f"Sounds in solr but not in fs:\t{len(in_solr_not_in_fs)}")
+        messages.append(f"Sounds in fs but not in solr:\t{len(in_fs_not_in_solr)}")
         console_logger.info('\n'.join(messages))
 
         if not options['no-changes']:
             # Mark fs sounds to go processing
             if in_fs_not_in_solr:
-                console_logger.info("Changing is_index_dirty_state of %i sounds" % len(in_fs_not_in_solr))
+                console_logger.info(f"Changing is_index_dirty_state of {len(in_fs_not_in_solr)} sounds")
                 Sound.objects.filter(id__in=in_fs_not_in_solr).update(is_index_dirty=True)
 
             # Delete sounds from solr that are not in the db
             if in_solr_not_in_fs:
-                console_logger.info("\nDeleting %i sounds that should not be in solr" % len(in_solr_not_in_fs))
+                console_logger.info(f"\nDeleting {len(in_solr_not_in_fs)} sounds that should not be in solr")
                 delete_sounds_from_search_engine(sound_ids=in_solr_not_in_fs)
 
         in_gaia_not_in_fs = list(set(gaia_ids).intersection(set(set(gaia_ids).difference(fs_mpa))))
@@ -97,7 +97,7 @@ class Command(LoggingBaseCommand):
 
         messages = []
         messages.append("\n***************\nGAIA INDEX\n***************\n")
-        messages.append("Sounds in gaia but not in fs:\t%i" % len(in_gaia_not_in_fs))
+        messages.append(f"Sounds in gaia but not in fs:\t{len(in_gaia_not_in_fs)}")
         messages.append("Sounds in fs but not in gaia:\t%i  (only considering sounds correctly analyzed)" \
                    % len(in_fs_not_in_gaia))
         console_logger.info('\n'.join(messages))

--- a/general/tasks.py
+++ b/general/tasks.py
@@ -257,7 +257,7 @@ def process_sound(sound_id, skip_previews=False, skip_displays=False):
     # Import Sound model from apps to avoid circular dependency
     Sound = apps.get_model('sounds.Sound')
 
-    set_timeout_alarm(settings.WORKER_TIMEOUT, 'Processing of sound %s timed out' % sound_id)
+    set_timeout_alarm(settings.WORKER_TIMEOUT, f'Processing of sound {sound_id} timed out')
     workers_logger.info("Starting processing of sound (%s)" % json.dumps({
         'task_name': SOUND_PROCESSING_TASK_NAME, 'sound_id': sound_id}))
     start_time = time.time()
@@ -308,7 +308,7 @@ def process_before_description(audio_file_path):
     Args:
         audio_file_path (str): path to the uploaded file
     """
-    set_timeout_alarm(settings.WORKER_TIMEOUT, 'Processing-before-describe of sound %s timed out' % audio_file_path)
+    set_timeout_alarm(settings.WORKER_TIMEOUT, f'Processing-before-describe of sound {audio_file_path} timed out')
     workers_logger.info("Starting processing-before-describe of sound (%s)" % json.dumps({
         'task_name': PROCESS_BEFORE_DESCRIPTION_TASK_NAME, 'audio_file_path': audio_file_path}))
     start_time = time.time()

--- a/general/templatetags/absurl.py
+++ b/general/templatetags/absurl.py
@@ -28,7 +28,7 @@ register = Library()
 class AbsoluteURLNode(URLNode):
     def render(self, context):
         path = super().render(context)
-        domain = "https://%s" % Site.objects.get_current().domain
+        domain = f"https://{Site.objects.get_current().domain}"
         return urllib.parse.urljoin(domain, path)
 
 def absurl(parser, token, node_cls=AbsoluteURLNode):

--- a/manage.py
+++ b/manage.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
             if (os.environ.get('RUN_MAIN') or os.environ.get('WERKZEUG_RUN_MAIN')) and not os.environ.get('DISABLE_DEBUGPY'):
                 import debugpy
                 debugpy.listen((settings.DEBUGGER_HOST, settings.DEBUGGER_PORT))
-                print('Debugger ready and listening at http://{}:{}/'.format(settings.DEBUGGER_HOST, settings.DEBUGGER_PORT))
+                print(f'Debugger ready and listening at http://{settings.DEBUGGER_HOST}:{settings.DEBUGGER_PORT}/')
         
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -146,7 +146,7 @@ def queries_stats_ajax(request):
         params = {
             'query': '*',
             'range': 14 * 60 * 60 * 24,
-            'filter': 'streams:%s' % settings.GRAYLOG_SEARCH_STREAM_ID,
+            'filter': f'streams:{settings.GRAYLOG_SEARCH_STREAM_ID}',
             'field': 'query'
         }
         req = requests.get(settings.GRAYLOG_DOMAIN + '/graylog/api/search/universal/relative/terms',

--- a/ratings/tests.py
+++ b/ratings/tests.py
@@ -133,16 +133,16 @@ class RatingsPageTestCase(TestCase):
 
         self.client.force_login(self.user1)
         resp = self.client.get(self.sound.get_absolute_url())
-        self.assertContains(resp, '<a href="/people/Anton/sounds/%s/rate/1/" title="pretty bad :-(" class="one-star">' % self.sound.id)
+        self.assertContains(resp, f'<a href="/people/Anton/sounds/{self.sound.id}/rate/1/" title="pretty bad :-(" class="one-star">')
 
     def test_no_rating_link_logged_out(self):
         """A logged out user doesn't see links to rate a sound"""
         resp = self.client.get(self.sound.get_absolute_url())
-        self.assertNotContains(resp, '<a href="/people/Anton/sounds/%s/rate/1/" title="pretty bad :-(" class="one-star">' % self.sound.id)
+        self.assertNotContains(resp, f'<a href="/people/Anton/sounds/{self.sound.id}/rate/1/" title="pretty bad :-(" class="one-star">')
 
     def test_no_rating_link_own_sound(self):
         """A user doesn't see links to rate their own sound"""
         user = User.objects.get(username="Anton")
         self.client.force_login(user)
         resp = self.client.get(self.sound.get_absolute_url())
-        self.assertNotContains(resp, '<a href="/people/Anton/sounds/%s/rate/1/" title="pretty bad :-(" class="one-star">' % self.sound.id)
+        self.assertNotContains(resp, f'<a href="/people/Anton/sounds/{self.sound.id}/rate/1/" title="pretty bad :-(" class="one-star">')

--- a/search/management/commands/test_search_engine_backend.py
+++ b/search/management/commands/test_search_engine_backend.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
         except ImportError as e:
             raise Exception(f'Backend class to test could not be imported: {e}')
 
-        console_logger.info('Testing search engine backend: {}'.format(options['backend_class']))
+        console_logger.info(f"Testing search engine backend: {options['backend_class']}")
         backend_name = options['backend_class']
         write_output = options['write_output']
 

--- a/search/templatetags/search.py
+++ b/search/templatetags/search.py
@@ -47,7 +47,7 @@ def display_facet(context, flt, facet, facet_type, title=""):
             if element['name'].count("_") > 0:
                 # We also modify the display name to remove the id
                 element['display_name'] = element['name'][element['name'].find("_")+1:]
-                element['params'] = '{} {}:"{}"'.format(filter_query, flt, urlquote_plus(element['name']))
+                element['params'] = f"{filter_query} {flt}:\"{urlquote_plus(element['name'])}\""
             else:
                 # If facet element belongs to "grouping pack" filter but does not have the "_" character in it, it
                 # means this corresponds to the "no pack" grouping which we don't want to show as a facet element.
@@ -55,8 +55,8 @@ def display_facet(context, flt, facet, facet_type, title=""):
         else:
             element['display_name'] = element['name']
 
-        element['params'] = '{} {}:"{}"'.format(filter_query, flt, urlquote_plus(element['name']))
-        element['id'] = '{}--{}'.format(flt, urlquote_plus(element['name']))
+        element['params'] = f"{filter_query} {flt}:\"{urlquote_plus(element['name'])}\""
+        element['id'] = f"{flt}--{urlquote_plus(element['name'])}"
         element['add_filter_url'] = '.?g={}&only_p={}&q={}&f={}&s={}&w={}'.format(
             context['group_by_pack_in_request'],
             context['only_sounds_with_pack'],

--- a/search/views.py
+++ b/search/views.py
@@ -53,7 +53,7 @@ def search_view_helper(request, tags_mode=False):
 
     # check if there was a filter parsing error
     if extra_vars['parsing_error']:
-        search_logger.error('Query filter parsing error. filter: %s' % (request.GET.get("f", "")))
+        search_logger.error(f"Query filter parsing error. filter: {request.GET.get('f', '')}")
         extra_vars.update({'error_text': 'There was an error while searching, is your query correct?'})
         return render(request, 'search/search.html', extra_vars)
 
@@ -185,7 +185,7 @@ def search_view_helper(request, tags_mode=False):
         search_logger.error(f'Search error: query: {str(query_params)} error {e}')
         tvars.update({'error_text': 'There was an error while searching, is your query correct?'})
     except Exception as e:
-        search_logger.error('Could probably not connect to Solr - %s' % e)
+        search_logger.error(f'Could probably not connect to Solr - {e}')
         tvars.update({'error_text': 'The search server could not be reached, please try again later.'})
 
     if request.GET.get("ajax", "") != "1":
@@ -424,7 +424,7 @@ def search_forum(request):
             error = True
             error_text = 'There was an error while searching, is your query correct?'
         except Exception as e:
-            search_logger.error("Could probably not connect to the search engine - %s" % e)
+            search_logger.error(f"Could probably not connect to the search engine - {e}")
             error = True
             error_text = 'The search server could not be reached, please try again later.'
 

--- a/sounds/admin.py
+++ b/sounds/admin.py
@@ -64,7 +64,7 @@ class SoundAdmin(DjangoObjectActions, admin.ModelAdmin):
 
     def get_sound_name(self, obj):
         max_len = 15
-        return '{}{}'.format(obj.original_filename[:max_len], '...' if len(obj.original_filename) > max_len else '')
+        return f"{obj.original_filename[:max_len]}{'...' if len(obj.original_filename) > max_len else ''}"
     get_sound_name.short_description = 'Name'
 
     def reprocess_sound(self, request, queryset_or_object):

--- a/sounds/forms.py
+++ b/sounds/forms.py
@@ -189,7 +189,7 @@ class NewLicenseForm(forms.Form):
             new_qs = License.objects.filter(Q(name__startswith='Attribution') | Q(name__startswith='Creative')).exclude(deed_url__contains="3.0")
             self.fields['license'].queryset = new_qs
             self.license_qs = new_qs
-        valid_licenses = ', '.join(['"%s"' % name for name in list(self.license_qs.values_list('name', flat=True))])
+        valid_licenses = ', '.join([f'"{name}"' for name in list(self.license_qs.values_list('name', flat=True))])
         self.fields['license'].error_messages.update({'invalid_choice': 'Invalid license. Should be one of %s'
                                                                         % valid_licenses})
     def clean_license(self):
@@ -316,8 +316,8 @@ class BWSoundEditAndDescribeForm(forms.Form):
             new_qs = License.objects.filter(Q(name__startswith='Attribution') | Q(name__startswith='Creative')).exclude(deed_url__contains="3.0")
             self.fields['license'].queryset = new_qs
             self.license_qs = new_qs
-        valid_licenses = ', '.join(['"%s"' % name for name in list(self.license_qs.values_list('name', flat=True))])
-        self.fields['license'].error_messages.update({'invalid_choice': 'Invalid license. Should be one of %s' % valid_licenses})
+        valid_licenses = ', '.join([f'"{name}"' for name in list(self.license_qs.values_list('name', flat=True))])
+        self.fields['license'].error_messages.update({'invalid_choice': f'Invalid license. Should be one of {valid_licenses}'})
 
         # Prepare pack field
         self.fields['pack'].queryset = user_packs.extra(select={'lower_name': 'lower(name)'}).order_by('lower_name')

--- a/sounds/management.py
+++ b/sounds/management.py
@@ -38,4 +38,4 @@ def create_locations(sender, **kwargs):
         if not os.path.isdir(folder):
             os.makedirs(folder, exist_ok=True)
         else:
-            print ("Folder: '%s' already exists" % folder)
+            print (f"Folder: '{folder}' already exists")

--- a/sounds/management/commands/check_sound_paths.py
+++ b/sounds/management/commands/check_sound_paths.py
@@ -49,4 +49,4 @@ class Command(BaseCommand):
 
         if missing_sound_ids and options['outfile'] is not None:
             json.dump(missing_sound_ids, open(options['outfile'], 'w'))
-            console_logger.info('List of sound IDs with missing files saved in "{}"'.format(options['outfile']))
+            console_logger.info(f"List of sound IDs with missing files saved in \"{options['outfile']}\"")

--- a/sounds/management/commands/update_cdn_sounds.py
+++ b/sounds/management/commands/update_cdn_sounds.py
@@ -105,7 +105,7 @@ class Command(LoggingBaseCommand):
                         # Before making the symlink, check again that sound exists, otherwise don't make it as there were problems copying sound
                         sound_exists = c.run(f'ls {dst_sound_path}', hide=True, warn=True).exited == 0
                         if sound_exists:
-                            c.run('rm {}'.format(os.path.join(cdn_symlinks_dir, folder_id,  f'{sound_id}-*')), hide=True, warn=True)
+                            c.run(f"rm {os.path.join(cdn_symlinks_dir, folder_id, f'{sound_id}-*')}", hide=True, warn=True)
                             random_uuid = str(uuid.uuid4())
                             symlink_name = f'{sound_id}-{random_uuid}'
                             dst_symlink_path = os.path.join(cdn_symlinks_dir, folder_id,  symlink_name)

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -174,14 +174,14 @@ class BulkUploadProgress(models.Model):
             'n_lines_with_errors': len(self.validation_output['lines_with_errors']),
             'n_global_errors': len(self.validation_output['global_errors']),
         })
-        web_logger.info('Validated data file for bulk upload (%s)' % json.dumps(bulk_upload_basic_data))
+        web_logger.info(f'Validated data file for bulk upload ({json.dumps(bulk_upload_basic_data)})')
 
     def describe_sounds(self):
         """
         Start the actual description of the sounds and add them to Freesound.
         """
         bulk_upload_basic_data = self.get_bulk_upload_basic_data_for_log()
-        web_logger.info('Started creating sound objects for bulk upload (%s)' % json.dumps(bulk_upload_basic_data))
+        web_logger.info(f'Started creating sound objects for bulk upload ({json.dumps(bulk_upload_basic_data)})')
         bulk_describe_from_csv(
             self.csv_path,
             delete_already_existing=False,
@@ -189,7 +189,7 @@ class BulkUploadProgress(models.Model):
             sounds_base_dir=os.path.join(settings.UPLOADS_PATH, str(self.user_id)),
             username=self.user.username,
             bulkupload_progress_id=self.id)
-        web_logger.info('Finished creating sound objects for bulk upload (%s)' % json.dumps(bulk_upload_basic_data))
+        web_logger.info(f'Finished creating sound objects for bulk upload ({json.dumps(bulk_upload_basic_data)})')
 
     def store_progress_for_line(self, line_no, message):
         """
@@ -1150,7 +1150,7 @@ class Sound(SocialModel):
 
     def create_moderation_ticket(self):
         ticket = Ticket.objects.create(
-            title='Moderate sound %s' % self.original_filename,
+            title=f'Moderate sound {self.original_filename}',
             status=TICKET_STATUS_NEW,
             queue=Queue.objects.get(name='sound moderation'),
             sender=self.user,
@@ -1158,7 +1158,7 @@ class Sound(SocialModel):
         )
         TicketComment.objects.create(
             sender=self.user,
-            text="I've uploaded %s. Please moderate!" % self.original_filename,
+            text=f"I've uploaded {self.original_filename}. Please moderate!",
             ticket=ticket,
         )
 
@@ -1193,7 +1193,7 @@ class Sound(SocialModel):
         if force or ((self.processing_state != "OK" or self.processing_ongoing_state != "FI") and self.estimate_num_processing_attemps() <= 3):
             self.set_processing_ongoing_state("QU")
             tasks.process_sound.delay(sound_id=self.id, skip_previews=skip_previews, skip_displays=skip_displays)
-            sounds_logger.info("Send sound with id %s to queue 'process'" % self.id)
+            sounds_logger.info(f"Send sound with id {self.id} to queue 'process'")
             return True
 
     def estimate_num_processing_attemps(self):

--- a/sounds/templatetags/sound_signature.py
+++ b/sounds/templatetags/sound_signature.py
@@ -10,7 +10,7 @@ SOUND_SIGNATURE_SOUND_URL_PLACEHOLDER = "${sound_url}"
 
 @register.filter(name='sound_signature_replace')
 def sound_signature_replace(value, sound):
-    domain = "https://%s" % Site.objects.get_current().domain
+    domain = f"https://{Site.objects.get_current().domain}"
     abs_url = urllib.parse.urljoin(domain, reverse('sound', args=[sound.user.username, sound.id]))
 
     replace = [(SOUND_SIGNATURE_SOUND_ID_PLACEHOLDER, str(sound.id)),

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -202,7 +202,7 @@ def front_page(request):
     top_donor_user_id = cache.get("top_donor_user_id", None)
     top_donor_donation_amount = cache.get("top_donor_donation_amount", None)
     if popular_searches is not None:
-        popular_searches = [(query_terms, '{}?q={}'.format(reverse('sounds-search'), query_terms))
+        popular_searches = [(query_terms, f"{reverse('sounds-search')}?q={query_terms}")
                             for query_terms in popular_searches]
 
     current_forum_threads = get_hot_threads(n=10)
@@ -329,7 +329,7 @@ def after_download_modal(request):
         modal_shown_timestamps = [item for item in modal_shown_timestamps if item > (time.time() - 24 * 3600)]
 
         if should_suggest_donation(request.user, len(modal_shown_timestamps)):
-            web_logger.info('Showing after download donate modal (%s)' % json.dumps({'user_id': request.user.id}))
+            web_logger.info(f"Showing after download donate modal ({json.dumps({'user_id': request.user.id})})")
             modal_shown_timestamps.append(time.time())
             cache.set(modal_shown_timestamps_cache_key(request.user), modal_shown_timestamps,
                       60 * 60 * 24)  # 24 lifetime cache
@@ -469,7 +469,7 @@ def sound_edit(request, username, sound_id):
             sound.original_filename = data["name"]
             sound.mark_index_dirty()
             sound.invalidate_template_caches()
-            update_sound_tickets(sound, '%s updated the sound description and/or tags.' % request.user.username)
+            update_sound_tickets(sound, f'{request.user.username} updated the sound description and/or tags.')
             return HttpResponseRedirect(sound.get_absolute_url())
     else:
         tags = " ".join([tagged_item.tag.name for tagged_item in sound.tags.all().order_by('tag__name')])
@@ -503,7 +503,7 @@ def sound_edit(request, username, sound_id):
 
             sound.mark_index_dirty()  # Marks as dirty and saves
             sound.invalidate_template_caches()
-            update_sound_tickets(sound, '%s updated the sound pack.' % request.user.username)
+            update_sound_tickets(sound, f'{request.user.username} updated the sound pack.')
             for affected_pack in affected_packs:  # Process affected packs
                 affected_pack.process()
 
@@ -534,7 +534,7 @@ def sound_edit(request, username, sound_id):
 
             sound.mark_index_dirty()
             sound.invalidate_template_caches()
-            update_sound_tickets(sound, '%s updated the sound geotag.' % request.user.username)
+            update_sound_tickets(sound, f'{request.user.username} updated the sound geotag.')
             return HttpResponseRedirect(sound.get_absolute_url())
     else:
         if sound.geotag:
@@ -554,7 +554,7 @@ def sound_edit(request, username, sound_id):
             if sound.pack:
                 sound.pack.process()  # Sound license changed, process pack (if sound has pack)
             sound.invalidate_template_caches()
-            update_sound_tickets(sound, '%s updated the sound license.' % request.user.username)
+            update_sound_tickets(sound, f'{request.user.username} updated the sound license.')
             return HttpResponseRedirect(sound.get_absolute_url())
     else:
         license_form = NewLicenseForm(initial={'license': sound.license}, 
@@ -638,7 +638,7 @@ def edit_and_describe_sounds_helper(request):
             except NoAudioException:
                 # If for some reason audio file does not exist, skip creating this sound
                 messages.add_message(request, messages.ERROR,
-                                     'Something went wrong with accessing the file {}.'.format(form.cleaned_data['name']))
+                                     f"Something went wrong with accessing the file {form.cleaned_data['name']}.")
             except AlreadyExistsException as e:
                 msg = e.message
                 messages.add_message(request, messages.WARNING, msg)
@@ -1036,7 +1036,7 @@ def pack(request, username, pack_id):
 @redirect_if_old_username_or_404
 def packs_for_user(request, username):
     if using_beastwhoosh(request):
-        return HttpResponseRedirect('{}?f=username:%22{}%22&s=Date+added+(newest+first)&g=1&only_p=1'.format(reverse('sounds-search'), username))
+        return HttpResponseRedirect(f"{reverse('sounds-search')}?f=username:%22{username}%22&s=Date+added+(newest+first)&g=1&only_p=1")
 
     user = request.parameter_user
     order = request.GET.get("order", "name")
@@ -1054,7 +1054,7 @@ def packs_for_user(request, username):
 @redirect_if_old_username_or_404
 def for_user(request, username):
     if using_beastwhoosh(request):
-        return HttpResponseRedirect('{}?f=username:%22{}%22&s=Date+added+(newest+first)&g=1'.format(reverse('sounds-search'), username))
+        return HttpResponseRedirect(f"{reverse('sounds-search')}?f=username:%22{username}%22&s=Date+added+(newest+first)&g=1")
 
     sound_user = request.parameter_user
     paginator = paginate(request, Sound.public.only('id').filter(user=sound_user), settings.SOUNDS_PER_PAGE)
@@ -1089,7 +1089,7 @@ def delete(request, username, sound_id):
             try:
                 ticket = sound.ticket
                 tc = TicketComment(sender=request.user,
-                                   text="User %s deleted the sound" % request.user,
+                                   text=f"User {request.user} deleted the sound",
                                    ticket=ticket,
                                    moderator_only=False)
                 tc.save()

--- a/support/views.py
+++ b/support/views.py
@@ -71,7 +71,7 @@ def create_zendesk_ticket(request_email, subject, message, user=None):
             reverse('account', args=[user.username])
         )
 
-        message += "\n\n-- \n%s" % user_url
+        message += f"\n\n-- \n{user_url}"
 
         requester.name = user.username
 

--- a/tags/views.py
+++ b/tags/views.py
@@ -50,7 +50,7 @@ def tags(request, multiple_tags=None):
         if multiple_tags:
             # If using BW and tags in URL, we re-write tags as query filter and redirect
             tags_as_filter = "+".join('tag:"' + tag + '"' for tag in multiple_tags)
-            return HttpResponseRedirect('{}?f={}'.format(reverse('tags'), tags_as_filter))
+            return HttpResponseRedirect(f"{reverse('tags')}?f={tags_as_filter}")
         else:
             # Share same view code as for the search view, but set "tags mode" on
             return search_view_helper(request, tags_mode=True)
@@ -101,10 +101,10 @@ def tags(request, multiple_tags=None):
 
     except SearchEngineException as e:
         error = True
-        search_logger.error('Search error: %s' % e)
+        search_logger.error(f'Search error: {e}')
     except Exception as e:
         error = True
-        search_logger.error('Could probably not connect to Solr - %s' % e)
+        search_logger.error(f'Could probably not connect to Solr - {e}')
 
     # Calculate follow_tags_url, unfollow_tags_url and show_unfollow_button tvars
     slash_tag = "/".join(multiple_tags)

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -362,7 +362,7 @@ def moderation_assign_user(request, user_id, only_unassigned=True):
 
     tickets.update(assignee=request.user, status=TICKET_STATUS_ACCEPTED, modified=datetime.datetime.now())
 
-    msg = 'You have been assigned all new sounds from %s.' % sender.username
+    msg = f'You have been assigned all new sounds from {sender.username}.'
     messages.add_message(request, messages.INFO, msg)
     invalidate_all_moderators_header_cache()
 
@@ -386,7 +386,7 @@ def moderation_assign_single_ticket(request, user_id, ticket_id):
     ticket.save()
     invalidate_all_moderators_header_cache()
 
-    msg = 'You have been assigned ticket "%s".' % ticket.title
+    msg = f'You have been assigned ticket "{ticket.title}".'
     messages.add_message(request, messages.INFO, msg)
 
     next = request.GET.get("next", None)
@@ -396,11 +396,11 @@ def moderation_assign_single_ticket(request, user_id, ticket_id):
         if next == "tardy_users":
             return redirect("tickets-moderation-tardy-users")
         elif next == "tardy_moderators":
-            return redirect(reverse("tickets-moderation-tardy-moderators")+"?page=%s" % p)
+            return redirect(reverse("tickets-moderation-tardy-moderators")+f"?page={p}")
         elif next == "ticket":
             return redirect(reverse("tickets-ticket", kwargs={'ticket_key': ticket.key}))
         else:
-            return redirect(reverse("tickets-moderation-home")+"?page=%s" % p)
+            return redirect(reverse("tickets-moderation-home")+f"?page={p}")
     else:
         return redirect("tickets-moderation-home")
 

--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -128,7 +128,7 @@ class FreesoundAudioProcessorBase:
         if settings.USE_PREVIEWS_WHEN_ORIGINAL_FILES_MISSING and not os.path.exists(sound_path):
             sound_path = self.sound.locations('preview.LQ.mp3.path')
         if not os.path.exists(sound_path):
-            raise AudioProcessingException('could not find file with path %s' % sound_path)
+            raise AudioProcessingException(f'could not find file with path {sound_path}')
         self.log_info("file found in " + sound_path)
         return sound_path
 
@@ -166,12 +166,12 @@ class FreesoundAudioProcessorBase:
             try:
                 audioprocessing.convert_using_ffmpeg(sound_path, tmp_wavefile, mono_out=mono)
             except AudioProcessingException as e:
-                raise AudioProcessingException("conversion to PCM failed: %s" % e)
+                raise AudioProcessingException(f"conversion to PCM failed: {e}")
             except OSError as e:
                 raise AudioProcessingException("conversion to PCM failed, "
                                                "make sure that ffmpeg executable exists: %s" % e)
         except Exception as e:
-            raise AudioProcessingException("unhandled exception while converting to PCM: %s" % e)
+            raise AudioProcessingException(f"unhandled exception while converting to PCM: {e}")
 
         self.log_info("PCM file path: " + tmp_wavefile)
         return tmp_wavefile
@@ -187,7 +187,7 @@ class FreesoundAudioProcessor(FreesoundAudioProcessorBase):
     def process(self, skip_previews=False, skip_displays=False):
 
         with TemporaryDirectory(
-                prefix='processing_%s_' % self.sound.id,
+                prefix=f'processing_{self.sound.id}_',
                 dir=settings.PROCESSING_TEMP_DIR) as tmp_directory:
 
             # Change ongoing processing state to "processing" in Sound model
@@ -371,10 +371,10 @@ class FreesoundAudioProcessorBeforeDescription(FreesoundAudioProcessorBase):
         console_logger.error(f"{self.audio_file_path} - {message}")
 
     def set_failure(self, message, error=None):
-        logging_message = "file with path %s failed\n" % self.audio_file_path
-        logging_message += "\tmessage: %s\n" % message
+        logging_message = f"file with path {self.audio_file_path} failed\n"
+        logging_message += f"\tmessage: {message}\n"
         if error:
-            logging_message += "\terror: %s" % str(error)
+            logging_message += f"\terror: {str(error)}"
         self.log_error(logging_message)
 
     def get_sound_object(self, sound_id):

--- a/utils/audioprocessing/processing.py
+++ b/utils/audioprocessing/processing.py
@@ -453,7 +453,7 @@ def convert_to_pcm(input_filename, output_filename):
     converts any audio file type to pcm audio
     """
     if not os.path.exists(input_filename):
-        raise AudioProcessingException("file %s does not exist" % input_filename)
+        raise AudioProcessingException(f"file {input_filename} does not exist")
     sound_type = get_sound_type(input_filename)
 
     if sound_type == "mp3":
@@ -500,7 +500,7 @@ def stereofy_and_find_info(stereofy_executble_path, input_filename, output_filen
     """
 
     if not os.path.exists(input_filename):
-        raise AudioProcessingException("file %s does not exist" % input_filename)
+        raise AudioProcessingException(f"file {input_filename} does not exist")
 
     cmd = [stereofy_executble_path, "--input", input_filename, "--output", output_filename]
 
@@ -547,7 +547,7 @@ def convert_to_mp3(input_filename, output_filename, quality=70):
     """
 
     if not os.path.exists(input_filename):
-        raise AudioProcessingException("file %s does not exist" % input_filename)
+        raise AudioProcessingException(f"file {input_filename} does not exist")
 
     command = ["lame", "--silent", "--abr", str(quality), input_filename, output_filename]
 
@@ -565,7 +565,7 @@ def convert_to_ogg(input_filename, output_filename, quality=1):
     """
 
     if not os.path.exists(input_filename):
-        raise AudioProcessingException("file %s does not exist" % input_filename)
+        raise AudioProcessingException(f"file {input_filename} does not exist")
 
     command = ["oggenc", "-q", str(quality), input_filename, "-o", output_filename]
 
@@ -585,7 +585,7 @@ def convert_using_ffmpeg(input_filename, output_filename, mono_out=False):
     """
 
     if not os.path.exists(input_filename):
-        raise AudioProcessingException("file %s does not exist" % input_filename)
+        raise AudioProcessingException(f"file {input_filename} does not exist")
 
     command = ["ffmpeg", "-y", "-i", input_filename, "-acodec", "pcm_s16le", "-ar", "44100"]
     if mono_out:

--- a/utils/audioprocessing/wav2png.py
+++ b/utils/audioprocessing/wav2png.py
@@ -45,13 +45,13 @@ def main(args):
         this_args = (input_file, output_file_w, output_file_s, args.width, args.height, args.fft_size,
                      progress_callback, args.color_scheme)
 
-        print("processing file %s:\n\t" % input_file, end="")
+        print(f"processing file {input_file}:\n\t", end="")
 
         if not args.profile:
             try:
                 create_wave_images(*this_args)
             except AudioProcessingException as e:
-                print("Error running wav2png: %s" % e)
+                print(f"Error running wav2png: {e}")
         else:
             from hotshot import stats
             import hotshot

--- a/utils/frontend_handling.py
+++ b/utils/frontend_handling.py
@@ -160,7 +160,7 @@ def redirect_if_beastwhoosh(redirect_url_name='front-page', kwarg_keys=None, que
                     new_args = []
                 url = reverse(redirect_url_name, args=new_args)
                 if query_string:
-                    url += '?%s' % query_string
+                    url += f'?{query_string}'
                 return HttpResponseRedirect(url)
         return _wrapped_view
     return decorator
@@ -184,7 +184,7 @@ def redirect_if_beastwhoosh_inline(function=None, redirect_url_name='front-page'
                     new_args = []
                 url = reverse(redirect_url_name, args=new_args)
                 if query_string:
-                    url += '?%s' % query_string
+                    url += f'?{query_string}'
                 return HttpResponseRedirect(url)
         return _wrapped_view
     return decorator(function)

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -35,7 +35,7 @@ def transform_unique_email(email):
     duplicated user emails by the contents returned in this function. This is reused for further
     checks in utils.mail.replace_email_to and accounts.views.multi_email_cleanup.
     """
-    return "dupemail+{}@freesound.org".format(email.replace("@", "%"))
+    return f"dupemail+{email.replace('@', '%')}@freesound.org"
 
 
 def _ensure_list(item):

--- a/utils/nginxsendfile.py
+++ b/utils/nginxsendfile.py
@@ -32,8 +32,8 @@ def prepare_sendfile_arguments_for_sound_download(sound):
 
     if settings.USE_PREVIEWS_WHEN_ORIGINAL_FILES_MISSING and not os.path.exists(sound_path):
         sound_path = sound.locations("preview.LQ.mp3.path")
-        sound_friendly_filename = '{}.{}'.format(sound_friendly_filename[:sound_friendly_filename.rfind('.')], 'mp3')
-        sound_sendfile_url = '{}.{}'.format(sound_sendfile_url[:sound_sendfile_url.rfind('.')], 'mp3')
+        sound_friendly_filename = f"{sound_friendly_filename[:sound_friendly_filename.rfind('.')]}.mp3"
+        sound_sendfile_url = f"{sound_sendfile_url[:sound_sendfile_url.rfind('.')]}.mp3"
 
     return sound_path, sound_friendly_filename, sound_sendfile_url
 
@@ -50,6 +50,6 @@ def sendfile(path, attachment_name, secret_url=None):
         response['X-Accel-Redirect'] = secret_url
 
     response['Content-Type'] = "application/octet-stream"
-    response['Content-Disposition'] = "attachment; filename=\"%s\"" % attachment_name
+    response['Content-Disposition'] = f"attachment; filename=\"{attachment_name}\""
     
     return response

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -562,7 +562,7 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
     def get_user_tags(self, username):
         query = SolrQuery()
         query.set_query('*:*')
-        filter_query = 'username:"%s"' % username
+        filter_query = f'username:"{username}"'
         query.set_query_options(field_list=["id"], filter_query=filter_query)
         query.add_facet_fields("tag")
         query.set_facet_options("tag", limit=10, mincount=1)

--- a/utils/search/backends/solr_common.py
+++ b/utils/search/backends/solr_common.py
@@ -143,12 +143,12 @@ class SolrQuery:
         except KeyError:
             raise SearchEngineException("you haven't defined any facet fields yet")
 
-        self.params['f.%s.facet.limit' % field] = limit
-        self.params['f.%s.facet.offset' % field] = offset
-        self.params['f.%s.facet.prefix' % field] = prefix
-        self.params['f.%s.facet.sort' % field] = sort
-        self.params['f.%s.facet.mincount' % field] = mincount
-        self.params['f.%s.facet.missing' % field] = count_missing
+        self.params[f'f.{field}.facet.limit'] = limit
+        self.params[f'f.{field}.facet.offset'] = offset
+        self.params[f'f.{field}.facet.prefix'] = prefix
+        self.params[f'f.{field}.facet.sort'] = sort
+        self.params[f'f.{field}.facet.mincount'] = mincount
+        self.params[f'f.{field}.facet.missing'] = count_missing
 
     def add_date_facet_fields(self, *args):
         """Add date facet fields
@@ -182,11 +182,11 @@ class SolrQuery:
         except KeyError:
             raise SearchEngineException("you haven't defined any date facet fields yet")
 
-        self.params['f.%s.date.start' % field] = start
-        self.params['f.%s.date.end' % field] = start
-        self.params['f.%s.date.gap' % field] = gap
-        self.params['f.%s.date.hardend' % field] = hardened
-        self.params['f.%s.date.other' % field] = count_other
+        self.params[f'f.{field}.date.start'] = start
+        self.params[f'f.{field}.date.end'] = start
+        self.params[f'f.{field}.date.gap'] = gap
+        self.params[f'f.{field}.date.hardend'] = hardened
+        self.params[f'f.{field}.date.other'] = count_other
 
     def set_highlighting_options_default(self, field_list=None, snippets=None, fragment_size=None,
                                          merge_contiguous=None, require_field_match=None, max_analyzed_chars=None,
@@ -238,12 +238,12 @@ class SolrQuery:
         except KeyError:
             raise SearchEngineException("you haven't defined any highlighting fields yet")
 
-        self.params['f.%s.hl.fl.snippets' % field] = snippets
-        self.params['f.%s.hl.fragsize' % field] = fragment_size
-        self.params['f.%s.hl.mergeContiguous' % field] = merge_contiguous
-        self.params['f.%s.hl.alternateField' % field] = alternate_field
-        self.params['f.%s.hl.simple.pre' % field] = pre
-        self.params['f.%s.hl.simple.post' % field] = post
+        self.params[f'f.{field}.hl.fl.snippets'] = snippets
+        self.params[f'f.{field}.hl.fragsize'] = fragment_size
+        self.params[f'f.{field}.hl.mergeContiguous'] = merge_contiguous
+        self.params[f'f.{field}.hl.alternateField'] = alternate_field
+        self.params[f'f.{field}.hl.simple.pre'] = pre
+        self.params[f'f.{field}.hl.simple.post'] = post
 
     def __str__(self):
         return urllib.parse.urlencode(self.params, doseq=True)

--- a/utils/search/backends/test_search_engine_backend.py
+++ b/utils/search/backends/test_search_engine_backend.py
@@ -65,7 +65,7 @@ class TestSearchEngineBackend():
                 results.highlighting
             ))
         for count, doc in enumerate(results.docs):
-            self.output_file.write('\t{}. {}: {}\n'.format(count + 1, doc['id'], doc))
+            self.output_file.write(f"\t{count + 1}. {doc['id']}: {doc}\n")
 
     def run_sounds_query_and_save_results(self, query_data):
         """Run a sounds search query in the search engine, save and return the results
@@ -424,7 +424,7 @@ class TestSearchEngineBackend():
         results = self.run_forum_query_and_save_results(dict(group_by_thread=False))
         for result1, result2 in zip(results.docs[:-1], results.docs[1:]):
             for field in expected_fields:
-                assert_and_continue(field in result1, '{} not present in result ID {}'.format(field, result1['id']))
+                assert_and_continue(field in result1, f"{field} not present in result ID {result1['id']}")
                 assert_and_continue(result1["thread_created"] >= result2["thread_created"],
                                     'Wrong sorting in query results')
 

--- a/utils/search/search_forum.py
+++ b/utils/search/search_forum.py
@@ -41,8 +41,8 @@ def add_posts_to_search_engine(post_objects):
         get_search_engine().add_forum_posts_to_index(post_objects)
         return num_posts
     except SearchEngineException as e:
-        console_logger.error("Failed to add posts to search engine index: %s" % str(e))
-        search_logger.error("Failed to add posts to search engine index: %s" % str(e))
+        console_logger.error(f"Failed to add posts to search engine index: {str(e)}")
+        search_logger.error(f"Failed to add posts to search engine index: {str(e)}")
         return 0
 
 
@@ -52,13 +52,13 @@ def delete_posts_from_search_engine(post_ids):
     Args:
         post_ids (list[int]): IDs of the forum posts to delete
     """
-    console_logger.info("Deleting %d forum posts from search engine" % len(post_ids))
-    search_logger.info("Deleting %d forum posts from search engine" % len(post_ids))
+    console_logger.info(f"Deleting {len(post_ids)} forum posts from search engine")
+    search_logger.info(f"Deleting {len(post_ids)} forum posts from search engine")
     try:
         get_search_engine().remove_forum_posts_from_index(post_ids)
     except SearchEngineException as e:
-        console_logger.error("Could not delete forum posts: %s" % str(e))
-        search_logger.error("Could not delete forum posts: %s" % str(e))
+        console_logger.error(f"Could not delete forum posts: {str(e)}")
+        search_logger.error(f"Could not delete forum posts: {str(e)}")
 
 
 def delete_all_posts_from_search_engine():
@@ -66,7 +66,7 @@ def delete_all_posts_from_search_engine():
     try:
         get_search_engine().remove_all_forum_posts()
     except SearchEngineException as e:
-        console_logger.error("Could not delete forum posts: %s" % str(e))
+        console_logger.error(f"Could not delete forum posts: {str(e)}")
 
 
 def get_all_post_ids_from_search_engine(page_size=2000):
@@ -91,5 +91,5 @@ def get_all_post_ids_from_search_engine(page_size=2000):
             solr_count = response.num_found
             current_page += 1
     except SearchEngineException as e:
-        console_logger.error("Could retrieve all forum post IDs from search engine: %s" % str(e))
+        console_logger.error(f"Could retrieve all forum post IDs from search engine: {str(e)}")
     return sorted(solr_ids)

--- a/utils/search/search_sounds.py
+++ b/utils/search/search_sounds.py
@@ -353,8 +353,8 @@ def add_sounds_to_search_engine(sound_objects):
         get_search_engine().add_sounds_to_index(sound_objects)
         return num_sounds
     except SearchEngineException as e:
-        console_logger.error("Failed to add sounds to search engine index: %s" % str(e))
-        search_logger.error("Failed to add sounds to search engine index: %s" % str(e))
+        console_logger.error(f"Failed to add sounds to search engine index: {str(e)}")
+        search_logger.error(f"Failed to add sounds to search engine index: {str(e)}")
         return 0
 
 
@@ -364,13 +364,13 @@ def delete_sounds_from_search_engine(sound_ids):
     Args:
         sound_ids (list[int]): IDs of the sounds to delete
     """
-    console_logger.info("Deleting %d sounds from search engine" % len(sound_ids))
-    search_logger.info("Deleting %d sounds from search engine" % len(sound_ids))
+    console_logger.info(f"Deleting {len(sound_ids)} sounds from search engine")
+    search_logger.info(f"Deleting {len(sound_ids)} sounds from search engine")
     try:
         get_search_engine().remove_sounds_from_index(sound_ids)
     except SearchEngineException as e:
-        console_logger.error("Could not delete sounds: %s" % str(e))
-        search_logger.error("Could not delete sounds: %s" % str(e))
+        console_logger.error(f"Could not delete sounds: {str(e)}")
+        search_logger.error(f"Could not delete sounds: {str(e)}")
 
 
 def delete_all_sounds_from_search_engine():
@@ -380,8 +380,8 @@ def delete_all_sounds_from_search_engine():
     try:
         get_search_engine().remove_all_sounds()
     except SearchEngineException as e:
-        console_logger.error("Could not delete sounds: %s" % str(e))
-        search_logger.error("Could not delete sounds: %s" % str(e))
+        console_logger.error(f"Could not delete sounds: {str(e)}")
+        search_logger.error(f"Could not delete sounds: {str(e)}")
 
 
 def get_all_sound_ids_from_search_engine(page_size=2000):
@@ -408,7 +408,7 @@ def get_all_sound_ids_from_search_engine(page_size=2000):
             solr_count = response.num_found
             current_page += 1
     except SearchEngineException as e:
-        search_logger.error("Could not retrieve all sound IDs from search engine: %s" % str(e))
+        search_logger.error(f"Could not retrieve all sound IDs from search engine: {str(e)}")
     return sorted(solr_ids)
 
 
@@ -418,5 +418,5 @@ def get_random_sound_id_from_search_engine():
         search_logger.info("Making random sound query")
         return get_search_engine().get_random_sound_id()
     except SearchEngineException as e:
-        search_logger.error("Could not retrieve a random sound ID from search engine: %s" % str(e))
+        search_logger.error(f"Could not retrieve a random sound ID from search engine: {str(e)}")
     return 0

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -261,7 +261,7 @@ def create_sound(user,
             if sound.pack:
                 sound.pack.process()
         except Exception as e:
-            sounds_logger.info('Error sending sound to process and analyze: %s' % str(e))
+            sounds_logger.info(f'Error sending sound to process and analyze: {str(e)}')
 
     # Log
     if sound.uploaded_with_apiv2_client is not None:
@@ -365,7 +365,7 @@ def validate_input_csv_file(csv_header, csv_lines, sounds_base_dir, username=Non
 
             # Check that number of columns is ok
             if len(line) != len(EXPECTED_HEADER) and username is None:
-                line_errors['columns'] = 'Row should have %i columns but it has %i.' % (len(EXPECTED_HEADER), len(line))
+                line_errors['columns'] = f'Row should have {len(EXPECTED_HEADER)} columns but it has {len(line)}.'
                 n_columns_is_ok = False
 
             if len(line) != len(EXPECTED_HEADER_NO_USERNAME) and username is not None:
@@ -509,7 +509,7 @@ def bulk_describe_from_csv(csv_file_path, delete_already_existing=False, force_i
         console_logger.info('Major issues were found while validating the CSV file. '
                             'Fix them and re-run the command.')
         for error in global_errors:
-            console_logger.info('- %s' % error)
+            console_logger.info(f'- {error}')
         return
 
     # Print line error messages if any
@@ -519,10 +519,10 @@ def bulk_describe_from_csv(csv_file_path, delete_already_existing=False, force_i
             console_logger.info('The following %i lines contain invalid data. Fix them or re-run with -f to import '
                                 'skipping these lines:' % len(lines_with_errors))
         else:
-            console_logger.info('Skipping the following %i lines due to invalid data' % len(lines_with_errors))
+            console_logger.info(f'Skipping the following {len(lines_with_errors)} lines due to invalid data')
         for line in lines_with_errors:
             errors = '; '.join(line['line_errors'].values())
-            console_logger.info('l{}: {}'.format(line['line_no'], errors))
+            console_logger.info(f"l{line['line_no']}: {errors}")
         if not force_import:
             return
 
@@ -537,7 +537,7 @@ def bulk_describe_from_csv(csv_file_path, delete_already_existing=False, force_i
 
     # Start the actual process of uploading files
     lines_ok = [line for line in lines_validated if not line['line_errors']]
-    console_logger.info('Adding %i sounds to Freesound' % len(lines_ok))
+    console_logger.info(f'Adding {len(lines_ok)} sounds to Freesound')
     for line in lines_ok:
         line_cleaned = line['line_cleaned']
 
@@ -585,7 +585,7 @@ def bulk_describe_from_csv(csv_file_path, delete_already_existing=False, force_i
 
             message = 'l%i: Successfully added sound \'%s\' to Freesound.' % (line['line_no'], sound.original_filename,)
             if error_sending_to_process is not None:
-                message += ' Sound could have not been sent to process (%s).' % error_sending_to_process
+                message += f' Sound could have not been sent to process ({error_sending_to_process}).'
             console_logger.info(message)
 
         except NoAudioException:

--- a/utils/spam.py
+++ b/utils/spam.py
@@ -40,7 +40,7 @@ def is_spam(request, comment):
             return True
 
     # Akismet check
-    domain = "https://%s" % Site.objects.get_current().domain
+    domain = f"https://{Site.objects.get_current().domain}"
     try:
         api = Akismet(key=settings.AKISMET_KEY, blog_url=domain)
     except (APIKeyError, ConfigurationError):

--- a/utils/tests/test_forms.py
+++ b/utils/tests/test_forms.py
@@ -71,7 +71,7 @@ class TagFieldTest(TestCase):
         # maximum number tags
         err_message = "There can be maximum 30 tags, please select the most relevant ones!"
         with self.assertRaisesMessage(ValidationError, err_message):
-            tags = " ".join(["tag%s" % i for i in range(35)])
+            tags = " ".join([f"tag{i}" for i in range(35)])
             f.clean(tags)
 
         # remove common words

--- a/utils/tests/test_processing.py
+++ b/utils/tests/test_processing.py
@@ -97,7 +97,7 @@ class AudioProcessingTestCase(TestCase):
         # Do some stuff which needs to be carried out right before each test
         self.assertEqual(self.sound.processing_state, "PE")
         if create_sound_file:
-            create_test_files(paths=['{}'.format(self.sound.locations('path'))], make_valid_wav_files=True, duration=2)
+            create_test_files(paths=[f"{self.sound.locations('path')}"], make_valid_wav_files=True, duration=2)
     
     def setUp(self):
         user, _, sounds = create_user_and_sounds(num_sounds=1, type="wav")

--- a/wiki/tests.py
+++ b/wiki/tests.py
@@ -59,11 +59,11 @@ class WikiTestCase(TestCase):
         self.assertContains(resp, 'Help version 2')
 
         # Version that doesn't exist (uses latest)
-        resp = self.client.get('%s?version=100' % helpurl)
+        resp = self.client.get(f'{helpurl}?version=100')
         self.assertContains(resp, 'Help version 3')
 
         # Not a number in version param (uses latest)
-        resp = self.client.get('%s?version=notint' % helpurl)
+        resp = self.client.get(f'{helpurl}?version=notint')
         self.assertContains(resp, 'Help version 3')
 
     def test_page_with_no_content(self):


### PR DESCRIPTION
Here I used [flynt](https://github.com/ikamensh/flynt) to auto-convert some of the remaining non f-strings. There are still quite a number of `%` and `.format()` strings in the codebase which have not been auto converted because they are multi-line or have other formatted strings inside the format call, etc. Maybe one day we can manually convert the remaining ones, but actually in some cases the `.format` syntax is also more readable so I think I'm happy with how it is now :)