### PR TITLE
Tags view refactor

### DIFF
--- a/accounts/management/commands/clean_old_tmp_upload_files.py
+++ b/accounts/management/commands/clean_old_tmp_upload_files.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
 
     def handle(self,  *args, **options):
         for f in os.listdir(settings.FILE_UPLOAD_TEMP_DIR):
-            f_mod_date = datetime.datetime.fromtimestamp(os.path.getmtime(settings.FILE_UPLOAD_TEMP_DIR + f), tz=timezone.utc)
+            f_mod_date = datetime.datetime.fromtimestamp(os.path.getmtime(settings.FILE_UPLOAD_TEMP_DIR + f), tz=datetime.timezone.utc)
             now = timezone.now()
             if (now - f_mod_date).total_seconds() > 3600*24:
                 print(f"Deleting {f}")

--- a/freesound/urls.py
+++ b/freesound/urls.py
@@ -39,6 +39,7 @@ from apiv2.apiv2_utils import apiv1_end_of_life_message
 
 admin.autodiscover()
 
+
 urlpatterns = [
     path('', sounds.views.front_page, name='front-page'),
 
@@ -90,7 +91,7 @@ urlpatterns = [
 
     path('browse/', sounds.views.sounds, name="sounds"),
     path('browse/tags/', tags.views.tags, name="tags"),
-    re_path(r'^browse/tags/(?P<multiple_tags>[\w//-]+)/$', tags.views.tags, name="tags"),
+    re_path(r'^browse/tags/(?P<multiple_tags>[\w//-]+)/$', tags.views.multiple_tags_lookup, name="tags"),
     path('browse/packs/', sounds.views.packs, name="packs"),
     path('browse/random/', sounds.views.random, name="sounds-random"),
     re_path(r'^browse/geotags/(?P<tag>[\w-]+)?/?$', geotags.views.geotags, name="geotags"),
@@ -144,7 +145,6 @@ urlpatterns = [
     re_path(r'^tagsViewSingle', tags.views.old_tag_link_redirect, name="old-tag-page"),
     re_path(r'^forum/viewtopic', forum.views.old_topic_link_redirect, name="old-topic-page"),
 ]
-
 urlpatterns += [path('silk/', include('silk.urls', namespace='silk'))]
 
 # if you need django to host the admin files...

--- a/general/management/commands/clean_data_volume.py
+++ b/general/management/commands/clean_data_volume.py
@@ -66,7 +66,7 @@ class Command(LoggingBaseCommand):
         # Clean files from tmp_uploads which are olden than a day
         for filename in os.listdir(settings.FILE_UPLOAD_TEMP_DIR):
             filepath = os.path.join(settings.FILE_UPLOAD_TEMP_DIR, filename)
-            if datetime.datetime.fromtimestamp(os.path.getmtime(filepath), tz=timezone.utc) < one_day_ago:
+            if datetime.datetime.fromtimestamp(os.path.getmtime(filepath), tz=datetime.timezone.utc) < one_day_ago:
                 # Delete sound
                 console_logger.info(f'Deleting file {filepath}')
                 cleaned_files['tmp_uploads'] += 1
@@ -82,7 +82,7 @@ class Command(LoggingBaseCommand):
                 if not files_in_folder:
                     should_delete = True
                 else:
-                    if all([datetime.datetime.fromtimestamp(os.path.getmtime(os.path.join(folderpath, filename)), tz=timezone.utc) < one_day_ago for filename in files_in_folder]):
+                    if all([datetime.datetime.fromtimestamp(os.path.getmtime(os.path.join(folderpath, filename)), tz=datetime.timezone.utc) < one_day_ago for filename in files_in_folder]):
                         should_delete = True
                 if should_delete:
                     # Delete directory and contents
@@ -100,7 +100,7 @@ class Command(LoggingBaseCommand):
                 if not files_in_folder:
                     should_delete = True
                 else:
-                    if all([datetime.datetime.fromtimestamp(os.path.getmtime(os.path.join(folderpath, sound_filename)), tz=timezone.utc) < one_year_ago for sound_filename in files_in_folder]):
+                    if all([datetime.datetime.fromtimestamp(os.path.getmtime(os.path.join(folderpath, sound_filename)), tz=datetime.timezone.utc) < one_year_ago for sound_filename in files_in_folder]):
                         should_delete = True
                 if should_delete:
                     # Delete directory and contents

--- a/tags/tests.py
+++ b/tags/tests.py
@@ -17,49 +17,119 @@
 # Authors:
 #     See AUTHORS file.
 #
+from unittest import mock
 
+from django.test import Client
 from django.test import TestCase
 from django.urls import reverse
 
-from tags.models import FS1Tag
+from tags.models import FS1Tag, Tag
+from utils.search import SearchResults, SearchResultsPaginator
+
+
+def create_fake_search_engine_results():
+    return SearchResults(
+        facets={
+            "tags": [
+                ("synth", 100),
+                ("analogue", 50),
+                ("field-recording", 30),
+                ("test", 20),
+                ("driven", 10),
+                ("development", 5),
+            ],
+        },
+    )
+
+
+def create_fake_perform_search_engine_query_response(num_results):
+    results = create_fake_search_engine_results()
+    results.docs = [
+        {
+            "group_docs": [{"id": sound_id}],
+            "id": sound_id,
+            "n_more_in_group": 0,
+            "group_name": f"{pack_id}_xyz" if pack_id is not None else str(sound_id),
+        }
+        for sound_id, pack_id in zip(range(num_results, 2), range(num_results))
+    ]
+    paginator = SearchResultsPaginator(results, num_results)
+    return results, paginator
+
+
+class TagsViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.tag1 = Tag.objects.create(name="testtag1")
+        self.tag2 = Tag.objects.create(name="testtag2")
+        self.NUM_RESULTS = 15
+        self.perform_search_engine_query_response = create_fake_perform_search_engine_query_response(self.NUM_RESULTS)
+
+    @mock.patch("tags.views.perform_search_engine_query")
+    def test_tags_view_without_tags(self, perform_search_engine_query):
+        perform_search_engine_query.return_value = self.perform_search_engine_query_response
+
+        response = self.client.get(reverse("tags"))
+        perform_search_engine_query.assert_called()
+        self.assertTemplateUsed(response, "tags/tag_cloud.html")
+        self.assertContains(response, "Choose a tag to start browsing")
+
+    @mock.patch("tags.views.cache")
+    def test_tags_view_without_tags_cache(self, cache):
+        cache.get.return_value = [
+            {"name": "synth", "count": 707, "browse_url": "/browse/tags/synth/"},
+            {"name": "analogue", "count": 514, "browse_url": "/browse/tags/analogue/"},
+            {"name": "multisample", "count": 513, "browse_url": "/browse/tags/multisample/"},
+        ]
+
+        response = self.client.get(reverse("tags"))
+        cache.get.assert_called()
+        self.assertContains(response, "Choose a tag to start browsing")
+        self.assertContains(response, "synth")
+        self.assertTemplateUsed(response, "tags/tag_cloud.html")
+
+    @mock.patch("tags.views.perform_search_engine_query")
+    def test_tags_view_with_multiple_tags(self, perform_search_engine_query):
+        perform_search_engine_query.return_value = self.perform_search_engine_query_response
+        response = self.client.get(reverse("tags", args=["synth/analogue"]))
+        self.assertEqual(response.status_code, 302)
 
 
 class OldTagLinksRedirectTestCase(TestCase):
-    
-    fixtures = ['fs1tags']
-    
+    fixtures = ["fs1tags"]
+
     def setUp(self):
         self.fs1tags = [tag.fs1_id for tag in FS1Tag.objects.all()[0:2]]
-        
+
     def test_old_tag_link_redirect_single_ok(self):
         # 301 permanent redirect, single tag result exists
-        response = self.client.get(reverse('old-tag-page'), data={'id' : self.fs1tags[0]})
+        response = self.client.get(reverse("old-tag-page"), data={"id": self.fs1tags[0]})
         self.assertEqual(response.status_code, 301)
-    
-    def test_old_tag_link_redirect_multi_ok(self):    
+
+    def test_old_tag_link_redirect_multi_ok(self):
         # 301 permanent redirect, multiple tags result exists
-        ids = '_'.join([ str(temp) for temp in self.fs1tags])
-        response = self.client.get(reverse('old-tag-page'), data={'id' : ids})
+        ids = "_".join([str(temp) for temp in self.fs1tags])
+        response = self.client.get(reverse("old-tag-page"), data={"id": ids})
         self.assertEqual(response.status_code, 301)
-        
+
     def test_old_tag_link_redirect_partial_ids_list(self):
         # 301 permanent redirect, one of the tags in the list exists
-        partial_ids = str(self.fs1tags[0]) + '_0'
-        response = self.client.get(reverse('old-tag-page'), data={'id' : partial_ids})
-        self.assertEqual(response.status_code, 301)    
-        
+        partial_ids = str(self.fs1tags[0]) + "_0"
+        response = self.client.get(reverse("old-tag-page"), data={"id": partial_ids})
+        self.assertEqual(response.status_code, 301)
+
     def test_old_tag_link_redirect_not_exists_id(self):
         # 404 id exists does not exist
-        response = self.client.get(reverse('old-tag-page'), data={'id' : 0}, follow=True)
+        response = self.client.get(reverse("old-tag-page"), data={"id": 0}, follow=True)
         self.assertEqual(response.status_code, 404)
-        
+
     def test_old_tag_link_redirect_invalid_id(self):
         # 404 invalid id
-        response = self.client.get(reverse('old-tag-page'), data={'id' : 'invalid_id'}, follow=True)
-        self.assertEqual(response.status_code, 404)    
-        
+        response = self.client.get(reverse("old-tag-page"), data={"id": "invalid_id"}, follow=True)
+        self.assertEqual(response.status_code, 404)
+
     def test_old_tag_link_redirect_partial_invalid_id(self):
         # 404 invalid id in the id list
-        partial_ids = str(self.fs1tags[0]) + '_invalidValue'
-        response = self.client.get(reverse('old-tag-page'), data={'id' : partial_ids}, follow=True)
-        self.assertEqual(response.status_code, 404) 
+        partial_ids = str(self.fs1tags[0]) + "_invalidValue"
+        response = self.client.get(reverse("old-tag-page"), data={"id": partial_ids}, follow=True)
+        self.assertEqual(response.status_code, 404)

--- a/tags/views.py
+++ b/tags/views.py
@@ -35,73 +35,86 @@ from utils.search.search_sounds import perform_search_engine_query
 search_logger = logging.getLogger("search")
 
 
-def tags(request, multiple_tags=None):
-    
-    if multiple_tags:
-        multiple_tags = multiple_tags.split('/')
+def tags(request):
+    # Share same view code as for the search view, but "tags mode" will be on
+    tvars = search_view_helper(request)
+
+    # If there are no tags in filter, get display initial tag cloud
+    if 'sqp' in tvars and not tvars["sqp"].get_tags_in_filters():
+        return tag_cloud(request)
+
+    return render(request, "search/search.html", tvars)
+
+
+def tag_cloud(request):
+    tvars = {}
+    initial_tagcloud = cache.get("initial_tagcloud")
+    if initial_tagcloud is None:
+        try:
+            # If tagcloud is not cached, make a query to retrieve it and save it to cache
+            results, _ = perform_search_engine_query(
+                dict(
+                    textual_query="",
+                    query_filter="*:*",
+                    num_sounds=1,
+                    facets={settings.SEARCH_SOUNDS_FIELD_TAGS: {"limit": 200}},
+                    group_by_pack=True,
+                    group_counts_as_one_in_facets=False,
+                )
+            )
+        except SearchEngineException as e:
+            search_logger.info(f"Tag browse error: Could probably not connect to Solr - {e}")
+            # Manually capture exception so it has more info and Sentry can organize it properly
+            sentry_sdk.capture_exception(e)
+            tvars.update({"error_text": "The search server could not be reached, please try again later."})
+        else:
+            if settings.SEARCH_SOUNDS_FIELD_TAGS in results.facets:
+                initial_tagcloud = [
+                    dict(name=f[0], count=f[1], browse_url=reverse("tags", args=[f[0]]))
+                    for f in results.facets.get(settings.SEARCH_SOUNDS_FIELD_TAGS, [])
+                ]
+                cache.set("initial_tagcloud", initial_tagcloud, 60 * 60 * 12)  # cache for 12 hours
+                tvars.update({"initial_tagcloud": initial_tagcloud})
+            else:
+                tvars.update({"error_text": "There was an error while loading results, please try again later."})
     else:
-        multiple_tags = []
-    #Make all tags lower-cased and unique to get a case-insensitive search filter and shortened browse url
+        tvars.update({"initial_tagcloud": initial_tagcloud})
+
+    return render(request, "tags/tag_cloud.html", tvars)
+
+
+def multiple_tags_lookup(request, multiple_tags):
+    multiple_tags = multiple_tags.split("/")
+
+    # Make all tags lower-cased and unique to get a case-insensitive search filter and shortened browse url
     multiple_tags = sorted({x.lower() for x in multiple_tags if x})
-    if multiple_tags:
-        # We re-write tags as query filter and redirect
-        search_filter = "+".join('tag:"' + tag + '"' for tag in multiple_tags)
-        username_flt = request.GET.get('username_flt', None)
-        if username_flt is not None:
-            # If username is passed as a GET parameter, add it as well to the filter
-            search_filter += f'+username:{username_flt}'
-        pack_flt = request.GET.get('pack_flt', None)
-        if pack_flt is not None:
-            # If username is passed as a GET parameter, add it as well to the filter
-            search_filter += f'+grouping_pack:{pack_flt}'
+    # We re-write tags as query filter and redirect
+    search_filter = "+".join('tag:"' + tag + '"' for tag in multiple_tags)
+    username_flt = request.GET.get("username_flt", None)
+    if username_flt is not None:
+        # If username is passed as a GET parameter, add it as well to the filter
+        search_filter += f"+username:{username_flt}"
+    pack_flt = request.GET.get("pack_flt", None)
+    if pack_flt is not None:
+        # If username is passed as a GET parameter, add it as well to the filter
+        search_filter += f"+grouping_pack:{pack_flt}"
 
-        return HttpResponseRedirect(f"{reverse('tags')}?f={search_filter}")
-    else:
-        # Share same view code as for the search view, but "tags mode" will be on
-        tvars = search_view_helper(request)
-
-        # If there are no tags in filter, get initial tagcloud and add it to tvars
-        if 'sqp' in tvars and not tvars['sqp'].get_tags_in_filters():
-            initial_tagcloud = cache.get('initial_tagcloud')
-            if initial_tagcloud is None:
-                try:
-                    # If tagcloud is not cached, make a query to retrieve it and save it to cache
-                    results, _ = perform_search_engine_query(dict(
-                        textual_query='',
-                        query_filter= "*:*",
-                        num_sounds=1,
-                        facets={settings.SEARCH_SOUNDS_FIELD_TAGS: {'limit': 200}},
-                        group_by_pack=True,
-                        group_counts_as_one_in_facets=False,
-                    ))
-                    if settings.SEARCH_SOUNDS_FIELD_TAGS in results.facets:
-                        initial_tagcloud = [dict(name=f[0], count=f[1], browse_url=reverse('tags', args=[f[0]])) for f in results.facets.get(settings.SEARCH_SOUNDS_FIELD_TAGS, [])]
-                        cache.set('initial_tagcloud', initial_tagcloud, 60 * 60 * 12)  # cache for 12 hours
-                        tvars.update({'initial_tagcloud': initial_tagcloud})
-                    else:
-                        tvars.update({'error_text': 'There was an error while loading results, please try again later.'})
-                except SearchEngineException as e:
-                    search_logger.info(f'Tag browse error: Could probably not connect to Solr - {e}')
-                    sentry_sdk.capture_exception(e)  # Manually capture exception so it has more info and Sentry can organize it properly
-                    tvars.update({'error_text': 'The search server could not be reached, please try again later.'})
-            tvars.update({'initial_tagcloud': initial_tagcloud})
-
-        return render(request, 'search/search.html', tvars)
+    return HttpResponseRedirect(f"{reverse('tags')}?f={search_filter}")
 
 
 def old_tag_link_redirect(request):
-    fs1tag_id = request.GET.get('id', False)
+    fs1tag_id = request.GET.get("id", False)
     if fs1tag_id:
-        tags = fs1tag_id.split('_')
+        tags = fs1tag_id.split("_")
         try:
-            fs1tags = FS1Tag.objects.filter(fs1_id__in=tags).values_list('tag', flat=True)
-        except ValueError as e:
+            fs1tags = FS1Tag.objects.filter(fs1_id__in=tags).values_list("tag", flat=True)
+        except ValueError:
             raise Http404
 
-        tags = Tag.objects.filter(id__in=fs1tags).values_list('name', flat=True)
+        tags = Tag.objects.filter(id__in=fs1tags).values_list("name", flat=True)
         if not tags:
             raise Http404
 
-        return HttpResponsePermanentRedirect(reverse("tags", args=['/'.join(tags)]))
+        return HttpResponsePermanentRedirect(reverse("tags", args=["/".join(tags)]))
     else:
         raise Http404

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -14,328 +14,317 @@
 
 {% block content %}
 
-<div class="container">
-    {% if error_text %}
-    <div class="navbar-space-filler v-spacing-3 v-spacing-top-2">
-        <div class="v-spacing-6 v-spacing-top-4">
-            <p class="v-spacing-4">{{ error_text }}</p>
-            <p><button onclick="window.history.back();" class="btn-primary">Go back</button></p>
-        </div>
-    </div>
-    {% else %}
-    <div class="navbar-space-filler v-spacing-3 v-spacing-top-2">
-        {% if initial_tagcloud %}
-        <section id="tags-mode-input-section" class="v-spacing-5">
-            <h3 class="v-spacing-5 text-light-grey center">Choose a tag to start browsing</h3>
-            {% for tag in initial_tagcloud|add_sizes:"count:0.1:1.0" %}
-            {% bw_tag tag.name 1 '' tag.browse_url tag.size %}
-            {% endfor %}
-        </section>
+    <div class="container">
+        {% if error_text %}
+            <div class="navbar-space-filler v-spacing-3 v-spacing-top-2">
+                <div class="v-spacing-6 v-spacing-top-4">
+                    <p class="v-spacing-4">{{ error_text }}</p>
+                    <p><button onclick="window.history.back();" class="btn-primary">Go back</button></p>
+                </div>
+            </div>
         {% else %}
-        <form method="get" id="search_form" action="{% if not sqp.tags_mode_active %}{% url 'sounds-search' %}{% else %}{% url 'tags' %}{% endif %}">
-            {% comment %}main search input section and hidden fields{% endcomment %}
-            <div class="v-spacing-5 {% if sqp.tags_mode_active %}display-none{% endif %}">
-                <div class="middle center">
-                    <div class="bw-search__input_wrapper"><i class="bw-icon-search input-icon text-light-grey"></i>
-                        <input id="search-input-browse" 
-                        class="bw-search__input" 
-                        name="{{ sqp.options.query.query_param_name }}" 
-                        type="text" 
-                        value="{% if not sqp.similar_to_active %}{{ sqp.options.query.value_to_apply }}{% endif %}" 
-                        placeholder="{% if not sqp.similar_to_active %}Search {% if not sqp.display_as_packs_active %}sounds{% else %}packs{% endif %}...{% else %}Similar to {{ sqp.similar_to_active }}{% endif %}" 
-                        autocomplete="off"
-                        {% if sqp.options.query.disabled %}disabled{% endif %} />
+            <div class="navbar-space-filler v-spacing-3 v-spacing-top-2">
+                <form method="get" id="search_form" action="{% if not sqp.tags_mode_active %}{% url 'sounds-search' %}{% else %}{% url 'tags' %}{% endif %}">
+                    {% comment %}main search input section and hidden fields{% endcomment %}
+                    <div class="v-spacing-5 {% if sqp.tags_mode_active %}display-none{% endif %}">
+                        <div class="middle center">
+                            <div class="bw-search__input_wrapper"><i class="bw-icon-search input-icon text-light-grey"></i>
+                                <input id="search-input-browse"
+                                       class="bw-search__input"
+                                       name="{{ sqp.options.query.query_param_name }}"
+                                       type="text"
+                                       value="{% if not sqp.similar_to_active %}{{ sqp.options.query.value_to_apply }}{% endif %}"
+                                       placeholder="{% if not sqp.similar_to_active %}Search {% if not sqp.display_as_packs_active %}sounds{% else %}packs{% endif %}...{% else %}Similar to {{ sqp.similar_to_active }}{% endif %}"
+                                       autocomplete="off"
+                                       {% if sqp.options.query.disabled %}disabled{% endif %}/>
+                            </div>
+                            <span class="bw-search_remove-query" id="remove-content-search">{% bw_icon 'close' %}</span>
+                        </div>
+                        <input type="hidden" name="f" value="{{ sqp.get_filter_string_for_url|urlencode }}"/>
+                        {% if not sqp.options.field_weights.is_default_value %} {% display_search_option "field_weights" "hidden" %}{% endif %}
+                        {% if not sqp.options.similar_to.is_default_value %} {% display_search_option "similar_to" "hidden" %}{% endif %}
                     </div>
-                    <span class="bw-search_remove-query" id="remove-content-search">{% bw_icon 'close' %}</span>
-                </div>
-                <input type="hidden" name="f" value="{{ sqp.get_filter_string_for_url|urlencode }}" />
-                {% if not sqp.options.field_weights.is_default_value %}{% display_search_option "field_weights" "hidden" %}{% endif %}
-                {% if not sqp.options.similar_to.is_default_value %}{% display_search_option "similar_to" "hidden" %}{% endif %}
-            </div>
-            {% if sqp.tags_mode_active %}
-            {% comment %}"sounds tagged as" label with follow/unfollow buttons{% endcomment %}
-            <div id="tags-mode-input-section" class="v-spacing-5">
-                <div class="between middle">
-                    <h3>
-                        <span class="text-light-grey h-spacing-1">Sounds tagged as</span>
-                        {% for tag in sqp.get_tags_in_filters %}
-                        {{ tag }}{% if not forloop.last %}<span class="h-spacing-left-1 h-spacing-1 text-light-grey">·</span>{% endif %}
-                        {% endfor %}
-                    </h3>
-                    {% bw_follow_tags_widget %}
-                </div>
-            </div>
-            {% endif %}
-            <div>
-                {% comment %}search navbar{% endcomment %}
-                <div class="divider-light"></div>
-                <div class="padding-3 v-padding-2 between font-weight-bold middle">
-                    {% comment %}number of results{% endcomment %}
-                    <div class="col-4">
-                    {% if not sqp.display_as_packs_active %}
-                        {% if non_grouped_number_of_results > 0 %}{{ non_grouped_number_of_results|bw_intcomma }}{% else %}{{ paginator.count|bw_intcomma }}{% endif %} sound{{ non_grouped_number_of_results|pluralize }}
-                    {% else %}
-                        {{ paginator.count|bw_intcomma }} pack{{ paginator.count|pluralize }}
+                    {% if sqp.tags_mode_active %}
+                        {% comment %}"sounds tagged as" label with follow/unfollow buttons{% endcomment %}
+                        <div id="tags-mode-input-section" class="v-spacing-5">
+                            <div class="between middle">
+                                <h3>
+                                    <span class="text-light-grey h-spacing-1">Sounds tagged as</span>
+                                    {% for tag in sqp.get_tags_in_filters %}
+                                        {{ tag }}{% if not forloop.last %} <span class="h-spacing-left-1 h-spacing-1 text-light-grey">·</span> {% endif %}
+                                    {% endfor %}
+                                </h3>
+                                {% bw_follow_tags_widget %}
+                            </div>
+                        </div>
                     {% endif %}
-                    </div>
-                    {% comment %}advanced search toggle{% endcomment %}
-                    <div class="col-4 middle center">
-                        <a href="#" class="bw-link--grey-light" id="toggle_advanced_search_options"></a>
-                        {% if has_advanced_search_settings_set %}<span class="text-red h-spacing-left-1 text-44 line-height-14 padding-bottom-1" title="There are active filters in the advanced search options">·</span>{% endif %}
-                    </div>
-                    {% comment %}sorting options{% endcomment %}
-                    <div class="col-4 right browse__search-overview-sorter">
-                        <div class="{% if sqp.map_mode_active %}display-none{% endif %}"> 
-                            {% if not sqp.similar_to_active %}
-                                {% display_search_option "sort_by" %}
+                    <div>
+                        {% comment %}search navbar{% endcomment %}
+                        <div class="divider-light"></div>
+                        <div class="padding-3 v-padding-2 between font-weight-bold middle">
+                            {% comment %}number of results{% endcomment %}
+                            <div class="col-4">
+                                {% if not sqp.display_as_packs_active %}
+                                    {% if non_grouped_number_of_results > 0 %} {{ non_grouped_number_of_results|bw_intcomma }}{% else %} {{ paginator.count|bw_intcomma }}{% endif %} sound {{ non_grouped_number_of_results|pluralize }}
+                                {% else %}
+                                    {{ paginator.count|bw_intcomma }} pack{{ paginator.count|pluralize }}
+                                {% endif %}
+                            </div>
+                            {% comment %}advanced search toggle{% endcomment %}
+                            <div class="col-4 middle center">
+                                <a href="#" class="bw-link--grey-light" id="toggle_advanced_search_options"></a>
+                                {% if has_advanced_search_settings_set %} <span class="text-red h-spacing-left-1 text-44 line-height-14 padding-bottom-1" title="There are active filters in the advanced search options">·</span>{% endif %}
+                            </div>
+                            {% comment %}sorting options{% endcomment %}
+                            <div class="col-4 right browse__search-overview-sorter">
+                                <div class="{% if sqp.map_mode_active %}display-none{% endif %}">
+                                    {% if not sqp.similar_to_active %}
+                                        {% display_search_option "sort_by" %}
+                                    {% else %}
+                                        <span class="font-weight-normal text-light-grey d-none d-md-inline">{{ sqp.options.sort_by.label }}:</span>
+                                        <span><b>Similarity to target</b></span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
+                        <div class="divider-light"></div>
+                        {% comment %}advanced search options{% endcomment %}
+                        <div id="advanced-search-options" data-visible="{% if not has_advanced_search_settings_set or advanced_search_closed_on_load %}0{% else %}1{% endif %}" class="{% if not has_advanced_search_settings_set or advanced_search_closed_on_load %}display-none{% endif %}">
+                            <div class="padding-2">
+                                {% comment %}first row of advanced search options{% endcomment %}
+                                <div class="row">
+                                    {% comment %}left section{% endcomment %}
+                                    <div class="col-md-4 bw-search__advanced-search-filter-section v-spacing-2">
+                                        <div class="bw-search__filter-section-name caps text-light-grey text-18">
+                                            {{ sqp.options.search_in.label }}
+                                        </div>
+                                        <div class="row no-gutters v-spacing-top-1 {% if sqp.options.search_in.disabled %}opacity-020{% endif %}">
+                                            {% for option in sqp.options.search_in.get_choices_annotated_with_selection %}
+                                                <div class="col-6 v-padding-1">
+                                                    <label class="between w-100 cursor-pointer">
+                                                        <div class="bw-search__filter-checkbox">
+                                                            <input name="{{ option.0 }}" type="checkbox" class="bw-checkbox" {% if option.2 %}checked{% endif %} {% if sqp.options.search_in.disabled %}disabled{% endif %}/>
+                                                        </div>
+                                                        <div class="bw-search__filter-name">{{ option.1 }}</div>
+                                                    </label>
+                                                </div>
+                                            {% endfor %}
+                                        </div>
+                                    </div>
+                                    {% comment %}middle section{% endcomment %}
+                                    <div class="col-md-3 bw-search__advanced-search-filter-section v-spacing-2">
+                                        <div class="bw-search__filter-section-name caps text-light-grey text-18">
+                                            {{ sqp.options.duration.label }}
+                                        </div>
+                                        <div class="bw-search__filter-range v-spacing-top-2">
+                                            <input name="{{ sqp.options.duration.query_param_min }}" class="bw-search_input-range v-spacing-1" type="text" value="{{ sqp.options.duration.value.0 }}"/> - <input name="{{ sqp.options.duration.query_param_max }}" class="bw-search_input-range" type="text" value="{{ sqp.options.duration.value.1 }}"/> <span>seconds</span>
+                                        </div>
+                                    </div>
+                                    {% comment %}right section{% endcomment %}
+                                    <div class="col-md-5 bw-search__advanced-search-filter-section v-spacing-2">
+                                        <div class="bw-search__filter-section-name caps text-light-grey text-18">
+                                            Other
+                                        </div>
+                                        <div class="row no-gutters v-spacing-top-1">
+                                            <div class="col-6 v-padding-1">
+                                                {% display_search_option "is_geotagged" %}
+                                            </div>
+                                            <div class="col-6 v-padding-1">
+                                                {% display_search_option "is_remix" %}
+                                            </div>
+                                            <div class="col-6 v-padding-1">
+                                                {% display_search_option "group_by_pack" %}
+                                            </div>
+                                            <div class="col-6 v-padding-1">
+                                                {% display_search_option "display_as_packs" %}
+                                            </div>
+                                            <div class="col-6 v-padding-1">
+                                                {% display_search_option "grid_mode" %}
+                                            </div>
+                                            <div class="col-6 v-padding-1">
+                                                {% display_search_option "map_mode" %}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                {% if show_beta_search_options %}
+                                    <div class="row v-spacing-top-1">
+                                        <div class="col-12">
+                                            <div class="bw-search__filter-section-name caps text-light-grey text-18">
+                                                Experimental Search Options
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-4 v-padding-1">
+                                            <div class="v-spacing-top-1">{% display_search_option "similarity_space" %}</div>
+                                            <div class="v-spacing-top-1">{% display_search_option "similar_to" %}</div>
+                                            <div class="v-spacing-top-1">{% display_search_option "compute_clusters" %}</div>
+                                        </div>
+                                        <div class="col-8 v-padding-1">
+                                            <div class="v-spacing-top-1">{% display_search_option "include_audio_problems" %}</div>
+                                            <div class="v-spacing-top-1">{% display_search_option "single_event" %}</div>
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            </div>
+                            {% comment %}apply button{% endcomment %}
+                            <div class="v-spacing-4 center">
+                                <button id="avanced-search-apply-button" class="btn-primary" disabled>Apply advanced search filters</button>
+                            </div>
+                            <div class="divider-light"></div>
+                        </div>
+                        {% comment %}cluster results section{% endcomment %}
+                        {% if sqp.compute_clusters_active %}
+                            {% if clusters_data %}
+                                {% include 'search/clustering_results.html' %}
                             {% else %}
-                                <span class="font-weight-normal text-light-grey d-none d-md-inline">{{ sqp.options.sort_by.label }}:</span>
-                                <span><b>Similarity to target</b></span>
+                                {% if get_clusters_url %}
+                                    <div class="async-section"
+                                         data-async-section-content-url="{{ get_clusters_url }}">
+                                        <div class="h-padding-2 v-spacing-top-2">
+                                            <div class="center v-spacing-top-2">
+                                                <img width="12px" height="12px" src="{% static 'bw-frontend/public/bw_indicator.gif' %}">
+                                            </div>
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            {% endif %}
+                        {% endif %}
+                    </div>
+                </form>
+            </div>
+            <div class="row">
+                <div class="col-12 center v-spacing-top-negative-2 d-md-none">
+                    <div data-target="collapsable-filters" data-show-text="Show filters" data-hide-text="Hide filters" data-hide-on-load class="collapsable-toggle v-spacing-top-2 font-weight-bold text-light-grey"></div>
+                </div>
+                {% comment %}facets{% endcomment%}
+                <aside class="col-md-4 col-lg-3 collapsable-block md-max-h-100" id="collapsable-filters">
+                    {% if sqp.tags_mode_active %}
+                        {% display_facet "tags" %}
+                    {% endif %}
+                    {% display_facet "license" %}
+                    {% if not sqp.tags_mode_active %}
+                        {% display_facet "tags" %}
+                    {% endif %}
+                    {% display_facet "type" %}
+                    {% display_facet "channels" %}
+                    {% display_facet "samplerate" %}
+                    {% if not sqp.display_as_packs_active %}
+                        {% display_facet "pack_grouping" %}
+                    {% endif %}
+                    {% display_facet "username" %}
+                    {% display_facet "bitdepth" %}
+                    {% display_facet "bitrate" %}
+                    {% if show_beta_search_options %}
+                        {% for experimental_facet in experimental_facets %}
+                            {% display_facet experimental_facet %}
+                        {% endfor %}
+                    {% endif %}
+                </aside>
+                <div class="col-12 divider-light d-md-none v-spacing-top-3 v-spacing-3"></div>
+                {% comment %}search results{% endcomment %}
+                <main class="col-12 col-md-8 col-lg-9 col-extra-left-padding-large-md">
+                    {% comment %}filters{% endcomment %}
+                    {% with sqp.get_filters_data_to_display_in_search_results_page as filters_data %}
+                        {% if filters_data %}
+                            <div class="v-spacing-3 v-spacing-top-2 line-height-33">
+                                {% for name, value, remove_url in filters_data %}
+                                    <a class="no-hover btn-inverse bw-search__active-filters-button" href="{{ remove_url }}" title="Remove this filter">
+                                        {{ name }}:{{ value }}<span class="h-spacing-left-1">{% bw_icon 'close' %} </span>
+                                    </a>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    {% endwith %}
+                    {% comment %}map{% endcomment %}
+                    {% if sqp.map_mode_active %}
+                        <div class="col-12 v-spacing-top-3 no-paddings">
+                            <div id="mapCanvas" class="map main-map"
+                                 data-map-show-search="{% if sound %}false{% else %}true{% endif %}"
+                                 data-geotags-url="{{ map_bytearray_url }}"
+                                 data-access-token="pk.eyJ1IjoiZnJlZXNvdW5kIiwiYSI6ImNrd3E0Mm9lbjBqM2Qyb2wwdmwxaWI3a3oifQ.MZkgLSByRuk_Xql67CySAg"
+                            ><span id="mapLoadingIndicator">Loading map... <img width="12px" height="12px" src="{% static 'bw-frontend/public/bw_indicator.gif' %}"></span> </div>
+                        </div>
+                        <div class="row middle">
+                            <div class="col-lg-4 v-spacing-top-4">
+                                <a class="no-hover btn-secondary btn-inverse" href="{{ open_in_map_url }}">See results in full map</a>
+                            </div>
+                            <div class="col-lg-8 v-spacing-top-2">
+                                {% if paginator.count > max_search_results_map_mode %}
+                                    <div class="text-lg-right">
+                                        <p class="text-grey">{% bw_icon 'notification' %} Note that only the first {{ max_search_results_map_mode|bw_intcomma }} search results are shown on the map</p>
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    {% else %}
+                        {% comment %}list/grid of sounds{% endcomment %}
+                        <div class="v-spacing-6 v-spacing-top-2">
+                            {% if paginator.count > 0 %}
+                                {% if sqp.grid_mode_active %}
+                                    <div class="row">
+                                        {% for result in docs %}
+                                            <div class="col-6 col-lg-4">
+                                                {% if sqp.display_as_packs_active %}
+                                                    {% display_pack result.pack %}
+                                                    <p class="text-grey text-right v-spacing-top-negative-2">
+                                                        {% bw_icon 'plus' %} <a href="{{ result.more_from_this_pack_url }}">See {{ result.n_more_in_group|add:1|bw_intcomma }} result{{ result.n_more_in_group|add:1|pluralize }} from pack</a>
+                                                    </p>
+                                                {% else %}
+                                                    {% display_sound_small result.sound %}
+                                                    {% if result.more_from_this_pack_url %}
+                                                        <p class="text-grey text-right v-spacing-top-negative-2">
+                                                            {% bw_icon 'plus' %} <a href="{{ result.more_from_this_pack_url }}">See {{ result.n_more_in_group|add:1|bw_intcomma }} result{{ result.n_more_in_group|add:1|pluralize }} from pack:</a> <a class="bw-link--grey" href="{% url 'pack' result.sound.username result.sound.pack_id %}">{{ result.sound.pack_name|truncate_string:35 }}</a>
+                                                        </p>
+                                                    {% endif %}
+                                                {% endif %}
+                                            </div>
+                                        {% endfor %}
+                                    </div>
+                                {% else %}
+                                    {% for result in docs %}
+                                        <div class="bw-search__result">
+                                            {% if sqp.display_as_packs_active %}
+                                                {% display_pack_big result.pack %}
+                                                <div class="text-grey text-right v-spacing-top-negative-1 v-spacing-2 padding-right-1">
+                                                    {% bw_icon 'plus' %} <a href="{{ result.more_from_this_pack_url }}">See {{ result.n_more_in_group|add:1|bw_intcomma }} result{{ result.n_more_in_group|add:1|pluralize }} from this pack</a>
+                                                </div>
+                                            {% else %}
+                                                {% display_sound_middle result.sound %}
+                                                {% if result.more_from_this_pack_url %}
+                                                    <div class="text-grey text-right v-spacing-top-negative-1 v-spacing-2">
+                                                        {% bw_icon 'plus' %} <a href="{{ result.more_from_this_pack_url }}">See {{ result.n_more_in_group|add:1|bw_intcomma }} result{{ result.n_more_in_group|add:1|pluralize }} from same pack</a>
+                                                    </div>
+                                                {% endif %}
+                                            {% endif %}
+                                            {% if not forloop.last %}
+                                                <div class="divider-light v-spacing-2"></div>
+                                            {% endif %}
+                                        </div>
+                                    {% endfor %}
+                                {% endif %}
+                            {% else %}
+                                <div class="v-spacing-7 v-spacing-top-6 w-100">
+                                    <h5>No results... &#128543</h5>
+                                    <p class="text-grey v-spacing-2">Please try another query or change the filters</p>
+                                </div>
                             {% endif %}
                         </div>
-                    </div>
-                </div>
-                <div class="divider-light"></div>
-                {% comment %}advanced search options{% endcomment %}
-                <div id="advanced-search-options" data-visible="{% if not has_advanced_search_settings_set or advanced_search_closed_on_load %}0{% else %}1{% endif %}" class="{% if not has_advanced_search_settings_set or advanced_search_closed_on_load %}display-none{% endif %}">
-                    <div class="padding-2">
-                        {% comment %}first row of advanced search options{% endcomment %}
-                        <div class="row">
-                            {% comment %}left section{% endcomment %}
-                            <div class="col-md-4 bw-search__advanced-search-filter-section v-spacing-2">
-                                <div class="bw-search__filter-section-name caps text-light-grey text-18">
-                                    {{ sqp.options.search_in.label }}
-                                </div>
-                                <div class="row no-gutters v-spacing-top-1 {% if sqp.options.search_in.disabled %}opacity-020{% endif %}">
-                                    {% for option in sqp.options.search_in.get_choices_annotated_with_selection %}
-                                    <div class="col-6 v-padding-1">    
-                                        <label class="between w-100 cursor-pointer">
-                                            <div class="bw-search__filter-checkbox">
-                                                <input name="{{ option.0 }}" type="checkbox" class="bw-checkbox" {% if option.2 %}checked{% endif %} {% if sqp.options.search_in.disabled %}disabled{% endif %}/>
-                                            </div>
-                                            <div class="bw-search__filter-name">{{ option.1 }}</div>
-                                        </label>
-                                    </div>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                            {% comment %}middle section{% endcomment %}
-                            <div class="col-md-3 bw-search__advanced-search-filter-section v-spacing-2">
-                                <div class="bw-search__filter-section-name caps text-light-grey text-18">
-                                    {{ sqp.options.duration.label }}
-                                </div>
-                                <div class="bw-search__filter-range v-spacing-top-2">
-                                    <input name="{{ sqp.options.duration.query_param_min }}" class="bw-search_input-range v-spacing-1" type="text" value="{{ sqp.options.duration.value.0 }}" /> - <input name="{{ sqp.options.duration.query_param_max }}" class="bw-search_input-range" type="text" value="{{ sqp.options.duration.value.1 }}" /> <span>seconds</span>
-                                </div>
-                            </div>
-                            {% comment %}right section{% endcomment %}
-                            <div class="col-md-5 bw-search__advanced-search-filter-section v-spacing-2">
-                                <div class="bw-search__filter-section-name caps text-light-grey text-18">
-                                    Other
-                                </div>
-                                <div class="row no-gutters v-spacing-top-1">
-                                    <div class="col-6 v-padding-1">
-                                        {% display_search_option "is_geotagged" %}
-                                    </div>
-                                    <div class="col-6 v-padding-1">
-                                        {% display_search_option "is_remix" %}
-                                    </div>
-                                    <div class="col-6 v-padding-1">
-                                        {% display_search_option "group_by_pack" %}
-                                    </div>
-                                    <div class="col-6 v-padding-1">
-                                        {% display_search_option "display_as_packs" %}
-                                    </div>
-                                    <div class="col-6 v-padding-1">
-                                        {% display_search_option "grid_mode" %}
-                                    </div>
-                                    <div class="col-6 v-padding-1">
-                                        {% display_search_option "map_mode" %}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        {% if show_beta_search_options %}
-                        <div class="row v-spacing-top-1">
-                            <div class="col-12"> 
-                                <div class="bw-search__filter-section-name caps text-light-grey text-18">
-                                    Experimental Search Options
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row">    
-                            <div class="col-4 v-padding-1">
-                                <div class="v-spacing-top-1">{% display_search_option "similarity_space" %}</div>
-                                <div class="v-spacing-top-1">{% display_search_option "similar_to" %}</div>
-                                <div class="v-spacing-top-1">{% display_search_option "compute_clusters" %}</div>
-                            </div>
-                            <div class="col-8 v-padding-1">
-                                <div class="v-spacing-top-1">{% display_search_option "include_audio_problems" %}</div>
-                                <div class="v-spacing-top-1">{% display_search_option "single_event" %}</div>
-                            </div>
+                        <div class="v-spacing-6">
+                            {% bw_paginator paginator page current_page request "sound" non_grouped_number_of_results %}
                         </div>
                     {% endif %}
-                    </div>
-                    {% comment %}apply button{% endcomment %}
-                    <div class="v-spacing-4 center">
-                        <button id="avanced-search-apply-button" class="btn-primary" disabled>Apply advanced search filters</button>
-                    </div>
-                    <div class="divider-light"></div>
-                </div>
-                {% comment %}cluster results section{% endcomment %}
-                {% if sqp.compute_clusters_active %}
-                    {% if clusters_data %}
-                    {% include 'search/clustering_results.html' %}
-                    {% else %}
-                    {% if get_clusters_url %}
-                    <div class="async-section"
-                        data-async-section-content-url="{{ get_clusters_url }}">
-                        <div class="h-padding-2 v-spacing-top-2">
-                            <div class="center v-spacing-top-2">
-                                <img width="12px" height="12px" src="{% static 'bw-frontend/public/bw_indicator.gif' %}">
-                            </div>
-                        </div>
-                    </div>
-                    {% endif %}
-                    {% endif %}
-                {% endif %}
+                </main>
             </div>
-        </form>
         {% endif %}
     </div>
-    {% if not initial_tagcloud %}
-    <div class="row">
-        <div class="col-12 center v-spacing-top-negative-2 d-md-none">
-            <div data-target="collapsable-filters" data-show-text="Show filters" data-hide-text="Hide filters" data-hide-on-load class="collapsable-toggle v-spacing-top-2 font-weight-bold text-light-grey"></div>
-        </div>
-        {% comment %}facets{% endcomment%}
-        <aside class="col-md-4 col-lg-3 collapsable-block md-max-h-100" id="collapsable-filters">
-            {% if sqp.tags_mode_active %}
-            {% display_facet "tags" %}
-            {% endif %}
-            {% display_facet "license" %}
-            {% if not sqp.tags_mode_active %}
-            {% display_facet "tags"%}
-            {% endif %}
-            {% display_facet "type" %}
-            {% display_facet "channels" %}
-            {% display_facet "samplerate" %}
-            {% if not sqp.display_as_packs_active %}
-            {% display_facet "pack_grouping" %}
-            {% endif %}
-            {% display_facet "username" %}
-            {% display_facet "bitdepth" %}
-            {% display_facet "bitrate" %}
-            {% if show_beta_search_options %}
-                {% for experimental_facet in experimental_facets %}
-                    {% display_facet experimental_facet %}
-                {% endfor %}
-            {% endif %}
-        </aside>
-        <div class="col-12 divider-light d-md-none v-spacing-top-3 v-spacing-3"></div>
-        {% comment %}search results{% endcomment %}
-        <main class="col-12 col-md-8 col-lg-9 col-extra-left-padding-large-md">
-            {% comment %}filters{% endcomment %}
-            {% with sqp.get_filters_data_to_display_in_search_results_page as filters_data %}
-            {% if filters_data %}
-            <div class="v-spacing-3 v-spacing-top-2 line-height-33">
-                {% for name, value, remove_url in filters_data %}
-                <a class="no-hover btn-inverse bw-search__active-filters-button" href="{{ remove_url }}" title="Remove this filter">
-                    {{ name }}:{{ value }}<span class="h-spacing-left-1">{% bw_icon 'close' %} </span>
-                </a>
-                {% endfor %}
-            </div>
-            {% endif %}
-            {% endwith %}
-            {% comment %}map{% endcomment %}
-            {% if sqp.map_mode_active %}
-            <div class="col-12 v-spacing-top-3 no-paddings">
-                <div id="mapCanvas" class="map main-map"
-                     data-map-show-search="{% if sound %}false{% else %}true{% endif %}"
-                     data-geotags-url="{{ map_bytearray_url }}"
-                     data-access-token="pk.eyJ1IjoiZnJlZXNvdW5kIiwiYSI6ImNrd3E0Mm9lbjBqM2Qyb2wwdmwxaWI3a3oifQ.MZkgLSByRuk_Xql67CySAg"
-                ><span id="mapLoadingIndicator">Loading map... <img width="12px" height="12px" src="{% static 'bw-frontend/public/bw_indicator.gif' %}"></span></div>
-            </div>
-            <div class="row middle">
-                <div class="col-lg-4 v-spacing-top-4">
-                    <a class="no-hover btn-secondary btn-inverse" href="{{ open_in_map_url }}">See results in full map</a>
-                </div>
-                <div class="col-lg-8 v-spacing-top-2">
-                    {% if paginator.count > max_search_results_map_mode %}
-                    <div class="text-lg-right">
-                        <p class="text-grey">{% bw_icon 'notification' %} Note that only the first {{ max_search_results_map_mode|bw_intcomma }} search results are shown on the map</p>
-                    </div>
-                    {% endif %}
-                </div>
-            </div>
-            {% else %}
-            {% comment %}list/grid of sounds{% endcomment %}
-            <div class="v-spacing-6 v-spacing-top-2">
-                {% if paginator.count > 0 %}
-                {% if sqp.grid_mode_active %}
-                <div class="row">
-                    {% for result in docs %}
-                    <div class="col-6 col-lg-4">
-                        {% if sqp.display_as_packs_active %}
-                            {% display_pack result.pack %}
-                            <p class="text-grey text-right v-spacing-top-negative-2">
-                                {% bw_icon 'plus' %} <a href="{{ result.more_from_this_pack_url }}">See {{result.n_more_in_group|add:1|bw_intcomma}} result{{ result.n_more_in_group|add:1|pluralize }} from pack</a>
-                            </p>
-                        {% else %}
-                            {% display_sound_small result.sound %}
-                            {% if result.more_from_this_pack_url %}
-                            <p class="text-grey text-right v-spacing-top-negative-2">
-                                {% bw_icon 'plus' %} <a href="{{ result.more_from_this_pack_url }}">See {{result.n_more_in_group|add:1|bw_intcomma}} result{{ result.n_more_in_group|add:1|pluralize }} from pack:</a> <a class="bw-link--grey" href="{% url 'pack' result.sound.username result.sound.pack_id %}">{{ result.sound.pack_name|truncate_string:35 }}</a>
-                            </p>
-                            {% endif %}
-                        {% endif %}
-                    </div>
-                    {% endfor %}      
-                </div>
-                {% else %}
-                {% for result in docs %}
-                <div class="bw-search__result">
-                    {% if sqp.display_as_packs_active %}
-                        {% display_pack_big result.pack %}
-                        <div class="text-grey text-right v-spacing-top-negative-1 v-spacing-2 padding-right-1">
-                            {% bw_icon 'plus' %} <a href="{{ result.more_from_this_pack_url }}">See {{result.n_more_in_group|add:1|bw_intcomma}} result{{ result.n_more_in_group|add:1|pluralize }} from this pack</a>
-                        </div>
-                    {% else %}
-                        {% display_sound_middle result.sound %}
-                        {% if result.more_from_this_pack_url %}
-                        <div class="text-grey text-right v-spacing-top-negative-1 v-spacing-2">
-                            {% bw_icon 'plus' %} <a href="{{ result.more_from_this_pack_url }}">See {{result.n_more_in_group|add:1|bw_intcomma}} result{{ result.n_more_in_group|add:1|pluralize }} from same pack</a>
-                        </div>
-                        {% endif %}
-                    {% endif %}
-                    {% if not forloop.last %}
-                    <div class="divider-light v-spacing-2"></div>
-                    {% endif %}
-                </div>
-                {% endfor %}
-                {% endif %}
-                {% else %}
-                <div class="v-spacing-7 v-spacing-top-6 w-100">
-                    <h5>No results... &#128543</h5>
-                    <p class="text-grey v-spacing-2">Please try another query or change the filters</p>
-                </div>
-                {% endif %}
-            </div>
-            <div class="v-spacing-6">
-                {% bw_paginator paginator page current_page request "sound" non_grouped_number_of_results %}
-            </div>
-            {% endif %}
-        </main>
-    </div>
-    {% endif %}
-    {% endif %}
-</div>
 {% endblock %}
 
 {% block extrabody %}
-{% if not error_text and not initial_tagcloud %}
-{% comment %}If there were errors reaching the search server, don't even load the
+    {% if not error_text %}
+        {% comment %}If there were errors reaching the search server, don't even load the
 JS bits because we only display the error message{% endcomment %}
-<script src="{% static 'bw-frontend/dist/search.js' %}"></script>
-{% endif %}
+        <script src="{% static 'bw-frontend/dist/search.js' %}"></script>
+    {% endif %}
 {% endblock %}

--- a/templates/tags/tag_cloud.html
+++ b/templates/tags/tag_cloud.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% load bw_templatetags %}
+{% load tags %}
+
+{% block title %}Search{% endblock %}
+
+{% block navbar %}
+        {% include 'molecules/navbar.html' %}
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        {% if error_text %}
+            <div class="navbar-space-filler v-spacing-3 v-spacing-top-2">
+                <div class="v-spacing-6 v-spacing-top-4">
+                    <p class="v-spacing-4">{{ error_text }}</p>
+                    <p>
+                        <button onclick="window.history.back();" class="btn-primary">Go back</button>
+                    </p>
+                </div>
+            </div>
+        {% else %}
+            <div class="navbar-space-filler v-spacing-3 v-spacing-top-2">
+            <section id="tags-mode-input-section" class="v-spacing-5">
+                <h3 class="v-spacing-5 text-light-grey center">Choose a tag to start browsing</h3>
+                {% for tag in initial_tagcloud|add_sizes:"count:0.1:1.0" %}
+                    {% bw_tag tag.name 1 '' tag.browse_url tag.size %}
+                {% endfor %}
+            </section>
+            </div>
+        {% endif %}
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/pull/1845 fixed an issue that was not detected by our tests

**Description**
I started out covering `/browse/tags` with tags after the above mentioned issue and ended up refactoring major parts of it.

1. tag cloud: this is now a separate template as it had no connection to the search page.
    1. removed special case handling for `initial_tagcloud` from `search.html`
    2. add `templates/tags/tag_cloud.html`
3. introduced a separate view function for the multiple tag look-up --> redirect

**Deployment steps**:
none
