### PR TITLE
Remove "This pack has no description" when a pack has no description

### DIFF
--- a/templates/sounds/display_pack.html
+++ b/templates/sounds/display_pack.html
@@ -44,8 +44,6 @@
                     {{ preprocessed_description|truncatechars_html:55 }}
                 </div>
                 {% endwith %}
-            {% else %}
-                This pack has no description.
             {% endif %}
         </div>
     </div>
@@ -91,8 +89,6 @@
                         {{ preprocessed_description|truncatewords_html:20 }}
                     </div>
                     {% endwith %}
-                {% else %}
-                    This pack has no description.
                 {% endif %}
             </div>
             {% with pack.get_pack_tags_bw as tags %}


### PR DESCRIPTION
In slack I mentioned that removing this text might reduce a bit of clutter from the pack results page. 

We're still not sure if we want to do this or not, leaving this PR here to start a discussion