### PR TITLE
If email1 validation fails, remove email2 validation errors

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -219,6 +219,16 @@ class RegistrationForm(forms.Form):
         self.fields['password1'].widget.attrs['placeholder'] = 'Password'
         self.fields['accepted_tos'].widget.attrs['class'] = 'bw-checkbox'
 
+    def clean(self):
+        # In the case that clean_email1 fails, the check for clean_email2 will report as "the email addresses are not the same"
+        # Therefore, in this specific case we remove the email2 error message because it doesn't make sense to 
+        # have email1 say "you cannot use this email to create an account" and email2 say "the email addresses are not the same"
+        cleaned_data = super().clean()
+        if self.has_error("email1") and "email2" in self.errors:
+            del self.errors["email2"]
+        return cleaned_data
+
+
     def clean_username(self):
         username = self.cleaned_data["username"]
         if not username_taken_by_other_user(username):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -318,6 +318,11 @@ def registration_modal(request):
             # If the form is NOT valid we return the Django rendered HTML version of the
             # registration modal (which includes the form and error messages) so the browser can show the updated
             # modal contents to the user
+            if form.has_error("email1") and "email2" in form.data:
+                # If email1 has an error, remove the value of email2
+                post_data = request.POST.copy()
+                post_data["email2"] = ""
+                form = RegistrationForm(post_data)
             return render(request, 'accounts/modal_registration.html', {'registration_form': form})
     else:
         form = RegistrationForm()


### PR DESCRIPTION
**Issue(s)**
Fixes #1817

**Description**
email1 validation checks to see if the email address is used 
email2 validation checks if the values are the same. 
If email1 fails then the cleaned value is always different to email2 and the check fails. Remove the check and the value for email2 in this case

I removed the value for email2 because the user needs to change it anyway, if not necessary we can remove that bit of code
