### PR TITLE
remove a few calls to old_div

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Pull docker images
       run: docker-compose -f docker-compose.test.yml pull
 
-    - uses: satackey/action-docker-layer-caching@v0.0.11
+    - uses: jpribyl/action-docker-layer-caching@v0.1.1
       continue-on-error: true
 
     - name: Build base image

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -18,7 +18,6 @@
 #     See AUTHORS file.
 #
 
-from past.utils import old_div
 import datetime
 import os
 import random
@@ -216,16 +215,16 @@ class Profile(SocialModel):
     @property
     def num_comments(self):
         return Comment.objects.filter(user=self.user).count()
-    
+
     def get_absolute_url(self):
         return reverse('account', args=[smart_str(self.user.username)])
-    
+
     def get_user_sounds_in_search_url(self):
         return f'{reverse("sounds-search")}?f=username:"{ self.user.username }"&s=Date+added+(newest+first)&g=0'
 
     @staticmethod
     def locations_static(user_id, has_avatar):
-        id_folder = str(old_div(user_id, 1000))
+        id_folder = str(user_id // 1000)
         if has_avatar:
             s_avatar = settings.AVATARS_URL + "%s/%d_S.jpg" % (id_folder, user_id)
             m_avatar = settings.AVATARS_URL + "%s/%d_M.jpg" % (id_folder, user_id)
@@ -589,17 +588,17 @@ class Profile(SocialModel):
 
     @property
     def avg_rating(self):
-        # Returns the average raring from 0 to 10
+        """Returns the average raring from 0 to 10"""
         ratings = list(SoundRating.objects.filter(sound__user=self.user).values_list('rating', flat=True))
         if ratings:
-            return old_div(1.0*sum(ratings),len(ratings))
+            return sum(ratings) / len(ratings)
         else:
             return 0
 
     @property
     def avg_rating_0_5(self):
-        # Returns the average raring, normalized from 0 tp 5
-        return old_div(self.avg_rating,2)
+        """Returns the average raring, normalized from 0 to 5"""
+        return self.avg_rating / 2
 
     def get_total_uploaded_sounds_length(self):
         # NOTE: this only includes duration of sounds that have been processed and moderated

--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -18,11 +18,11 @@
 #     See AUTHORS file.
 #
 
-from past.utils import old_div
 import collections
 import datetime
 import json
 import logging
+import math
 import urllib.parse
 from urllib.parse import unquote
 
@@ -502,13 +502,13 @@ class ApiSearchPaginator:
     def __init__(self, results, count, num_per_page):
         self.num_per_page = num_per_page
         self.count = count
-        self.num_pages = old_div(count, num_per_page) + int(count % num_per_page != 0)
+        self.num_pages = math.ceil(count / num_per_page)
         self.page_range = list(range(1, self.num_pages + 1))
         self.results = results
 
     def page(self, page_num):
         has_next = page_num < self.num_pages
-        has_previous = page_num > 1 and page_num <= self.num_pages
+        has_previous = 1 < page_num <= self.num_pages
 
         return {'object_list': self.results,
                 'has_next': has_next,

--- a/apiv2/serializers.py
+++ b/apiv2/serializers.py
@@ -20,7 +20,6 @@
 
 import json
 
-from past.utils import old_div
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -287,7 +286,7 @@ class AbstractSoundSerializer(serializers.HyperlinkedModelSerializer):
 
     avg_rating = serializers.SerializerMethodField()
     def get_avg_rating(self, obj):
-        return old_div(obj.avg_rating,2)
+        return obj.avg_rating / 2
 
     comments = serializers.SerializerMethodField()
     def get_comments(self, obj):

--- a/clustering/clustering.py
+++ b/clustering/clustering.py
@@ -275,7 +275,7 @@ class ClusteringEngine(object):
         sound_features, sound_ids_out = self.feature_store.return_features(sound_ids_list)
         A = kneighbors_graph(sound_features, k)
         for idx_from, (idx_to, distance) in enumerate(zip(A.indices, A.data)):
-            idx_from = int(old_div(idx_from, k))
+            idx_from = int(idx_from / k)
             if distance < clust_settings.MAX_NEIGHBORS_DISTANCE:
                 graph.add_edge(sound_ids_out[idx_from], sound_ids_out[idx_to])
 

--- a/forum/views.py
+++ b/forum/views.py
@@ -19,7 +19,6 @@
 #
 
 
-from past.utils import old_div
 import datetime
 import re
 import functools
@@ -196,7 +195,7 @@ def post(request, forum_name_slug, thread_id, post_id):
                              moderation_state="OK")
 
     posts_before = Post.objects.filter(thread=post.thread, moderation_state="OK", created__lt=post.created).count()
-    page = 1 + old_div(posts_before, settings.FORUM_POSTS_PER_PAGE)
+    page = 1 + (posts_before // settings.FORUM_POSTS_PER_PAGE)
     url = post.thread.get_absolute_url() + "?page=%d#post%d" % (page, post.id)
 
     return HttpResponseRedirect(url)

--- a/general/templatetags/util.py
+++ b/general/templatetags/util.py
@@ -18,7 +18,6 @@
 #     See AUTHORS file.
 #
 
-from past.utils import old_div
 import datetime
 import time
 
@@ -45,7 +44,7 @@ def truncate_string(value, length):
 
 @register.filter
 def duration(value):
-    duration_minutes = int(old_div(value,60))
+    duration_minutes = int(value / 60)
     duration_seconds = int(value) % 60
     duration_miliseconds = int((value - int(value)) * 1000)
     return "%d:%02d.%03d" % (duration_minutes, duration_seconds, duration_miliseconds)
@@ -66,7 +65,7 @@ def formatnumber(number):
         return f'{number/1000000:.1f}M'
     else:
         return f'{number}'
-    
+
 
 @register.filter
 def in_list(value,arg):
@@ -102,7 +101,7 @@ def element_at_index(l, index):
 
 @register.filter
 def strip_unnecessary_br(value):
-    # In HTMLCleaningFields some HTML tags are allowed. When the contents of these fields are passed to Django's |linebreaks 
+    # In HTMLCleaningFields some HTML tags are allowed. When the contents of these fields are passed to Django's |linebreaks
     # templatetag, <br> tags can be inserted between other HTML tags (linebreaks is not HTML-aware). This templatetag
     # implements a hacky fix for the most common issue which is the unnecessary br elements introduced after ul and li elements.
     value = value.replace('</li><br>', '</li>')

--- a/geotags/tests.py
+++ b/geotags/tests.py
@@ -18,7 +18,6 @@
 #     See AUTHORS file.
 #
 
-from past.utils import old_div
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
@@ -95,5 +94,5 @@ class GeoTagsTests(TestCase):
 
         resp = self.client.get(reverse('geotags-barray', kwargs={'tag': tag}))
         # Response contains 3 int32 objects per sound: id, lat and lng. Total size = 3 * 4 bytes = 12 bytes
-        n_sounds = old_div(len(resp.content), 12)
+        n_sounds = len(resp.content) // 12
         self.assertEqual(n_sounds, 2)

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -18,7 +18,6 @@
 #     See AUTHORS file.
 #
 
-from past.utils import old_div
 import datetime
 from collections import Counter
 
@@ -185,7 +184,7 @@ def monitor_moderation(request):
         len(tickets.views._get_tardy_moderator_tickets())
     tardy_user_sounds_count = len(tickets.views._get_tardy_user_tickets())
 
-    time_span = datetime.datetime.now()-datetime.timedelta(old_div(6*365,12))
+    time_span = datetime.datetime.now() - datetime.timedelta((6 * 365) // 12)
     #Maybe we should user created and not modified
     user_ids = tickets.models.Ticket.objects.filter(
             status=TICKET_STATUS_CLOSED,
@@ -220,7 +219,7 @@ def monitor_stats(request):
 @login_required
 @user_passes_test(lambda u: u.is_staff, login_url='/')
 def moderators_stats(request):
-    time_span = datetime.datetime.now()-datetime.timedelta(old_div(6*365,12))
+    time_span = datetime.datetime.now() - datetime.timedelta((6 * 365) // 12)
     #Maybe we should user created and not modified
     user_ids = tickets.models.Ticket.objects.filter(
             status=TICKET_STATUS_CLOSED,
@@ -327,7 +326,7 @@ def process_sounds(request):
 
 def moderator_stats_ajax(request):
     user_id = request.GET.get('user_id', None)
-    time_span = datetime.datetime.now()-datetime.timedelta(old_div(6*365,12))
+    time_span = datetime.datetime.now() - datetime.timedelta((6 * 365) // 12)
     tickets_mod = tickets.models.Ticket.objects.filter(
             assignee_id=user_id,
             status=TICKET_STATUS_CLOSED,

--- a/search/templatetags/search.py
+++ b/search/templatetags/search.py
@@ -19,7 +19,6 @@
 #
 
 
-from past.utils import old_div
 from django import template
 from django.conf import settings
 from urllib.parse import quote_plus
@@ -104,7 +103,7 @@ def display_facet(context, flt, facet, facet_type, title=""):
             filtered_facet = sorted(filtered_facet, key=lambda x: x['count'], reverse=True)
             max_count = max([element['count'] for element in filtered_facet])
             for element in filtered_facet:
-                element['weight'] = old_div((1.0 * element['count']), max_count)
+                element['weight'] = element['count'] / max_count
 
         # In BW we also add icons to license facets
         if flt == 'license':

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -19,7 +19,6 @@
 #
 
 
-from past.utils import old_div
 import json
 import os
 import time
@@ -59,7 +58,7 @@ class CommentSoundsTestCase(TestCase):
         sound.add_comment(user, "Test comment")
         sound.refresh_from_db()
         self.assertEqual(current_num_comments + 1, sound.num_comments)
-        self.assertEqual(sound.is_index_dirty, True)
+        self.assertTrue(sound.is_index_dirty)
 
     def test_email_notificaiton_on_send_email(self):
         # Add a comment to a sound using the view and test that email was sent
@@ -110,7 +109,7 @@ class CommentSoundsTestCase(TestCase):
         sound.post_delete_comment()
         sound.refresh_from_db()
         self.assertEqual(2, sound.num_comments)
-        self.assertEqual(sound.is_index_dirty, True)
+        self.assertTrue(sound.is_index_dirty)
 
     def test_delete_comment(self):
         sound = Sound.objects.get(id=19)
@@ -121,7 +120,7 @@ class CommentSoundsTestCase(TestCase):
         comment.delete()
         sound = Sound.objects.get(id=19)
         self.assertEqual(current_num_comments, sound.num_comments)
-        self.assertEqual(sound.is_index_dirty, True)
+        self.assertTrue(sound.is_index_dirty)
 
 
 class ChangeSoundOwnerTestCase(TestCase):
@@ -164,7 +163,7 @@ class ChangeSoundOwnerTestCase(TestCase):
         self.assertEqual(userA.profile.num_sounds, 3)
         self.assertEqual(userB.profile.num_sounds, 1)
         self.assertEqual(sound.user, userB)
-        self.assertEqual(sound.is_index_dirty, True)
+        self.assertTrue(sound.is_index_dirty)
         self.assertEqual(sound.pack.name, target_sound_pack.name)
         self.assertEqual(sound.pack.num_sounds, 1)
         self.assertEqual(target_sound_pack.num_sounds, 3)
@@ -1094,7 +1093,7 @@ class SoundAnalysisModel(TestCase):
 
         # Now create an analysis object which stores output in a JSON file. Again check that get_analysis works.
         analysis_filename = '%i-TestExtractor2.json' % sound.id
-        sound_analysis_folder = os.path.join(settings.ANALYSIS_PATH, str(old_div(sound.id, 1000)))
+        sound_analysis_folder = os.path.join(settings.ANALYSIS_PATH, str(sound.id // 1000))
         os.makedirs(sound_analysis_folder, exist_ok=True)
         with open(os.path.join(sound_analysis_folder, analysis_filename), 'w') as f:
             json.dump(analysis_data, f)
@@ -1227,7 +1226,7 @@ class SoundEditTestCase(TestCase):
         self.assertEqual(self.sound.original_filename, new_name)
         self.assertListEqual(sorted(self.sound.get_sound_tags()), sorted(new_tags))
         self.assertEqual(self.sound.sources.all().count(), len(new_sound_sources))
-        self.assertEqual(Pack.objects.filter(name='Name of a new pack').exists(), True)
+        self.assertTrue(Pack.objects.filter(name='Name of a new pack').exists())
         self.assertEqual(self.sound.pack.name, new_pack_name)
-        self.assertTrue(self.sound.geotag is not None)
+        self.assertIsNotNone(self.sound.geotag)
         self.assertAlmostEqual(self.sound.geotag.lat, geotag_lat)

--- a/templates_bw/accounts/account.html
+++ b/templates_bw/accounts/account.html
@@ -186,7 +186,7 @@
                         </li>
                         <li class="v-spacing-3">
                             {% with user.profile.num_downloads_on_sounds_and_packs as num_downloads %}{% bw_icon 'download' 'text-light-grey' %} <span class="text-19" title="{{ user.username }}'s sounds and packs have been downloaded {{ num_downloads }} times">{{ num_downloads|formatnumber }} download{{ num_downloads|pluralize }}</span>{% endwith %}
-                        </a>
+                        </li>
                         <li class="v-spacing-3">
                             {% bw_icon 'comments' 'text-light-grey' %} <span class="text-19" title="{{ user.username }} has written {{ user.profile.num_posts }} forum posts">{{ user.profile.num_posts|formatnumber }} forum post{{ user.profile.num_posts|pluralize }}</span>
                         </li>

--- a/utils/audioprocessing/processing.py
+++ b/utils/audioprocessing/processing.py
@@ -116,7 +116,7 @@ class AudioProcessor:
         fft = numpy.fft.rfft(numpy.ones(fft_size) * self.window)
         max_fft = (numpy.abs(fft)).max()
         # set the scale to normalized audio and normalized FFT
-        self.scale = old_div(1.0 / max_level, max_fft) if max_level > 0 else 1
+        self.scale = (1.0 / max_level) / max_fft if max_level > 0 else 1
 
     def read(self, start, size, resize_if_less=False):
         """ read size samples starting at start, if resize_if_less is True and less than size

--- a/utils/search/__init__.py
+++ b/utils/search/__init__.py
@@ -17,9 +17,8 @@
 # Authors:
 #     See AUTHORS file.
 #
-
-from past.utils import old_div
 import importlib
+import math
 
 from django.conf import settings
 
@@ -157,7 +156,7 @@ class SearchResultsPaginator:
         self.num_per_page = num_per_page
         self.results = search_results.docs
         self.count = search_results.num_found
-        self.num_pages = old_div(search_results.num_found, num_per_page) + int(search_results.num_found % num_per_page != 0)
+        self.num_pages = math.ceil(search_results.num_found / num_per_page)
         self.page_range = list(range(1, self.num_pages + 1))
 
     def page(self, page_num):
@@ -356,5 +355,3 @@ class SearchEngineBase:
                 Eg: [('cat', 1), ('echo', 1), ('forest', 1)]
         """
         raise NotImplementedError
-
-

--- a/utils/tags.py
+++ b/utils/tags.py
@@ -18,16 +18,16 @@
 #     See AUTHORS file.
 #
 
-from past.utils import old_div
 import re
 
 
-def size_generator(small_size, large_size, num_items):
+def size_generator(small_size: float, large_size: float, num_items: int):
     if num_items <= 1:
-        yield (small_size + large_size)*0.5
+        yield (small_size + large_size) * 0.5
     else:
-        for i in range(0,num_items):
-            yield old_div((i*(large_size - small_size)),(num_items-1)) + small_size;
+        for i in range(0, num_items):
+            yield ((i * (large_size - small_size)) / (num_items - 1)) + small_size
+
 
 def annotate(dictionary, **kwargs):
     x = dictionary.copy()


### PR DESCRIPTION
**Description**
I removed calls to `past.utils.old_div` and replaced them with the expected division operation (floor division or true division). 
`old_div` was introduced when we `futurize`d the code base.
Once all calls to `old_div` are removed we can drop the dependency on `future`.

'Old' behaviour:
```python
>>> old_div(1, 2)
0
>>> old_div(1.0, 2)
0.5
>>> old_div(1, 2.0)
0.5
>>> old_div(1.0, 2.0)
0.5
```
'New' behaviour:
```python
>>> 1 / 2
0.5
>>> 1 // 2
0
>>> 1.0 // 2
0.0
```

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
