### PR TITLE
Update user delete method to remove sounds in chunks

### DIFF
--- a/general/management/commands/prune_database.py
+++ b/general/management/commands/prune_database.py
@@ -47,14 +47,11 @@ import sounds
 from sounds.models import BulkUploadProgress, DeletedSound, Flag
 import tickets
 from tickets.models import Ticket, TicketComment
+from utils.chunks import chunks
 
 console_logger = logging.getLogger('console')
 
 
-def chunks(l, n):
-    """Yield successive n-sized chunks from l."""
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
 
 
 class Command(BaseCommand):

--- a/utils/chunks.py
+++ b/utils/chunks.py
@@ -1,0 +1,24 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+def chunks(l, n):
+    """Yield successive n-sized chunks from l."""
+    for i in range(0, len(l), n):
+        yield l[i:i + n]


### PR DESCRIPTION
Deleting users with very large amount of sounds seems to cause problems in the database which make freesound go down. An hypothesis is that this happens because we're running all the deletion operations in a single transaction and this becomes too big. This PR splits the deletion operations so user sounds are removed in chunks and the atomic operations are applied at the chunk level. If our initial hypothesis is correct, this PR should fix db errors when deleting users with large amount of sounds. 
