### PR TITLE
enable password validation

### DIFF
--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -242,6 +242,23 @@ PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.SHA1PasswordHasher',
 ]
 
+# Password validation
+# https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
 
 # -------------------------------------------------------------------------------
 # Email settings


### PR DESCRIPTION
**Description**
This PR introduces [password validation](https://docs.djangoproject.com/en/3.2/topics/auth/passwords/#enabling-password-validation) for user registration and password change.

Up to now, there was no password validation done and consequently no password requirements enforced. 

The settings are taken from the default Django `settings.py`.

If I'm not mistaken there should be no effect on currently stored passwords. Only, new (and changed) passwords will need to fulfill the requirements.

Conveniently, the default password change form will inform the user about the password requirements (see below).

**Before**:
![Bildschirmfoto 2023-12-19 um 11 20 26](https://github.com/MTG/freesound/assets/13520622/62418eb4-2f85-497b-9142-9525cb4f68f7)

**After**:
![Bildschirmfoto 2023-12-19 um 11 18 21](https://github.com/MTG/freesound/assets/13520622/f2e96c27-d936-4d35-8df8-9a904ed6b848)


**Deployment steps**:
None
