### PR TITLE
fix initial_tagcloud not being added to context

### DIFF
--- a/tags/views.py
+++ b/tags/views.py
@@ -84,7 +84,8 @@ def tags(request, multiple_tags=None):
                     search_logger.info(f'Tag browse error: Could probably not connect to Solr - {e}')
                     sentry_sdk.capture_exception(e)  # Manually capture exception so it has more info and Sentry can organize it properly
                     tvars.update({'error_text': 'The search server could not be reached, please try again later.'})
-            
+            tvars.update({'initial_tagcloud': initial_tagcloud})
+
         return render(request, 'search/search.html', tvars)
 
 


### PR DESCRIPTION
This line was accidentally removed in https://github.com/MTG/freesound/pull/1824/files#diff-f14bc12154314087bc7a62c1f5772cdc27c38b163e9ea44fa3898446562fce19L75
