### PR TITLE
Change numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ ipython==4.2.0
 mapbox==0.18.0
 markdown==3.4.1
 networkx==1.5
-numpy==1.16.6
+numpy==1.21.6
 pillow==6.2.2
 psycopg2==2.7.7
 PyJWT==1.4.2


### PR DESCRIPTION
**Issue(s)**
When I tried to build from scratch the freesound development environment and tried to run manage.py, I came across the error below: 
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/dist-packages/pysndfile/__init__.py", line 22, in <module>
    from ._pysndfile import PySndfile, get_pysndfile_version, get_sndfile_version, get_sndfile_formats, g
et_sndfile_encodings, get_sf_log, construct_format, encoding_id_to_name, encoding_name_to_id, max_support
ed_string_length, fileformat_name_to_id, fileformat_id_to_name, endian_name_to_id, endian_id_to_name, com
mands_name_to_id, commands_id_to_name, stringtype_name_to_id, stringtype_id_to_name, SF_FORMAT_SUBMASK, S
F_FORMAT_TYPEMASK, SF_FORMAT_ENDMASK
  File "_pysndfile.pyx", line 1, in init _pysndfile
ImportError: numpy.core.multiarray failed to import (auto-generated because you didn't call 'numpy.import
_array()' after cimporting numpy; use '<void>numpy._import_array' to disable if you are certain you don't
 need it).
```

@alastair was able to recreate the error. 

It was corrected after upgrading the numpy version, but later I realized there were other problems. Either the upgrade caused more problems or there are other ones. It needs investigation.

**Description**
The numpy version is changed but we should investigate more if that causes any problems.
