### PR TITLE
Use docker/build-push-action to cache docker build

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v3
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,6 +50,7 @@ jobs:
         cache-to: type=gha,mode=max
         tags: mtgupf/freesound:2023-07
         push: false
+        outputs: type=docker
         load: true
 
     - name: Build cached image

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,6 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         install: true
-        driver: docker
 
     - name: Notify workflow starting
       uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,17 +42,33 @@ jobs:
       run: echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
       continue-on-error: true
 
+    - name: Log in to GitHub registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
     - name: Pull docker images
       run: docker-compose -f docker-compose.test.yml pull
 
-    - uses: jpribyl/action-docker-layer-caching@v0.1.1
-      continue-on-error: true
-
     - name: Build base image
-      run: make -C docker
+      uses: docker/build-push-action@v4
+      with:
+        context: docker
+        file: Dockerfile.base
+        cache-from: ghcr.io/mtg/freesound-base-cache:latest
+        # use mode=max to cache intermediate layers as well
+        cache-to: type=registry,mode=max,oci-mediatypes=true,compression=zstd,compression-level=7,ref=ghcr.io/mtg/freesound-base-cache:latest
+        tags: freesound:2023-07
+
+    - name: Build cached image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: docker/Dockerfile.workers_web
+        cache-from: ghcr.io/mtg/freesound-test-cache:latest
+        # use mode=max to cache intermediate layers as well
+        cache-to: type=registry,mode=max,oci-mediatypes=true,compression=zstd,compression-level=7,ref=ghcr.io/mtg/freesound-test-cache:latest
 
     - name: Build images
-      run: docker-compose -f docker-compose.test.yml build db test_runner
+      run: docker-compose -f docker-compose.test.yml build test_runner
 
     - name: Run tests
       run: docker-compose -f docker-compose.test.yml run --rm test_runner python manage.py test --noinput --settings=freesound.test_settings

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Build base image
       uses: docker/build-push-action@v4
       with:
-        context: docker
-        file: Dockerfile.base
+        context: ./docker
+        file: docker/Dockerfile.base
         cache-from: type=gha
         cache-to: type=gha,mode=max
         tags: freesound:2023-07

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,6 +18,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
       with:
         install: true
+        driver: docker
 
     - name: Setup
       run: bash -c 'mkdir -p ./freesound-data/{packs,uploads,avatars} && echo FS_USER_ID_FROM_ENV=$(id -u) > .env && cp freesound/local_settings.example.py freesound/local_settings.py'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,20 +42,13 @@ jobs:
       run: echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
       continue-on-error: true
 
-    - name: Log in to GitHub registry
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-
-    - name: Pull docker images
-      run: docker-compose -f docker-compose.test.yml pull
-
     - name: Build base image
       uses: docker/build-push-action@v4
       with:
         context: docker
         file: Dockerfile.base
-        cache-from: ghcr.io/mtg/freesound-base-cache:latest
-        # use mode=max to cache intermediate layers as well
-        cache-to: type=registry,mode=max,oci-mediatypes=true,compression=zstd,compression-level=7,ref=ghcr.io/mtg/freesound-base-cache:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         tags: freesound:2023-07
 
     - name: Build cached image
@@ -63,9 +56,11 @@ jobs:
       with:
         context: .
         file: docker/Dockerfile.workers_web
-        cache-from: ghcr.io/mtg/freesound-test-cache:latest
-        # use mode=max to cache intermediate layers as well
-        cache-to: type=registry,mode=max,oci-mediatypes=true,compression=zstd,compression-level=7,ref=ghcr.io/mtg/freesound-test-cache:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Pull docker images
+      run: docker-compose -f docker-compose.test.yml pull
 
     - name: Build images
       run: docker-compose -f docker-compose.test.yml build test_runner

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,7 +48,8 @@ jobs:
         file: docker/Dockerfile.base
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: freesound:2023-07
+        tags: mtgupf/freesound:2023-07
+        push: false
         load: true
 
     - name: Build cached image

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
         cache-to: type=gha,mode=max
         tags: mtgupf/freesound:2023-07
         push: false
-        outputs: type=docker
+        outputs: type=docker,name=mtgupf/freesound:2023-07
         load: true
 
     - name: Build cached image

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,24 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         install: true
-
-    - name: Notify workflow starting
-      uses: voxmedia/github-action-slack-notify-build@v1
-      continue-on-error: true
-      if: success()
-      id: slack
-      with:
-        channel_id: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL_ID }}
-        status: STARTING
-        color: warning
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
 
     - name: Setup
       run: bash -c 'mkdir -p ./freesound-data/{packs,uploads,avatars} && echo FS_USER_ID_FROM_ENV=$(id -u) > .env && cp freesound/local_settings.example.py freesound/local_settings.py'
@@ -42,16 +28,16 @@ jobs:
       continue-on-error: true
 
     - name: Build base image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
-        context: ./docker
         file: docker/Dockerfile.base
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: mtgupf/freesound:2023-07
         push: false
-        outputs: type=docker,name=mtgupf/freesound:2023-07
         load: true
+
+    - name: check images
+      run: docker image ls
 
     - name: Build cached image
       uses: docker/build-push-action@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,6 +49,7 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         tags: freesound:2023-07
+        load: true
 
     - name: Build cached image
       uses: docker/build-push-action@v4
@@ -57,6 +58,7 @@ jobs:
         file: docker/Dockerfile.workers_web
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        load: true
 
     - name: Pull docker images
       run: docker-compose -f docker-compose.test.yml pull

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,10 +5,9 @@ services:
         image: postgres:12.1
         volumes:
             - pgdata:/var/lib/postgresql/data
+            - ./freesound-data/db_dev_dump:/freesound-data/db_dev_dump
         env_file:
             - environment
-        volumes:
-            - ./freesound-data/db_dev_dump:/freesound-data/db_dev_dump
         ports:
             - "5432:5432"
         environment:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,9 +3,6 @@ version: "3.7"
 services:
     db:
         image: postgres:12.1
-        volumes:
-            - pgdata:/var/lib/postgresql/data
-            - ./freesound-data/db_dev_dump:/freesound-data/db_dev_dump
         env_file:
             - environment
         ports:

--- a/docker/Dockerfile.workers_web
+++ b/docker/Dockerfile.workers_web
@@ -11,7 +11,7 @@ RUN make clean && make
 
 # --- main Freesound docker file contents
 
-FROM freesound:2023-07
+FROM mtgupf/freesound:2023-07
 
 RUN mkdir -p /etc/apt/keyrings/
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg


### PR DESCRIPTION
**Description**
Now that we use docker buildx in the unit tests, use the `docker/build-push-action` to allow us to use docker's built-in layer cache when running tests.

This also builds the base image manually instead of using `make`, as the makefile now contains both the py2 and py3 base images and we only need the py3 one.

I manually build the worker image (to cache it), and then run docker-compose build again to correctly tag it. Theoretically this should use existing layers and then tag the image as expected.

I use 2 "cache images" in the github docker cache. This should make the caching operation quite fast because it stays within github instead of going to docker hub.