### PR TITLE
Actions tests remove cache

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,9 +45,6 @@ jobs:
     - name: Pull docker images
       run: docker compose -f docker-compose.test.yml pull
 
-    - uses: jpribyl/action-docker-layer-caching@v0.1.1
-      continue-on-error: true
-
     - name: Build base image
       run: make -C docker
 

--- a/monitor/tests.py
+++ b/monitor/tests.py
@@ -17,7 +17,7 @@ class QueryStatsAjaxTestCase(TestCase):
         resp = self.client.get(reverse('monitor-queries-stats-ajax'))
 
         self.assertEqual(resp.status_code, 500)
-        mock_get.assert_called_with('http://graylog/graylog/api/search/universal/relative/terms', auth=mock.ANY, params=mock.ANY)
+        mock_get.assert_called_with('http://graylog/api/search/universal/relative/terms', auth=mock.ANY, params=mock.ANY)
 
     @override_settings(GRAYLOG_DOMAIN='http://graylog')
     @mock.patch('requests.get')
@@ -29,7 +29,7 @@ class QueryStatsAjaxTestCase(TestCase):
         resp = self.client.get(reverse('monitor-queries-stats-ajax'))
 
         self.assertEqual(resp.status_code, 500)
-        mock_get.assert_called_with('http://graylog/graylog/api/search/universal/relative/terms', auth=mock.ANY, params=mock.ANY)
+        mock_get.assert_called_with('http://graylog/api/search/universal/relative/terms', auth=mock.ANY, params=mock.ANY)
 
     @override_settings(GRAYLOG_DOMAIN='http://graylog')
     @mock.patch('requests.get')
@@ -43,4 +43,4 @@ class QueryStatsAjaxTestCase(TestCase):
 
         self.assertEqual(resp.status_code, 200)
         self.assertJSONEqual(resp.content, {'response': 'ok'})
-        mock_get.assert_called_with('http://graylog/graylog/api/search/universal/relative/terms', auth=mock.ANY, params=mock.ANY)
+        mock_get.assert_called_with('http://graylog/api/search/universal/relative/terms', auth=mock.ANY, params=mock.ANY)


### PR DESCRIPTION
This step appears to always fail, doubling the runtime of the tests that it was supposed to be speeding up!

Tests take about 8-9 minutes to run, 4m30s of that time is this action trying to do something and failing. In my opinion 4 minutes for tests is pretty good, so just leave it at that...

I tried to clear the layer-caching cache with the other action, but it still takes a long time. It's possible that upgrading the action would also resolve this issue, but let's be happy with 4m instead of trying complex things to get it down to 3...