### PR TITLE
Avoid duplicating "volumes" key

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,13 +1,17 @@
 version: "3.7"
 
+volumes:
+    pgdata:
+
 services:
     db:
         image: postgres:12.1
         env_file:
             - environment
         volumes:
-            - ./freesound-data/db_dev_dump:/freesound-data/db_dev_dump
             - pgdata:/var/lib/postgresql/data
+            - ./freesound-data/db_dev_dump:/freesound-data/db_dev_dump
+            
         ports:
             - "5432:5432"
         environment:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,12 +3,11 @@ version: "3.7"
 services:
     db:
         image: postgres:12.1
-        volumes:
-            - pgdata:/var/lib/postgresql/data
         env_file:
             - environment
         volumes:
             - ./freesound-data/db_dev_dump:/freesound-data/db_dev_dump
+            - pgdata:/var/lib/postgresql/data
         ports:
             - "5432:5432"
         environment:


### PR DESCRIPTION
The docker compose file used for unit testing in github actions contained a duplicated "volumes" key which used to work but (I suspect) such use became unsupported. This PR merges the different volume declarations and will (hopefully) fix the issue.