### PR TITLE
Add new similarity fields to API text search form

### DIFF
--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -347,8 +347,12 @@ def api_search(
                 sort=processed_sort,
                 offset=(search_form.cleaned_data['page'] - 1) * search_form.cleaned_data['page_size'],
                 num_sounds=search_form.cleaned_data['page_size'],
-                group_by_pack=search_form.cleaned_data['group_by_pack']
+                group_by_pack=search_form.cleaned_data['group_by_pack'],
+                similar_to=search_form.cleaned_data['similar_to'],
+                similar_to_max_num_sounds=min(search_form.cleaned_data['page'] * search_form.cleaned_data['page_size'], settings.SEARCH_ENGINE_NUM_SIMILAR_SOUNDS_PER_QUERY),
+                similar_to_analyzer=search_form.cleaned_data['similarity_space'] or settings.SEARCH_ENGINE_DEFAULT_SIMILARITY_ANALYZER,
             )
+
             ids_score = [(int(element['id']), element['score']) for element in result.docs]
             num_found = result.num_found
             more_from_pack_data = None


### PR DESCRIPTION
**Description**
Our API was not yer capable of using new SOLR-based similarity, so this PR adds support for it. Only thing needed was to add the new fields in the corresponding api search form so they can be properly passed to the `search_sounds` method of the search engine backend.

This is experimental feature and it is not documented, this is expected.

**Deployment steps**:
None