### PR TITLE
Nodejs install did not install npm

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,3 @@
-ARG PYTHON
 FROM python:3.10
 
 LABEL org.opencontainers.image.authors="support@freesound.org"

--- a/docker/Dockerfile.workers_web
+++ b/docker/Dockerfile.workers_web
@@ -13,9 +13,7 @@ RUN make clean && make
 
 FROM freesound:2023-07
 
-RUN mkdir -p /etc/apt/keyrings/
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 
 # Install specific dependencies needed for processing, building static files and for ssh
 RUN apt-get update \


### PR DESCRIPTION
**Description**
give preference to the nodesource repo when installing nodejs
since debian bookworm nodejs was installed from the debian repo and not
from the nodesource repo. This package did not require npm by default.
Using the installer script solves the issue.

See: https://github.com/nodesource/distributions/issues/1725

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
