### PR TITLE
If a user's cookie for last forum visit has no tz, add it

### DIFF
--- a/forum/views.py
+++ b/forum/views.py
@@ -69,8 +69,12 @@ def last_action(view_func):
 
         if key not in request.COOKIES or not request.session.get(key, False):
             request.session[key] = now_as_string
-        elif now - datetime.datetime.fromisoformat(request.COOKIES[key]) > datetime.timedelta(minutes=30):
-            request.session[key] = request.COOKIES[key]
+        else:
+            cookie_value = datetime.datetime.fromisoformat(request.COOKIES[key])
+            if cookie_value.tzinfo is None:
+                cookie_value = cookie_value.replace(tzinfo=timezone.utc)
+            if now - cookie_value > datetime.timedelta(minutes=30):
+                request.session[key] = request.COOKIES[key]
 
         request.last_action_time = datetime.datetime.fromisoformat(request.session.get(key, now_as_string))
 


### PR DESCRIPTION
This is only necessary in the few days between our release of use_tz=True and users' cookies expiring, but without it no one can visit the forum

**Issue(s)**
https://logserver.mtg.upf.edu/organizations/sentry/issues/3789/?alert_rule_id=32&alert_type=issue&notification_uuid=cbf1cacf-fc38-4b64-bdfd-2368c1c343c6&project=3&referrer=slack

**Description**
<!-- Description of the contents of this PR -->

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
