### PR TITLE
Upgrade redis and set specific version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
 
     # Redis (caches)
     redis:
-        image: redis:alpine
+        image: redis:7.4.2
         command: redis-server --port 6379
 
     # Celery broker (queue manager)

--- a/requirements.in
+++ b/requirements.in
@@ -48,7 +48,7 @@ pysolr==3.10.0b1
 python-louvain==0.16  # community detection in clustering
 pytz==2023.3
 PyYAML==6.0.1
-redis==3.2.0
+redis==5.2.1
 scikit-learn==1.4.1.post1  # clustering
 scipy==1.12.0  # clustering
 sentry-sdk[django]~=2.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ asgiref==3.7.2
     #   django-cors-headers
 asttokens==2.4.1
     # via stack-data
+async-timeout==5.0.1
+    # via redis
 autopep8==1.5.7
     # via
     #   -r requirements.in
@@ -276,7 +278,7 @@ pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   djangorestframework-yaml
-redis==3.2.0
+redis==5.2.1
     # via
     #   -r requirements.in
     #   django-redis


### PR DESCRIPTION
**Issue(s)**
Fixes #1745

**Description**
Different versions of the redis-py library support different versions of redis. Use an explicit version in docker-compose.yml and update python dependency to a version which supports it.

**Deployment steps**:
Pending freesound-deploy PR to do the same thing on prod