### PR TITLE
Remove unneeded pytz dependency

### DIFF
--- a/ACKNOWLEDGMENTS
+++ b/ACKNOWLEDGMENTS
@@ -132,8 +132,7 @@
  pysndfile                      1.4.4        GNU Library or Lesser General Public License (LGPL)                                              
  pysolr                         3.10.0b1     BSD License                                                                                      
  python-dateutil                2.8.2        Apache Software License; BSD License                                                             
- pytz                           2023.3       MIT License                                                                                      
- redis                          3.2.0        MIT License                                                                                      
+ redis                          3.2.0        MIT License
  requests                       2.31.0       Apache Software License                                                                          
  requests-cache                 1.1.1        BSD License                                                                                      
  rich                           13.7.0       MIT License                                                                                      

--- a/requirements.in
+++ b/requirements.in
@@ -46,7 +46,6 @@ pyparsing==2.4.7
 pysndfile==1.4.4
 pysolr==3.10.0b1
 python-louvain==0.16  # community detection in clustering
-pytz==2023.3
 pytest~=8.0.2
 pytest-django~=4.8.0
 PyYAML==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -285,8 +285,6 @@ python-dateutil==2.8.2
     #   zenpy
 python-louvain==0.16
     # via -r requirements.in
-pytz==2023.3
-    # via -r requirements.in
 pyyaml==6.0.1
     # via
     #   -r requirements.in


### PR DESCRIPTION
pytz is defacto deprecated. See: https://stackoverflow.com/a/76583320 
