### PR TITLE
update to latest sentry-sdk

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -45,7 +45,7 @@ pysndfile==1.4.4
 pytz==2023.3
 PyYAML==6.0.1
 redis==3.2.0
-sentry-sdk==0.14.4
+sentry-sdk==1.9.10
 Sphinx==1.6.3
 stripe==2.28.1
 xlrd==2.0.1  # for reading .xls files (but not .xlsx)

--- a/requirements.in
+++ b/requirements.in
@@ -45,7 +45,7 @@ pysndfile==1.4.4
 pytz==2023.3
 PyYAML==6.0.1
 redis==3.2.0
-sentry-sdk==1.9.10
+sentry-sdk~=1.31
 Sphinx==1.6.3
 stripe==2.28.1
 xlrd==2.0.1  # for reading .xls files (but not .xlsx)

--- a/requirements.txt
+++ b/requirements.txt
@@ -265,7 +265,7 @@ requests==2.31.0
     #   zenpy
 s3transfer==0.6.1
     # via boto3
-sentry-sdk==1.9.10
+sentry-sdk==1.31.0
     # via -r requirements.in
 sgmllib3k==1.0.0
     # via feedparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -265,7 +265,7 @@ requests==2.31.0
     #   zenpy
 s3transfer==0.6.1
     # via boto3
-sentry-sdk==0.14.4
+sentry-sdk==1.9.10
     # via -r requirements.in
 sgmllib3k==1.0.0
     # via feedparser


### PR DESCRIPTION
**Description**
I noticed that we are running a quite old `sentry-sdk` install. Since we recently upgraded the `sentry` version it might be good to keep up on the application side.

I didn't want to go to [`1.10.0`](https://github.com/getsentry/sentry-python/releases/tag/1.10.0) because of breaking changes in dashboards and discover queries and I wasn't sure if we run any of those.
