### PR TITLE
remove a few more calls to old_div

### DIFF
--- a/apiv2/combined_search_strategies.py
+++ b/apiv2/combined_search_strategies.py
@@ -17,7 +17,6 @@
 # Authors:
 #     See AUTHORS file.
 #
-from past.utils import old_div
 from apiv2.forms import API_SORT_OPTIONS_MAP
 from utils.similarity_utilities import api_search as similarity_api_search
 from utils.search import SearchEngineException, get_search_engine
@@ -90,7 +89,7 @@ def filter_both(search_form, target_file=None, extra_parameters=None):
     if search_form.cleaned_data['target'] or target_file:
         # First search into gaia and then into solr (get all gaia results)
         gaia_ids, gaia_count, distance_to_target_data, note = get_gaia_results(search_form, target_file, page_size=gaia_page_size, max_pages=gaia_max_pages)
-        valid_ids_pages = [gaia_ids[i:i+solr_filter_id_block_size] for i in range(0, len(gaia_ids), solr_filter_id_block_size) if (old_div(i,solr_filter_id_block_size)) < solr_filter_id_max_pages]
+        valid_ids_pages = [gaia_ids[i:i+solr_filter_id_block_size] for i in range(0, len(gaia_ids), solr_filter_id_block_size) if (i / solr_filter_id_block_size) < solr_filter_id_max_pages]
         solr_ids = list()
         search_engine = get_search_engine()
         for valid_ids_page in valid_ids_pages:

--- a/sounds/management/commands/test_color_schemes.py
+++ b/sounds/management/commands/test_color_schemes.py
@@ -18,14 +18,15 @@
 #     See AUTHORS file.
 #
 
-from past.utils import old_div
+import os
+
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from sounds.models import Sound
 import utils.audioprocessing.processing as audioprocessing
+from sounds.models import Sound
 from utils.audioprocessing import color_schemes
-import os
+
 
 # docker-compose run --rm web python manage.py test_color_schemes 415154,415144,413973,402737,403343,194761
 

--- a/utils/audioprocessing/color_schemes.py
+++ b/utils/audioprocessing/color_schemes.py
@@ -1,6 +1,6 @@
-from past.utils import old_div
-from PIL import ImageColor
 from functools import partial
+
+from PIL import ImageColor
 
 
 def desaturate(rgb, amount):
@@ -27,80 +27,81 @@ CYBERPUNK_COLOR_SCHEME = 'Cyberpunk'
 RAINFOREST_COLOR_SCHEME = 'Rainforest'
 DEFAULT_COLOR_SCHEME_KEY = FREESOUND2_COLOR_SCHEME
 
-
 COLOR_SCHEMES = {
     FREESOUND2_COLOR_SCHEME: {
         'wave_colors': [
-            (0, 0, 0),  # Background color
-            (50, 0, 200),  # Low spectral centroid
+            (0, 0, 0),    # Background color
+            (50, 0, 200),    # Low spectral centroid
             (0, 220, 80),
             (255, 224, 0),
-            (255, 70, 0),  # High spectral centroid
+            (255, 70, 0),    # High spectral centroid
         ],
         'spec_colors': [
-            (0, 0, 0),  # Background color
-            (old_div(58,4), old_div(68,4), old_div(65,4)),
-            (old_div(80,2), old_div(100,2), old_div(153,2)),
+            (0, 0, 0),    # Background color
+            (58 // 4, 68 // 4, 65 // 4),
+            (80 // 2, 100 // 2, 153 // 2),
             (90, 180, 100),
             (224, 224, 44),
             (255, 60, 30),
             (255, 255, 255)
-         ],
-         'wave_zero_line_alpha': 25,
+        ],
+        'wave_zero_line_alpha': 25,
     },
     OLD_BEASTWHOOSH_COLOR_SCHEME: {
         'wave_colors': [
-            (255, 255, 255),  # Background color
-            (29, 159, 181),  # 1D9FB5, Low spectral centroid
-            (28, 174, 72),  # 1CAE48
-            (255, 158, 53),  # FF9E35
-            (255, 53, 70),  # FF3546, High spectral centroid
+            (255, 255, 255),    # Background color
+            (29, 159, 181),    # 1D9FB5, Low spectral centroid
+            (28, 174, 72),    # 1CAE48
+            (255, 158, 53),    # FF9E35
+            (255, 53, 70),    # FF3546, High spectral centroid
         ],
         'spec_colors': [
-            (0, 0, 0),  # Background color/Low spectral energy
-            (29, 159, 181),  # 1D9FB5
-            (28, 174, 72),  # 1CAE48
-            (255, 158, 53),  # FF9E35
-            (255, 53, 70),  # FF3546, High spectral energy
-         ]
+            (0, 0, 0),    # Background color/Low spectral energy
+            (29, 159, 181),    # 1D9FB5
+            (28, 174, 72),    # 1CAE48
+            (255, 158, 53),    # FF9E35
+            (255, 53, 70),    # FF3546, High spectral energy
+        ]
     },
     BEASTWHOOSH_COLOR_SCHEME: {
         'wave_colors': [
-            (20, 20, 36),  # Background color (not really used as we use transparent mode)
-            (29, 159, 181),  # Low spectral centroid
+            (20, 20, 36),    # Background color (not really used as we use transparent mode)
+            (29, 159, 181),    # Low spectral centroid
             (0, 220, 80),
             (255, 200, 58),
-            (255, 0, 70),  # High spectral centroid
+            (255, 0, 70),    # High spectral centroid
         ],
         'spec_colors': [
-            (20, 20, 36),  # Low spectral energy
+            (20, 20, 36),    # Low spectral energy
             (0, 18, 25),
             (0, 37, 56),
-            (11, 95, 118), 
+            (11, 95, 118),
             (29, 159, 181),
             (0, 220, 80),
             (255, 200, 58),
             (255, 125, 0),
-            (255, 0, 70),  
-            (255, 0, 20),  # High spectral energy
+            (255, 0, 70),
+            (255, 0, 20),    # High spectral energy
         ],
         'wave_transparent_background': True,
         'wave_zero_line_alpha': 12,
     },
     CYBERPUNK_COLOR_SCHEME: {
-        'wave_colors': [(0, 0, 0)] + [color_from_value(value/29.0) for value in range(0, 30)],
-        'spec_colors': [(0, 0, 0)] + [color_from_value(value/29.0) for value in range(0, 30)],
+        'wave_colors': [(0, 0, 0)] + [color_from_value(value / 29.0) for value in range(0, 30)],
+        'spec_colors': [(0, 0, 0)] + [color_from_value(value / 29.0) for value in range(0, 30)],
     },
     RAINFOREST_COLOR_SCHEME: {
-        'wave_colors': [(213, 217, 221)] + list(map(partial(desaturate, amount=0.7), [
-                        (50, 0, 200),
-                        (0, 220, 80),
-                        (255, 224, 0),
-                     ])),
-        'spec_colors': [(213, 217, 221)] + list(map(partial(desaturate, amount=0.7), [
-                        (50, 0, 200),
-                        (0, 220, 80),
-                        (255, 224, 0),
-                     ])),
+        'wave_colors': [(213, 217, 221)] +
+                       list(map(partial(desaturate, amount=0.7), [
+                           (50, 0, 200),
+                           (0, 220, 80),
+                           (255, 224, 0),
+                       ])),
+        'spec_colors': [(213, 217, 221)] +
+                       list(map(partial(desaturate, amount=0.7), [
+                           (50, 0, 200),
+                           (0, 220, 80),
+                           (255, 224, 0),
+                       ])),
     }
 }

--- a/utils/audioprocessing/freesound_audio_processing.py
+++ b/utils/audioprocessing/freesound_audio_processing.py
@@ -19,22 +19,22 @@
 #
 
 
-from past.utils import old_div
 import json
+import logging
 import os
 import signal
-import logging
 import tempfile
+from tempfile import TemporaryDirectory
+import sentry_sdk
 
 from django.apps import apps
 from django.conf import settings
 
-from . import color_schemes
 import utils.audioprocessing.processing as audioprocessing
 from utils.audioprocessing.processing import AudioProcessingException
-from tempfile import TemporaryDirectory
 from utils.mirror_files import copy_previews_to_mirror_locations, copy_displays_to_mirror_locations
 from utils.sound_upload import get_processing_before_describe_sound_folder
+from . import color_schemes
 
 console_logger = logging.getLogger("console")
 
@@ -244,7 +244,7 @@ class FreesoundAudioProcessor(FreesoundAudioProcessorBase):
                 if self.sound.type in settings.LOSSY_FILE_EXTENSIONS:
                     info['bitdepth'] = 0  # mp3 and ogg don't have bitdepth
                     if info['duration'] > 0:
-                        raw_bitrate = int(round(old_div(old_div(self.sound.filesize * 8, info['duration']), 1000)))
+                        raw_bitrate = round((self.sound.filesize * 8 / info['duration']) / 1000)
                         # Here we post-process a bit the bitrate to account for small rounding errors
                         # If we see computed bitrate is very close to a common bitrate, we quantize to that number
                         differences_with_common_bitrates = [abs(cbt - raw_bitrate) for cbt in settings.COMMON_BITRATES]

--- a/utils/audioprocessing/wav2png.py
+++ b/utils/audioprocessing/wav2png.py
@@ -21,7 +21,6 @@
 #
 
 
-from past.utils import old_div
 import argparse
 
 from utils.audioprocessing.processing import create_wave_images, AudioProcessingException
@@ -29,8 +28,8 @@ import sys
 
 
 def progress_callback(position, width):
-    percentage = old_div((position*100),width)
-    if position % (old_div(width, 10)) == 0:
+    percentage = (position * 100) // width
+    if position % (width // 10) == 0:
         sys.stdout.write(str(percentage) + "% ")
         sys.stdout.flush()
 


### PR DESCRIPTION
**Issue(s)**
#1633 introduced many calls to `old_div` that are the last reason we have a dependency on the `future` package.
This PR removes all in the core code components. `tagrecommendation` and `clustering` are still todo.

**Description**
<!-- Description of the contents of this PR -->

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
