### PR TITLE
Enable upload of different sound files with the same filename

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1284,7 +1284,18 @@ def upload(request, no_flash=False):
             form = UploadFileForm(request.POST, request.FILES)
             if form.is_valid():
                 submitted_files = request.FILES.getlist('files')
+                files_names = list()
                 for file_ in submitted_files:
+                    #check for duplicated names and add an identifier, otherwise, different files with the same
+                    #name will be overwritten in the description queue
+                    if file_.name in files_names:                        
+                        name_counter = files_names.count(file_.name) 
+                        files_names.append(file_.name) 
+                        name, extension = os.path.splitext(file_.name)
+                        file_.name = "%s(%d)%s" % (name, name_counter, extension) 
+                    else:
+                        files_names.append(file_.name)
+                    
                     if handle_uploaded_file(request.user.id, file_):
                         uploaded_file = file_
                         successes += 1


### PR DESCRIPTION
**Issue(s)**
#1181

**Description**
Sound files uploaded with the same file name got overwritten in the description queue.
In order to solve that, my proposal is to change the filenames adding an index as done in most of OS files handling (for example, for download), e.g.:

a.mp3
a(1).mp3

**Deployment steps**:
`upload()` creates a submitted files list, using this list:

1) Create a new list to store filenames
2) For each file name, check if the name already exists in the list and if so, give it an index for as many times as the name has already appeared.
3) Update the filename with the index appropiately

Note: all filenames will be added to the filenames list for indexing purposes (for the duplicated ones, addition must be done before filename modification).  
