### PR TITLE
Show user and pack durations as minutes if less than an hour 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+@pytest.fixture
+def use_dummy_cache_backend(settings):
+    settings.CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        },
+        'api_monitoring': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        },
+        'clustering': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        },
+        'cdn_map': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        }
+}

--- a/freesound/test_settings.py
+++ b/freesound/test_settings.py
@@ -5,15 +5,6 @@ if postgres_username is not None:
     DATABASES['default']['NAME'] = 'freesound'
     DATABASES['default']['USER'] = postgres_username
 
-use_django_nose = os.getenv('FS_TEST_USE_DJANGO_NOSE', None)
-if use_django_nose is not None:
-    INSTALLED_APPS = INSTALLED_APPS + ('django_nose',)
-    TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-    SOUTH_TESTS_MIGRATE = False
-    NOSE_ARGS = [
-        '--with-xunit',
-    ]
-
 AKISMET_KEY = ''  # Avoid making requests to "real" Akismet server if running
 SECRET_KEY = "testsecretwhichhastobeatleast16characterslong"
 SUPPORT = (('Name Surname', 'support@freesound.org'),)

--- a/general/templatetags/util.py
+++ b/general/templatetags/util.py
@@ -58,6 +58,24 @@ def duration_hours(total_seconds):
 
 
 @register.filter
+def smart_duration_with_units(total_seconds):
+    """Format the number of seconds in a human-readable format with units
+    For values less than 1 hour, returns "mm:ss minutes"
+    For values 1 hour or greater, returns "hh:mm hours"
+    """
+    if total_seconds < 3600:
+        minutes = int(total_seconds // 60)
+        seconds = int(total_seconds % 60)
+        formatted_length = f'{minutes}:{seconds:02d}'
+        length_text = 'minutes'
+    else:
+        hours = int(total_seconds // 3600)
+        minutes = int((total_seconds % 3600) // 60)
+        formatted_length = f'{hours}:{minutes:02d}'
+        length_text = 'hours'
+    return f'{formatted_length} {length_text}'
+
+@register.filter
 def formatnumber(number):
     if 1000 <= number < 1000000:
         return f'{number/1000:.1f}K'

--- a/general/tests/test_management.py
+++ b/general/tests/test_management.py
@@ -19,14 +19,11 @@
 #
 
 from django.core.management import call_command
-from django.test import TestCase, RequestFactory
+from django.test import TestCase
 from django.urls import reverse
 
 from forum.models import Thread, Post, Forum
-from general.templatetags.bw_templatetags import bw_paginator
 from ratings.models import SoundRating
-from sounds.models import Sound
-from utils.pagination import paginate
 from utils.test_helpers import create_user_and_sounds
 
 
@@ -127,23 +124,3 @@ class ReportCountStatusesManagementCommandTestCase(TestCase):
         self.assertEqual(sound.avg_rating, 4)
         self.assertEqual(sound.num_comments, 1)
         self.assertEqual(sound.num_downloads, 0)
-
-
-class PaginatorTestCase(TestCase):
-
-    def test_url_with_non_ascii_characters(self):
-        """Paginator objects are passed a request object which includes a list of request GET parameters and values.
-        The paginator uses this object to get parameters like the current page that is requested, and also to construct
-        pagination links which contain all the same GET parameters as the initial request so that whatever things
-        are determined there, will be preserved when moving to the next page. To do that the paginator iterates over
-        all GET parameters and values. This test checks that if non-ascii characters are passed as GET parameter names
-        or values, paginator does not break.
-        """
-        text_with_non_ascii = '�textèé'
-        dummy_request = RequestFactory().get(reverse('sounds'), {
-            text_with_non_ascii: '1',
-            'param_name': text_with_non_ascii,
-            'param2_name': 'ok_value',
-        })
-        paginator = paginate(dummy_request, Sound.objects.all(), 10)
-        bw_paginator({}, paginator['paginator'], paginator['page'], paginator['current_page'], dummy_request)

--- a/general/tests/test_templatetags.py
+++ b/general/tests/test_templatetags.py
@@ -1,0 +1,27 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+from general.templatetags.util import smart_duration_with_units
+
+
+def test_smart_duration_with_units():
+    assert smart_duration_with_units(100) == "1:40 minutes"
+    assert smart_duration_with_units(3620) == "1:00 hours"
+    assert smart_duration_with_units(3694) == "1:01 hours"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "freesound.test_settings"
 python_files = "test*.py"
+python_classes = ["Test*", "*Test"]

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -37,7 +37,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
-from django.db.models import Avg, F, Prefetch
+from django.db.models import Avg, F, Prefetch, Sum
 from django.db.models.functions import Greatest
 from django.db.models.signals import pre_delete, post_delete, post_save
 from django.dispatch import receiver
@@ -1827,8 +1827,8 @@ class Pack(models.Model):
             return Sound.objects.filter(pack=self, num_ratings__gte=settings.MIN_NUMBER_RATINGS)
 
     def get_total_pack_sounds_length(self):
-        durations = list(Sound.objects.filter(pack=self).values_list('duration', flat=True))
-        return sum(durations)
+        result = Sound.objects.filter(pack=self).aggregate(total_duration=Sum('duration'))
+        return result['total_duration'] or 0
 
     def num_sounds_unpublished(self):
         if hasattr(self, 'num_sounds_unpublished_precomputed'):

--- a/templates/accounts/account_stats_section.html
+++ b/templates/accounts/account_stats_section.html
@@ -8,7 +8,7 @@
         {% bw_icon 'stack' 'text-light-grey' %} <a class="text-19 bw-link--black" title="{{ user.username }} has created {{ user_stats.num_packs|bw_intcomma }} pack{{ user_stats.num_packs|pluralize }}" href="{{ user.profile.get_user_packs_in_search_url }}">{{ user_stats.num_packs|formatnumber }} pack{{ user_stats.num_packs|pluralize }}</a>
     </li>
     <li class="v-spacing-3">
-        {% bw_icon 'clock' 'text-light-grey' %} <span class="text-19" title="{{ user.username }}'s sounds together account for {{ user_stats.total_uploaded_sounds_length|duration_hours }} hours of audio">{{ user_stats.total_uploaded_sounds_length|duration_hours }} hours of audio</span>
+        {% bw_icon 'clock' 'text-light-grey' %} <span class="text-19" title="{{ user.username }}'s sounds together account for {{ user_stats.total_uploaded_sounds_length|smart_duration_with_units }} of audio">{{ user_stats.total_uploaded_sounds_length|smart_duration_with_units }}</span>
     </li>
     <li class="v-spacing-3">
         {% bw_icon 'star' 'text-light-grey' %} <span class="text-19" title="{{ user.username }}'s sounds have an average rating of {{ user_stats.avg_rating_0_5|floatformat:1 }}">{{ user_stats.avg_rating_0_5|floatformat:1 }} average rating</span>

--- a/templates/sounds/pack_stats_section.html
+++ b/templates/sounds/pack_stats_section.html
@@ -8,7 +8,7 @@
             {% bw_icon 'wave' 'text-light-grey' %} <a class="text-19 bw-link--black" title="This pack has {{ pack.num_sounds|bw_intcomma }} sound{{ pack.num_sounds|pluralize }}"  href="{% url "sounds-search" %}?f=grouping_pack:{{ pack.pack_filter_value }}&s=Date+added+(newest+first)&g=1" >{{ pack.num_sounds|formatnumber }} sound{{ pack.num_sounds|pluralize }}</a>
         </li>
         <li class="v-spacing-3">
-            {% with pack.get_total_pack_sounds_length as total_pack_sounds_length %}{% bw_icon 'clock' 'text-light-grey' %} <span class="text-19" title="The sounds of this pack together account for {{ total_pack_sounds_length|duration_hours }} hours of audio">{{ total_pack_sounds_length|duration_hours }} hours of audio</span>{% endwith %}
+            {% bw_icon 'clock' 'text-light-grey' %} <span class="text-19" title="The sounds of this pack together account for {{ pack.get_total_pack_sounds_length|smart_duration_with_units }} of audio">{{ pack.get_total_pack_sounds_length|smart_duration_with_units }}</span>
         </li>
         <li class="v-spacing-3">
             {% bw_icon 'download' 'text-light-grey' %}<a class="text-19 bw-link--black" title="This pack has been downloaded {{ pack.num_downloads|bw_intcomma }} time{{ pack.num_downloads|pluralize }}"  href="javascript:void(0);" data-toggle="modal-default" data-modal-content-url="{% url 'pack-downloaders' pack.user.username pack.id %}?ajax=1" data-modal-activation-param="downloaders">{{ pack.num_downloads|formatnumber }} download{{ pack.num_downloads|pluralize }}</a>

--- a/utils/tests/test_pagination.py
+++ b/utils/tests/test_pagination.py
@@ -18,9 +18,13 @@
 #     See AUTHORS file.
 #
 from django.test import TestCase
+from django.core.management import call_command
+from django.test import TestCase, RequestFactory
+from django.urls import reverse
 
 from sounds.models import Sound
-from utils.pagination import CountProvidedPaginator
+from utils.pagination import CountProvidedPaginator, paginate
+from general.templatetags.bw_templatetags import bw_paginator
 
 
 class PaginationTest(TestCase):
@@ -56,3 +60,20 @@ class PaginationTest(TestCase):
             # This should be the only query that runs, call len() to force the qs to be evaluated
             first_page = paginator.page(1)
             self.assertEqual(len(first_page), 10)
+
+    def test_url_with_non_ascii_characters(self):
+        """Paginator objects are passed a request object which includes a list of request GET parameters and values.
+        The paginator uses this object to get parameters like the current page that is requested, and also to construct
+        pagination links which contain all the same GET parameters as the initial request so that whatever things
+        are determined there, will be preserved when moving to the next page. To do that the paginator iterates over
+        all GET parameters and values. This test checks that if non-ascii characters are passed as GET parameter names
+        or values, paginator does not break.
+        """
+        text_with_non_ascii = '�textèé'
+        dummy_request = RequestFactory().get(reverse('sounds'), {
+            text_with_non_ascii: '1',
+            'param_name': text_with_non_ascii,
+            'param2_name': 'ok_value',
+        })
+        paginator = paginate(dummy_request, Sound.objects.all(), 10)
+        bw_paginator({}, paginator['paginator'], paginator['page'], paginator['current_page'], dummy_request)


### PR DESCRIPTION
**Issue(s)**
Fixes https://github.com/MTG/freesound/issues/1818

**Description**
'0:03 hours' isn't very useful, better to show '3:45 minutes'
<img width="1289" alt="Screenshot 2025-02-21 at 9 23 15 PM" src="https://github.com/user-attachments/assets/e9235109-0582-4e4f-89dc-b02ebea63aeb" />

The code for computing/selecting hours vs minutes is duplicated in two places, for now I'm not worried about this but we could combine it in a helper if needed. The `|duration_hours` templatetag is still used elsewhere, so don't remove it.

I updated the test settings to disable the cache, so that I could read values for the test multiple times. I think it generally makes sense to disable the cache during tests? although some tests are now failing.
If we want to keep it then I can work around it for just this test.