### PR TITLE
Use built-in redis cache client instead of django-redis

### DIFF
--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -124,25 +124,16 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
     'api_monitoring': {
-        "BACKEND": "django_redis.cache.RedisCache",
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{API_MONITORING_REDIS_STORE_ID}",
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        }
     },
     'cdn_map': {
-        "BACKEND": "django_redis.cache.RedisCache",
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{CDN_MAP_STORE_ID}",
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        }
     },
     'clustering': {
-        "BACKEND": "django_redis.cache.RedisCache",
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{CLUSTERING_CACHE_REDIS_STORE_ID}",
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        }
     }
 }
 

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,6 @@ django-oauth-toolkit==3.0.1
 django-object-actions==4.3.0
 django-ratelimit==4.1.0
 django-recaptcha==4.0.0
-django-redis==5.4.0
 django-silk==5.3.2
 Django~=4.2.19
 djangorestframework-jsonp==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,7 +100,6 @@ django==4.2.19
     #   django-multiupload-plus
     #   django-oauth-toolkit
     #   django-recaptcha
-    #   django-redis
     #   django-silk
     #   djangorestframework
     #   sentry-sdk
@@ -123,8 +122,6 @@ django-object-actions==4.3.0
 django-ratelimit==4.1.0
     # via -r requirements.in
 django-recaptcha==4.0.0
-    # via -r requirements.in
-django-redis==5.4.0
     # via -r requirements.in
 django-silk==5.3.2
     # via -r requirements.in
@@ -290,9 +287,7 @@ pyyaml==6.0.1
     #   -r requirements.in
     #   djangorestframework-yaml
 redis==5.2.1
-    # via
-    #   -r requirements.in
-    #   django-redis
+    # via -r requirements.in
 requests==2.31.0
     # via
     #   akismet


### PR DESCRIPTION
**Issue(s)**
Part of #1840

**Description**
We don't use anything special in django-redis, so just switch to the newly available cache library built into django

**Deployment steps**:
Requires associated PR in freesound-deploy to update local_settings. 

Will this change the "shape" of the cache items, causing an error when loading items from the cache? The easiest way to avoid this may be to just delete the cache and start again. Thoughts?
