### PR TITLE
refactor images.py to use PIL ImageOps for much simpler code

### DIFF
--- a/utils/images.py
+++ b/utils/images.py
@@ -17,62 +17,45 @@
 # Authors:
 #     See AUTHORS file.
 #
+from PIL import Image, ImageOps
+from PIL.Image import Resampling
 
-from past.utils import old_div
-from PIL import Image
 
-class ImageProcessingError(Exception):
-    pass
+def extract_square(input_filename, output_filename, size: int):
+    """Resize and crop image to square of size `size`.
 
-def extract_square(input_filename, output_filename, size):
+    If the image is smaller than `size` in both dimensions, it is padded with white.
+    If the image is smaller than `size` in only one dimension,
+        it is resized to fit the largest dimension and then padded with white.
+    Else, it is resized to fit the largest dimension and then cropped to square.
+
+    See https://pillow.readthedocs.io/en/stable/handbook/tutorial.html#relative-resizing
+    """
     im = Image.open(input_filename)
 
     if im.mode not in ('L', 'RGB'):
         im = im.convert('RGB')
 
-    #fill out and resize the image
     if im.size[0] < size and im.size[1] < size:
-        if im.size[0] < im.size[1]:
-            ratio = old_div(im.size[1], im.size[0])
-            im = im.resize((old_div(size, ratio), size), Image.ANTIALIAS)            
-        else: 
-            ratio = old_div(im.size[0], im.size[1]) 
-            im = im.resize((size,old_div(size, ratio)), Image.ANTIALIAS)
-        #fill out          
-        background = Image.new("RGB", (size,size), (255, 255, 255)) # use white for empty space
-        background.paste(im, (old_div((size - im.size[0]), 2), old_div((size - im.size[1]), 2)))  
-        background.save(output_filename)
-        return
-        
-    #if one side of the image is smaller and one is bigger
-    elif im.size[0] > size and im.size[1] < size:
-        ratio = old_div(im.size[0], im.size[1])
-        im = im.resize((size * ratio,size), Image.ANTIALIAS)  
-                     
-    elif im.size[0] < size and im.size[1] > size:  
-        ratio = old_div(im.size[1], im.size[0])
-        im = im.resize((size, size * ratio), Image.ANTIALIAS)
-           
-    if im.size[0] > im.size[1]:
-        # --------
-        # |      |
-        # --------
-        box = old_div((im.size[0]-im.size[1]),2), 0, im.size[0] - old_div((im.size[0]-im.size[1]),2), im.size[1]
-    else: 
-        # ____
-        # |  |
-        # |  |
-        # |__|
-        box = 0, old_div((im.size[1]-im.size[0]),2), im.size[0], im.size[1] - old_div((im.size[1]-im.size[0]),2) 
-    
-    im = im.crop(box)
-    im.thumbnail((size, size), Image.ANTIALIAS)
+        im = ImageOps.pad(im, (size, size), method=Resampling.LANCZOS, color="#fff")
+    elif (im.size[0] < size < im.size[1]) or (im.size[0] > size > im.size[1]):
+        reduced_size = (
+            im.size[0] if im.size[0] < size else size,
+            im.size[1] if im.size[1] < size else size,
+        )
+        im = im.resize(reduced_size, resample=Resampling.LANCZOS)
+        im = ImageOps.pad(im, (size, size), method=Resampling.LANCZOS, color="#fff")
+    else:
+        im = ImageOps.fit(im, (size, size), method=Resampling.LANCZOS)
     im.save(output_filename)
 
+
 if __name__ == "__main__":
-    import sys, os.path
+    import sys
+    import os.path
+
     input_filename = sys.argv[1]
     size = int(sys.argv[2])
     path, ext = os.path.splitext(input_filename)
-    output_filename = path + "_t" + ext 
+    output_filename = path + "_t" + ext
     extract_square(input_filename, output_filename, size)


### PR DESCRIPTION
I was following the tutorial in
https://pillow.readthedocs.io/en/stable/handbook/tutorial.html#relative-resizing

I started refactoring since I wanted to remove all calls to `old_div` but found it was easier just to rewrite large portions relying on PIL library code
