### PR TITLE
Display time info under mouse when ruler is activated

### DIFF
--- a/freesound/static/bw-frontend/src/components/player/player-ui.js
+++ b/freesound/static/bw-frontend/src/components/player/player-ui.js
@@ -99,14 +99,13 @@ const createProgressIndicator = (parentNode, audioElement, playerImgNode, player
         }
         const rulerIndicator = playerImgNode.parentNode.getElementsByClassName('bw-player__ruler-indicator')[0];
         rulerIndicator.innerText = readout;
-      } else {
-        // Update playhead
-        const progressPercentage = evt.offsetX / progressIndicatorContainer.clientWidth
-        setProgressIndicator(progressPercentage * 100, parentNode)
-
-        // Update selected time indicator (only in big players)
-        updateProgressBarIndicator(parentNode, audioElement, progressPercentage)
       }
+      // Update playhead
+      const progressPercentage = evt.offsetX / progressIndicatorContainer.clientWidth
+      setProgressIndicator(progressPercentage * 100, parentNode)
+
+      // Update selected time indicator (only in big players)
+      updateProgressBarIndicator(parentNode, audioElement, progressPercentage)
     }),
     50
   )


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/436

**Description**
Time information was only displayed in the player when ruler was inactive.
Now after checking if ruler is activated, display time whether or not that's true.
