### PR TITLE
Remove ifequal templatetag, removed in django 4

### DIFF
--- a/templates/accounts/attribution.html
+++ b/templates/accounts/attribution.html
@@ -20,7 +20,7 @@
 
 {% regroup page.object_list by created|date:"F jS, Y" as downloads %}
 
-{% ifequal format "regular" %}
+{% if format == "regular" %}
 	{% for group in downloads %}
 		<h4 class="v-spacing-top-4">Downloaded on {{group.grouper}}</h4>
 		<ul>
@@ -35,9 +35,9 @@
         {% endfor %}
 		</ul>
 	{% endfor %}
-{% endifequal %}
+{% endif %}
 
-{% ifequal format "html" %}
+{% if format == "html" %}
 <p>
 	{% for group in downloads %}
 		{% filter force_escape %}<h4>Downloaded on {{group.grouper}}</h4>{% endfilter %}<br />
@@ -56,9 +56,9 @@
 		{% filter force_escape %}</ul>{% endfilter %}<br />
 	{% endfor %}
 </p>
-{% endifequal %}
+{% endif %}
 
-{% ifequal format "plaintext" %}
+{% if format == "plaintext" %}
 <p>
 	{% for group in downloads %}
     Downloaded on {{group.grouper}}<br />
@@ -74,7 +74,7 @@
     {% endfor %}
 	{% endfor %}
 </p>
-{% endifequal %}
+{% endif %}
 
 </div>
 

--- a/templates/accounts/upload.html
+++ b/templates/accounts/upload.html
@@ -33,7 +33,7 @@
         <div class="col-md-6 col-lg-3">
             <div class="padding-right-2">
                 <h5>Formats</h5>
-                <p>We prefer {% for ext in lossless_file_extensions %}<strong>{{ ext }}</strong>{% if not forloop.last %}{% ifequal forloop.revcounter 2 %} and {% else %}, {% endifequal %}{% else %}{% endif %}{% endfor %}, but we support {% for ext in lossy_file_extensions %}<strong>{{ ext }}</strong>{% if not forloop.last %}{% ifequal forloop.revcounter 2 %} and {% else %}, {% endifequal %}{% else %}{% endif %}{% endfor %} too. For very large files, please use some compressed format.</p>
+                <p>We prefer {% for ext in lossless_file_extensions %}<strong>{{ ext }}</strong>{% if not forloop.last %}{% if forloop.revcounter == 2 %} and {% else %}, {% endif %}{% else %}{% endif %}{% endfor %}, but we support {% for ext in lossy_file_extensions %}<strong>{{ ext }}</strong>{% if not forloop.last %}{% if forloop.revcounter == 2 %} and {% else %}, {% endif %}{% else %}{% endif %}{% endfor %} too. For very large files, please use some compressed format.</p>
             </div>
         </div>
     </div>
@@ -46,7 +46,7 @@
                 
                 <div id="drag-tip">
                     <h1 class="text-light-grey">Drag files here...</h1>
-                    <p>...or click on 'Add files' (valid file extensions: {% for ext in all_file_extensions %}<strong>{{ ext }}</strong>{% if not forloop.last %}{% ifequal forloop.revcounter 2 %} and {% else %}, {% endifequal %}{% else %}{% endif %}{% endfor %}).</p>
+                    <p>...or click on 'Add files' (valid file extensions: {% for ext in all_file_extensions %}<strong>{{ ext }}</strong>{% if not forloop.last %}{% if forloop.revcounter == 2 %} and {% else %}, {% endif %}{% else %}{% endif %}{% endfor %}).</p>
                 </div>
                 <ul id="file-list" class="file-list"></ul>
                 <div class="progress-container h-spacing-2" id="progress-container"></div>

--- a/templates/moderation/assign_sounds.html
+++ b/templates/moderation/assign_sounds.html
@@ -14,10 +14,10 @@
         <div class="v-spacing-top-4 v-spacing-2">
             <span class="text-light-grey"><b>Sort by:</b></span>
             <select id="sort-by" name="order" onchange="this.form.submit()">
-                <option value="days" {% ifequal order "" %}selected{% endifequal %}>Days in queue</option>
-                <option value="username" {% ifequal order "username" %}selected{% endifequal %}>Username</option>
-                <option value="new_count" {% ifequal order "new_count" %}selected{% endifequal %}>Sounds in queue</option>
-                <option value="num_uploaded_sounds" {% ifequal order "num_uploaded_sounds" %}selected{% endifequal %}>Uploaded sounds</option>
+                <option value="days" {% if order == "" %}selected{% endif %}>Days in queue</option>
+                <option value="username" {% if order == "username" %}selected{% endif %}>Username</option>
+                <option value="new_count" {% if order == "new_count" %}selected{% endif %}>Sounds in queue</option>
+                <option value="num_uploaded_sounds" {% if order == "num_uploaded_sounds" %}selected{% endif %}>Uploaded sounds</option>
             </select>
         </div>
         </form>

--- a/templates/molecules/paginator.html
+++ b/templates/molecules/paginator.html
@@ -13,11 +13,11 @@
     {% endif %}
 
     {% for num in page_numbers %}
-        {% ifequal num current_page %}
+        {% if num == current_page %}
             <li class="bw-pagination_circle bw-pagination_selected"><a class="text-white" href="{{ url }}{{ num }}{% if anchor %}#{{anchor}}{% endif %}" title="Page {{ num }}">{{ num }}</a></li>
         {% else %}
             <li><a href="{{ url }}{{ num }}{% if anchor %}#{{anchor}}{% endif %}" title="Page {{ num }}">{{ num }}</a></li>
-        {% endifequal %}
+        {% endif %}
     {% endfor %}
 
     {% if show_last %}

--- a/templates/search/facet.html
+++ b/templates/search/facet.html
@@ -2,7 +2,7 @@
 {% if facet and facet|length > 1%}
 <div class="bw-search__filter-section">
     <div class="bw-search__filter-section-name caps text-light-grey between"><span>{{ title }}</span></div>
-    {% ifequal type "list" %}
+    {% if type == "list" %}
     <ul class="bw-search__filter-value-list">
         {% for f in facet %}
             <li class="bw-search__filter-value padding-bottom-1">
@@ -13,8 +13,8 @@
             </li>
         {% endfor %}
     </ul>
-    {% endifequal %}
-    {% ifequal type "range" %}
+    {% endif %}
+    {% if type == "range" %}
     <ul class="bw-search__filter-value-list">
         {% for f in facet %}
             <li class="bw-search__filter-value padding-bottom-1">
@@ -25,13 +25,13 @@
             </li>
         {% endfor %}
     </ul>
-    {% endifequal %}
-    {% ifequal type "cloud" %}
+    {% endif %}
+    {% if type == "cloud" %}
     <div class="bw-search__filter-tags-list">
         {% for f in facet %}
             {% bw_tag f.display_value 1 '' f.add_filter_url f.weight %}
         {% endfor %}
     </div>
-    {% endifequal %}
+    {% endif %}
 </div>
 {% endif %}


### PR DESCRIPTION
**Description**
Warning reported when running tests, replace with `{% if %}` template tag read for the django 4.2 upgrade
