### PR TITLE
SOLR schema: convert license to a docValues field for faster faceting

### DIFF
--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -564,7 +564,7 @@ ANALYZERS_CONFIGURATION = {
 # -------------------------------------------------------------------------------
 # Search engine
 
-FCW_FILTER_VALUE = '("attribution" OR "creative commons 0")'
+FCW_FILTER_VALUE = '("Attribution" OR "Creative Commons 0")'
 
 # Define the names of some of the indexed sound fields which are to be used later
 SEARCH_SOUNDS_FIELD_ID = 'sound_id'

--- a/search/templatetags/search.py
+++ b/search/templatetags/search.py
@@ -90,10 +90,6 @@ def display_facet(context, facet_name, facet_title=None):
             element['display_value'] = element['value'][element['value'].find("_")+1:]
         elif element['value'] == settings.FCW_FILTER_VALUE:
             element['display_value'] = "Approved for Free Cultural Works"
-        elif facet_name == 'license':
-            # License field in solr is case insensitive and will return facet names in lowercase. 
-            # We need to properly capitalize them to use official CC license names.
-            element['display_value'] = element['value'].title().replace('Noncommercial', 'NonCommercial')
         elif facet_type == 'range':
             # Update display value for range facets
             gap = sqp.facets[facet_name]['gap']

--- a/utils/search/solr9/cores/freesound/conf/schema.xml
+++ b/utils/search/solr9/cores/freesound/conf/schema.xml
@@ -194,7 +194,7 @@
   <field name="tag" type="alphaOnlySort" indexed="true" stored="true" required="false" multiValued="true"/>
   <field name="is_explicit" type="boolean" indexed="true" stored="true" required="false" />
 
-  <field name="license" type="lowercase" indexed="true" stored="true" />
+  <field name="license" type="string" indexed="false" stored="false" />
 
   <field name="is_remix" type="boolean" indexed="true" stored="true" required="false" />
   <field name="was_remixed" type="boolean" indexed="true" stored="true" required="false" />


### PR DESCRIPTION
**Description**
Change the type of `license` to `string` similar to other fields to mark `docValues` as `true`. This should [help speed up faceting of search results.](https://solr.apache.org/guide/solr/9_2/indexing-guide/docvalues.html#using-docvalues)

The `fieldType` definition looks like this: 
```<fieldType name=“string” class=“solr.StrField” sortMissingLast=“true” docValues=“true”/>```

**Deployment steps**:
Re-indexing required!
