### PR TITLE
Upgrade ipython

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -30,12 +30,13 @@ freezegun==1.2.2
 future~=0.18.2
 graypy==0.2.12
 gunicorn==21.2.0
-ipython==4.2.0
+ipython==8.14.0
 mapbox==0.18.1
 markdown==3.4.1
 networkx==1.5
 numpy==1.24.3
 Pillow==9.5.0
+pip-tools==7.1.0
 psycopg2-binary==2.9.6
 PyJWT==2.6.0
 pyparsing==2.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,15 +10,17 @@ alabaster==0.7.13
     # via sphinx
 amqp==2.6.1
     # via kombu
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
+asttokens==2.2.1
+    # via stack-data
 autopep8==1.5.7
     # via
     #   -r requirements.in
     #   django-silk
 babel==2.12.1
     # via sphinx
-backports-shutil-get-terminal-size==1.0.0
+backcall==0.2.0
     # via ipython
 bcrypt==4.0.1
     # via paramiko
@@ -33,17 +35,19 @@ boto3==1.26.130
     #   -r requirements.in
     #   django-amazon-ses
     #   mapbox
-botocore==1.29.130
+botocore==1.29.165
     # via
     #   boto3
     #   s3transfer
-cachecontrol==0.12.11
+build==0.10.0
+    # via pip-tools
+cachecontrol==0.13.1
     # via mapbox
-cachetools==5.3.0
+cachetools==5.3.1
     # via zenpy
 celery==4.4.7
     # via -r requirements.in
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   requests
     #   sentry-sdk
@@ -51,9 +55,11 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-cryptography==40.0.2
+click==8.1.6
+    # via pip-tools
+cryptography==41.0.2
     # via
     #   jwcrypto
     #   paramiko
@@ -63,7 +69,7 @@ decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via djangorestframework-xml
-deprecated==1.2.13
+deprecated==1.2.14
     # via jwcrypto
 dj-database-url==0.5.0
     # via -r requirements.in
@@ -113,10 +119,12 @@ djangorestframework-xml==2.0.0
     # via -r requirements.in
 djangorestframework-yaml==2.0.0
     # via -r requirements.in
-docutils==0.19
+docutils==0.20.1
     # via sphinx
 et-xmlfile==1.1.0
     # via openpyxl
+executing==1.2.0
+    # via stack-data
 fabric==2.6.0
     # via -r requirements.in
 feedparser==6.0.10
@@ -137,19 +145,21 @@ imagesize==1.4.1
     # via sphinx
 invoke==1.7.3
     # via fabric
-ipython==4.2.0
+ipython==8.14.0
     # via -r requirements.in
 iso3166==2.1.1
     # via mapbox
+jedi==0.18.2
+    # via ipython
 jinja2==3.0.3
     # via
     #   -r requirements.in
     #   sphinx
-jmespath==0.10.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jwcrypto==1.4.2
+jwcrypto==1.5.0
     # via django-oauth-toolkit
 kombu==4.6.11
     # via celery
@@ -157,8 +167,10 @@ mapbox==0.18.1
     # via -r requirements.in
 markdown==3.4.1
     # via -r requirements.in
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
+matplotlib-inline==0.1.6
+    # via ipython
 msgpack==1.0.5
     # via cachecontrol
 networkx==1.5
@@ -174,9 +186,13 @@ oauthlib==3.2.2
 openpyxl==3.1.0
     # via -r requirements.in
 packaging==23.1
-    # via gunicorn
-paramiko==3.1.0
+    # via
+    #   build
+    #   gunicorn
+paramiko==3.2.0
     # via fabric
+parso==0.8.3
+    # via jedi
 pathlib2==2.3.7.post1
     # via fabric
 pexpect==4.8.0
@@ -185,24 +201,34 @@ pickleshare==0.7.5
     # via ipython
 pillow==9.5.0
     # via -r requirements.in
+pip-tools==7.1.0
+    # via -r requirements.in
 polyline==2.0.0
     # via mapbox
+prompt-toolkit==3.0.39
+    # via ipython
 psycopg2-binary==2.9.6
     # via -r requirements.in
 ptyprocess==0.7.0
     # via pexpect
+pure-eval==0.2.2
+    # via stack-data
 pycodestyle==2.10.0
     # via autopep8
 pycparser==2.21
     # via cffi
 pygments==2.15.1
-    # via sphinx
+    # via
+    #   ipython
+    #   sphinx
 pyjwt==2.6.0
     # via -r requirements.in
 pynacl==1.5.0
     # via paramiko
 pyparsing==2.4.7
     # via -r requirements.in
+pyproject-hooks==1.0.0
+    # via build
 pysndfile==1.4.4
     # via -r requirements.in
 pysolr==3.10.0b1
@@ -227,7 +253,7 @@ redis==3.2.0
     # via
     #   -r requirements.in
     #   django-redis
-requests==2.30.0
+requests==2.31.0
     # via
     #   akismet
     #   cachecontrol
@@ -243,10 +269,9 @@ sentry-sdk==0.14.4
     # via -r requirements.in
 sgmllib3k==1.0.0
     # via feedparser
-simplegeneric==0.8.1
-    # via ipython
 six==1.16.0
     # via
+    #   asttokens
     #   bleach
     #   pathlib2
     #   python-dateutil
@@ -266,15 +291,26 @@ sqlparse==0.4.4
     #   django
     #   django-debug-toolbar
     #   django-silk
+stack-data==0.6.2
+    # via ipython
 stripe==2.28.1
     # via -r requirements.in
 toml==0.10.2
     # via autopep8
+tomli==2.0.1
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
 traitlets==5.9.0
-    # via ipython
+    # via
+    #   ipython
+    #   matplotlib-inline
+typing-extensions==4.7.1
+    # via asgiref
 uritemplate==4.1.1
     # via mapbox
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   requests
@@ -283,8 +319,12 @@ vine==1.3.0
     # via
     #   amqp
     #   celery
+wcwidth==0.2.6
+    # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
+wheel==0.41.0
+    # via pip-tools
 wrapt==1.15.0
     # via deprecated
 xlrd==2.0.1
@@ -293,4 +333,5 @@ zenpy==1.1.3
     # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
Ipython was failing to start up with an error:

```In [1]: from utils.search import get_search_engine
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/usr/local/lib/python3.10/codeop.py in __call__(self, source, filename, symbol)
    116
    117     def __call__(self, source, filename, symbol):
--> 118         codeob = compile(source, filename, symbol, self.flags, True)
    119         for feature in _features:
    120             if codeob.co_flags & feature.compiler_flag:

TypeError: required field "type_ignores" missing from Module
```

upgrading it fixes the error.

Also add pip-tools to the main requirements file to make it easier to run pip-compile when running a container as the fsweb user