### PR TITLE
Handle invalid ints in search queries

### DIFF
--- a/utils/search/search_query_processor_options.py
+++ b/utils/search/search_query_processor_options.py
@@ -223,7 +223,10 @@ class SearchOptionInt(SearchOption):
     def get_value_from_request(self):
         if self.query_param_name is not None:
             if self.query_param_name in self.request.GET:
-                return int(self.request.GET.get(self.query_param_name))
+                try:
+                    return int(self.request.GET.get(self.query_param_name))
+                except ValueError:
+                    return None
             
     def format_value(self, value):
         return str(value)

--- a/utils/tests/test_search_query_processor_options.py
+++ b/utils/tests/test_search_query_processor_options.py
@@ -1,0 +1,23 @@
+from django.test import RequestFactory, TestCase
+from django.contrib.auth.models import AnonymousUser
+from utils.search import search_query_processor_options, search_query_processor
+
+
+class SearchQueryProcessorOptionsTest(TestCase):
+    def test_search_option_int(self):
+        request = RequestFactory().get('/?test=1')
+        request.user = AnonymousUser()
+        sqp = search_query_processor.SearchQueryProcessor(request)
+
+        option = search_query_processor_options.SearchOptionInt(query_param_name='test')
+        option.set_search_query_processor(sqp)
+        assert option.get_value_from_request() == 1
+
+    def test_search_option_int_bad_type(self):
+        request = RequestFactory().get('/?test=not_an_int')
+        request.user = AnonymousUser()
+        sqp = search_query_processor.SearchQueryProcessor(request)
+
+        option = search_query_processor_options.SearchOptionInt(query_param_name='test')
+        option.set_search_query_processor(sqp)
+        assert option.get_value_from_request() is None


### PR DESCRIPTION
**Issue(s)**
Fixes https://logserver.mtg.upf.edu/organizations/sentry/issues/3819/

I'm not sure if we need extra code to remove None values from the parameter list

**Description**
```
ValueError: invalid literal for int() with base 10: '1\'"'
  File "django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "geotags/views.py", line 277, in for_query
    'query_description': SearchQueryProcessor(request).get_textual_description(),
  File "utils/search/search_query_processor.py", line 251, in __init__
    option.load_value()
  File "utils/search/search_query_processor_options.py", line 95, in load_value
    value_from_request = self.get_value_from_request()
  File "utils/search/search_query_processor_options.py", line 226, in get_value_from_request
    return int(self.request.GET.get(self.query_param_name))
```
