### PR TITLE
Set up new method of installing node from nodesource

### DIFF
--- a/docker/Dockerfile.workers_web
+++ b/docker/Dockerfile.workers_web
@@ -13,8 +13,11 @@ RUN make clean && make
 
 FROM freesound:2023-07
 
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+
 # Install specific dependencies needed for processing, building static files and for ssh
-RUN wget -q -O - https://deb.nodesource.com/setup_18.x | bash - && apt-get update \
+RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		sndfile-programs \
 		libsndfile1-dev \


### PR DESCRIPTION
**Description**
Installation of node using the `setup_x.sh` script is deprecated in favour of adding the repository manually

