### PR TITLE
Upgrade the version of postgres used in local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Below are instructions for setting up a local Freesound installation for develop
        # or if the above command does not work, try this one 
        docker compose run --rm --no-TTY db psql -h db -U freesound -d freesound < freesound-data/db_dev_dump/freesound-small-dev-dump-2023-09.sql
 
+If you a prompted for a password, use `localfreesoundpgpassword`, this is defined in the `docker-compose.yml` file.
+
 10. Update database by running Django migrations
 
         docker compose run --rm web python manage.py migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,17 +8,16 @@ services:
 
     # Database server
     db:
-        image: postgres:12.1
+        image: postgres:16.6
         volumes:
             - pgdata:/var/lib/postgresql/data
             - ./freesound-data/db_dev_dump:/freesound-data/db_dev_dump
-        env_file:
-            - environment
         ports:
             - "${FS_BIND_HOST:-127.0.0.1}:${LOCAL_PORT_PREFIX}5432:5432"
         environment:
             - POSTGRES_USER=freesound
             - POSTGRES_DB=freesound
+            - POSTGRES_PASSWORD=localfreesoundpgpassword
             - FS_USER_ID
 
     # Web worker

--- a/environment
+++ b/environment
@@ -1,1 +1,1 @@
-DJANGO_DATABASE_URL=postgres://freesound@db/freesound
+DJANGO_DATABASE_URL=postgres://freesound:localfreesoundpgpassword@db/freesound


### PR DESCRIPTION
New versions of the postgres docker image require a password, so add one

People with a local dev setup will need to delete the old data volume for postgres and reload a new dump, due to version differences.