### PR TITLE
Add support for WavPack file format

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -62,8 +62,11 @@ def validate_file_extension(audiofiles):
                     # Firefox seems to set wrong mime type for ogg files to video/ogg instead of audio/ogg.
                     # Also safari seems to use 'application/octet-stream'.
                     # For these reasons we also allow extra mime types for ogg files.
-                    print(content_type)
                     if not content_type.startswith("audio") and not content_type == 'video/ogg' and not content_type == 'application/octet-stream':
+                        raise forms.ValidationError('Uploaded file format not supported or not an audio file.')
+                elif ext == 'wv':
+                    # All major browsers seem to use 'application/octet-stream' for wv (wavpack) files.
+                    if not content_type == 'application/octet-stream':
                         raise forms.ValidationError('Uploaded file format not supported or not an audio file.')
                 else:
                     if not content_type.startswith("audio"):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1258,6 +1258,9 @@ def upload(request, no_flash=False):
         'no_flash': no_flash,
         'max_file_size': settings.UPLOAD_MAX_FILE_SIZE_COMBINED,
         'max_file_size_in_MB': int(round(settings.UPLOAD_MAX_FILE_SIZE_COMBINED * 1.0 / (1024 * 1024))),
+        'lossless_file_extensions': [ext for ext in settings.ALLOWED_AUDIOFILE_EXTENSIONS if ext not in settings.LOSSY_FILE_EXTENSIONS],
+        'lossy_file_extensions': settings.LOSSY_FILE_EXTENSIONS,
+        'all_file_extensions': settings.ALLOWED_AUDIOFILE_EXTENSIONS,
         'uploads_enabled': settings.UPLOAD_AND_DESCRIPTION_ENABLED
     }
     return render(request, 'accounts/upload.html', tvars)

--- a/docker/Dockerfile.workers_web
+++ b/docker/Dockerfile.workers_web
@@ -28,6 +28,7 @@ RUN apt-get update \
 		vorbis-tools \
 		flac \
 		faad \
+		wavpack \
 		libjpeg-dev \
 		zlib1g-dev \
 		libpng-dev \

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -350,8 +350,24 @@ USER_STATS_CACHE_KEY = 'user_stats_{}'
 USERFLAG_THRESHOLD_FOR_NOTIFICATION = 3
 USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING = 6
 
-ALLOWED_AUDIOFILE_EXTENSIONS = ['wav', 'aiff', 'aif', 'ogg', 'flac', 'mp3', 'm4a']
-LOSSY_FILE_EXTENSIONS = [ 'ogg', 'mp3', 'm4a']
+# Supported audio formats
+# When adding support for a new audio format you have to change the variables below and check:
+# - mime types in accounts.forms.validate_file_extension
+# - see if utils.audioprocessing.get_sound_type needs to be updated
+# - add corresponding decoder to utils.audioprocessing.processing.convert_to_pcm (and of course add it to the docker image as well)
+# - the audio analyzers will not need to be updated if the format is supported by ffmpeg
+ALLOWED_AUDIOFILE_EXTENSIONS = ['wav', 'aiff', 'aif', 'ogg', 'flac', 'mp3', 'm4a', 'wv']
+LOSSY_FILE_EXTENSIONS = ['ogg', 'mp3', 'm4a']
+# Note that some SOUND_TYPE_CHOICES below might correspond to multiple extensions (aiff/aif > aiff)
+SOUND_TYPE_CHOICES = (
+    ('wav', 'Wave'),
+    ('ogg', 'Ogg Vorbis'),
+    ('aiff', 'AIFF'),
+    ('mp3', 'Mp3'),
+    ('flac', 'Flac'),
+    ('m4a', 'M4a'),
+    ('wv', 'WavPack'),
+)
 COMMON_BITRATES = [32, 64, 96, 128, 160, 192, 224, 256, 320]
 
 # Allowed data file extensions for bulk upload
@@ -590,7 +606,7 @@ SEARCH_SOUNDS_DEFAULT_FACETS = {
     SEARCH_SOUNDS_FIELD_TAGS: {'limit': 30},
     SEARCH_SOUNDS_FIELD_BITRATE: {},
     SEARCH_SOUNDS_FIELD_BITDEPTH: {},
-    SEARCH_SOUNDS_FIELD_TYPE: {'limit': 6},  # Set after the number of choices in sounds.models.Sound.SOUND_TYPE_CHOICES
+    SEARCH_SOUNDS_FIELD_TYPE: {'limit': len(SOUND_TYPE_CHOICES)},
     SEARCH_SOUNDS_FIELD_CHANNELS: {},
     SEARCH_SOUNDS_FIELD_LICENSE_NAME: {'limit': 10},
 }

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -623,15 +623,7 @@ class Sound(models.Model):
         BulkUploadProgress, null=True, blank=True, default=None, on_delete=models.SET_NULL)
 
     # file properties
-    SOUND_TYPE_CHOICES = (
-        ('wav', 'Wave'),
-        ('ogg', 'Ogg Vorbis'),
-        ('aiff', 'AIFF'),
-        ('mp3', 'Mp3'),
-        ('flac', 'Flac'),
-        ('m4a', 'M4a')
-    )
-    type = models.CharField(db_index=True, max_length=4, choices=SOUND_TYPE_CHOICES)
+    type = models.CharField(db_index=True, max_length=4, choices=settings.SOUND_TYPE_CHOICES)
     duration = models.FloatField(default=0)
     bitrate = models.IntegerField(default=0)
     bitdepth = models.IntegerField(null=True, blank=True, default=None)

--- a/templates/accounts/upload.html
+++ b/templates/accounts/upload.html
@@ -33,7 +33,7 @@
         <div class="col-md-6 col-lg-3">
             <div class="padding-right-2">
                 <h5>Formats</h5>
-                <p>We prefer <strong>wav, aif and flac</strong>, but we support <strong>ogg</strong>, <strong>m4a</strong> and <strong>mp3</strong> too. For very large files please use some compressed format.</p>
+                <p>We prefer {% for ext in lossless_file_extensions %}<strong>{{ ext }}</strong>{% if not forloop.last %}{% ifequal forloop.revcounter 2 %} and {% else %}, {% endifequal %}{% else %}{% endif %}{% endfor %}, but we support {% for ext in lossy_file_extensions %}<strong>{{ ext }}</strong>{% if not forloop.last %}{% ifequal forloop.revcounter 2 %} and {% else %}, {% endifequal %}{% else %}{% endif %}{% endfor %} too. For very large files please use some compressed format.</p>
             </div>
         </div>
     </div>
@@ -46,7 +46,7 @@
                 
                 <div id="drag-tip">
                     <h1 class="text-light-grey">Drag files here...</h1>
-                    <p>...or click on 'Add files' (valid file extensions: flac, wav, aif, aiff, m4a, ogg and mp3).</p>
+                    <p>...or click on 'Add files' (valid file extensions: {% for ext in all_file_extensions %}<strong>{{ ext }}</strong>{% if not forloop.last %}{% ifequal forloop.revcounter 2 %} and {% else %}, {% endifequal %}{% else %}{% endif %}{% endfor %}).</p>
                 </div>
                 <ul id="file-list" class="file-list"></ul>
                 <div class="progress-container h-spacing-2" id="progress-container"></div>

--- a/utils/audioprocessing/processing.py
+++ b/utils/audioprocessing/processing.py
@@ -471,7 +471,7 @@ def convert_to_pcm(input_filename, output_filename, use_ffmpeg_for_unknown_type=
         raise AudioProcessingException(f"file {input_filename} does not exist")
     sound_type = get_sound_type(input_filename)
 
-    if sound_type in ["mp3", "ogg", "flac", "m4a"]:
+    if sound_type in ["mp3", "ogg", "flac", "m4a", "wv"]:
         if sound_type == "mp3":
             cmd = ["lame", "--decode", input_filename, output_filename]
             error_messages = ["WAVE file contains 0 PCM samples"]
@@ -486,6 +486,9 @@ def convert_to_pcm(input_filename, output_filename, use_ffmpeg_for_unknown_type=
             error_messages = ["Unable to find correct AAC sound track in the MP4 file",
                             "Error: Bitstream value not allowed by specification",
                             "Error opening file"]
+        elif sound_type == "wv":
+            cmd = ["wvunpack", input_filename, "-o", output_filename]
+            error_messages = []
    
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = process.communicate()


### PR DESCRIPTION
**Description**
This PR adds support for the "WavPack" file format which is similar to FLAC but it allows for greater channel counts. This is useful for multi-channel recordings like ambisonics for which using FLAC is a limitation because it supports a maximum of 8 channels. Adding this format to Freesound will allow users to upload these kind of recordings in a lossless format but with some compression. 

**Deployment steps**:
Deploy not only the web pods but also the celery processing pods.
