### PR TITLE
fix AttributeError on Bookmark.__str__

### DIFF
--- a/bookmarks/models.py
+++ b/bookmarks/models.py
@@ -40,7 +40,7 @@ class Bookmark(models.Model):
     created = models.DateTimeField(db_index=True, auto_now_add=True)
     
     def __str__(self):
-        return f"Bookmark: {self.name}"
+        return f"Bookmark: {self.sound} by {self.user}"
 
     @property
     def category_name_or_uncategorized(self):


### PR DESCRIPTION
**Issue(s)**
fixes FREESOUND-WEB-1V5 and FREESOUND-WEB-1V4

**Description**
```
AttributeError: 'Bookmark' object has no attribute 'name'
(14 additional frame(s) were not displayed)
...
  File "bookmarks/models.py", line 43, in __str__
    return f"Bookmark: {[self.name](http://self.name/)}"
```

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
