### PR TITLE
Set postgres runtime password in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,10 @@ services:
         environment:
             - POSTGRES_USER=freesound
             - POSTGRES_DB=freesound
+            # Used to set up the initial database
             - POSTGRES_PASSWORD=localfreesoundpgpassword
+            # Used to connect to the database if we run psql in this container
+            - PGPASSWORD=localfreesoundpgpassword
             - FS_USER_ID
 
     # Web worker


### PR DESCRIPTION
**Description**
in https://github.com/MTG/freesound/pull/1811 we upgraded the version of postgres, in recent versions of the docker image it's required to either set a password or explicitly say that there is no password.
I decided to set a password, but it meant that running `psql` commands would now ask for it.
it's possible to set an env variable PGPASSWORD with the password value. While this is "insecure", it's not an issue in local development where the password is defined in plaintext anyway.