### PR TITLE
uncategorized bookmarked sounds download

### DIFF
--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -69,7 +69,7 @@ class BookmarksTest(TestCase):
         self.assertEqual(1, len(response.context['page'].object_list))  # 1 bookmark uncategorized
         self.assertEqual(1, len(response.context['bookmark_categories']))  # 1 bookmark cateogry
 
-        # Test bookmark cateogry page
+        # Test bookmark category page
         response = self.client.get(reverse('bookmarks-category', kwargs={'category_id': category.id}))
         self.assertEqual(200, response.status_code)
         self.assertEqual(2, len(response.context['page'].object_list))  # 2 sounds in cateogry
@@ -78,3 +78,7 @@ class BookmarksTest(TestCase):
         # Test category does not exist
         response = self.client.get(reverse('bookmarks-category', kwargs={'category_id': 1234}))
         self.assertEqual(404, response.status_code)
+
+        # Test category licenses for downloading    
+        response = self.client.get(reverse('category-licenses', kwargs={'category_id': category.id}))
+        self.assertEqual(200, response.status_code)

--- a/templates/bookmarks/bookmarks.html
+++ b/templates/bookmarks/bookmarks.html
@@ -15,7 +15,8 @@
                 <div class="v-spacing-top-3">
                 {% if bookmark_categories %}
                     <ul class="list-style-type-none">
-                        <li><a href="{% url "bookmarks-for-user" user.username %}" {% if not category %}style="font-weight:bold"{% endif %} aria-label="Category: Uncategorized">Uncategorized</a> <span class="text-grey"> · {{n_uncat|bw_intcomma}} bookmark{{ n_uncat|pluralize }}</span></li>
+                        <li><a href="{% url "bookmarks-for-user" user.username %}" {% if not category %}style="font-weight:bold"{% endif %} aria-label="Category: Uncategorized">Uncategorized</a> <span class="text-grey"> · {{n_uncat|bw_intcomma}} bookmark{{ n_uncat|pluralize }}</span>
+                        <a class="cursor-pointer h-spacing-left-1" href="{% url 'download-bookmark-category' 0 %}" title="Download bookmark category" aria-label="Download bookmark category">{% bw_icon 'download' %}</a></li>
                         {% for cat in bookmark_categories %}
                             <li><a href="{% url "bookmarks-for-user-for-category" user.username cat.id %}" {% if category.id == cat.id %}style="font-weight:bold"{% endif %} aria-label="Category: {{cat.name}}">{{cat.name}}</a> <span class="text-grey"> · {{cat.num_bookmarks|bw_intcomma}} bookmark{{ cat.num_bookmarks|pluralize }}</span>
                             {% if is_owner %}

--- a/templates/sounds/multiple_sounds_attribution.txt
+++ b/templates/sounds/multiple_sounds_attribution.txt
@@ -1,14 +1,16 @@
 {% load absurl %}{{type}} downloaded from Freesound
 ----------------------------------------
 {# NOTE: an object can either be a pack of sounds or a bookmark category#}
-"{{ object.name }}"
+{%if object.name%}"{{ object.name }}"
+{%else%}"Uncategorized bookmarks category"
+{%endif%}
 
 This {{ type }} of sounds contains sounds by the following user{{ users|pluralize }}:
 {% for user in users %} - {{user.username}} ( {% absurl 'account' user.username %} ){% endfor %}
 
 {% if type == "Pack" %}You can find this pack online at: {% absurl 'pack' object.user.username object.id %}{% endif %}
 
-{%if object.description %}
+{%if object and object.description %}
 {{ type }} description
 ----------------
 

--- a/utils/tests/tests.py
+++ b/utils/tests/tests.py
@@ -63,6 +63,9 @@ class UtilsTest(TestCase):
         ret = utils.downloads.download_sounds(licenses_url, licenses_content, sounds_list, pack.friendly_filename())
         self.assertEqual(ret.status_code, 200)
 
+        ret = self.client.get(reverse('pack-licenses', args=["testuser", pack.id]))
+        self.assertEqual(ret.status_code, 200)
+
     @override_uploads_path_with_temp_directory
     def test_upload_sounds(self):
         # create new sound files


### PR DESCRIPTION
**Issue(s)**
#1290 - uncategorized bookmarked sounds

**Description**
Make available the download of uncategorized bookmarked sounds for a user. 
New view function to handle these type of sounds, which since they do not correspond to a BookmarkCategory object they need slight changes in their handling.

**Deployment steps**
1. Download uncategorized bookmarks id set to 0 (URL handling).
2. download_bookmark_category view computes necessary information according to category_id
3. uncat_bookmark_data returns all necessary information to download uncategorized bookmarks. It only uses the "request" parameter because it needs to be called both from "download_bookmark_category" and "bookmark_category_licenses" views, and I did not know how to handle the latter with suitable parameters for the purpose.
4. bookmark_category_licenses view returns url according to category_id
5. .txt template contemplates receiving "not_an_object" for its rendering, since uncategorized bookmarks do not group in any object itself (I think).