### PR TITLE
Collect CPU usage of gunicorn processes each minute

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -4,6 +4,10 @@ LABEL org.opencontainers.image.authors="support@freesound.org"
 
 ENV PYTHONUNBUFFERED=1
 
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
                        build-essential \
@@ -19,4 +23,4 @@ RUN adduser -q --gecos "" --disabled-password fsweb
 
 COPY entrypoint.sh /usr/local/bin
 
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "entrypoint.sh"]

--- a/docker/Dockerfile.clustering
+++ b/docker/Dockerfile.clustering
@@ -1,4 +1,4 @@
-FROM freesound:2023-07
+FROM freesound:2025-03
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.workers_web
+++ b/docker/Dockerfile.workers_web
@@ -11,7 +11,7 @@ RUN make clean && make
 
 # --- main Freesound docker file contents
 
-FROM freesound:2023-07
+FROM freesound:2025-03
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,7 +2,7 @@ py2:
 	docker build -t freesound:2023-07-py2 -f Dockerfile.py2.base .
 
 py3:
-	docker build -t freesound:2023-07 -f Dockerfile.base .
+	docker build -t freesound:2025-03 -f Dockerfile.base .
 
 all: py2 py3
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,10 @@ if [[ -v FS_USER_ID && $FS_USER_ID != 0 && -n $FS_USER_ID ]]; then
     echo Set fsweb UID to: "$FS_USER_ID"
     usermod -u "$FS_USER_ID" fsweb
 
+    if [[ -v COLLECT_GUNICORN_STATS ]]; then
+        gosu fsweb python -m stats.gunicorn_stats &
+    fi
+
     exec gosu fsweb "$@"
 else
     exec "$@"

--- a/requirements.in
+++ b/requirements.in
@@ -38,6 +38,7 @@ numpy==1.24.3
 oauthlib
 openpyxl==3.1.0  # for reading .xlsx files (but not .xls)
 Pillow==9.5.0
+psutil~=7.0.0
 psycopg~=3.2.4
 PyJWT==2.6.0
 pyparsing==2.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -231,6 +231,8 @@ prompt-toolkit==3.0.43
     # via
     #   click-repl
     #   ipython
+psutil==7.0.0
+    # via -r requirements.in
 psycopg==3.2.4
     # via -r requirements.in
 ptyprocess==0.7.0

--- a/stats/gunicorn_stats.py
+++ b/stats/gunicorn_stats.py
@@ -1,0 +1,74 @@
+import json
+import logging
+import logging.config
+import time
+
+import psutil
+
+from freesound.logger import LOGGING
+
+logging.config.dictConfig(LOGGING)
+
+logger = logging.getLogger('monitor')
+
+def find_procs_by_name(name):
+    """Return a list of processes matching 'name'."""
+    ls = []
+    for p in psutil.process_iter(['name']):
+        if p.info['name'] == name:
+            ls.append(p)
+    return ls
+
+
+def main():
+    interval = 60
+
+    while True:
+        next_collection_time = time.monotonic() + interval
+        
+        processes = find_procs_by_name("gunicorn")
+        pid_to_percent = {}
+        if not processes:
+            print("No gunicorn processes found.")
+        else:
+            for p in processes:
+                p.cpu_percent(None)
+            
+            time.sleep(2)
+
+            for p in processes:
+                cpu = p.cpu_percent(None)
+                pid_to_percent[p.pid] = cpu
+
+            # Absolute CPU values
+            stats = {
+                f"gunicorn_cpu_percent_{pid}": cpu
+                for pid, cpu in pid_to_percent.items()
+            }
+
+            # Histogram of CPU values
+            # This will miss items with cpu > 100 (e.g. more than 1 thread per process)
+            ranges = [(0, 0), (1, 10), (11, 20), (21, 30), (31, 40), 
+                        (41, 50), (51, 60), (61, 70), (71, 80), (81, 90), (91, 100)]
+
+            hist = {f"{start}_{end}": 0 for start, end in ranges}
+
+            for cpu in pid_to_percent.values():
+                if cpu == 0:
+                    hist["0_0"] += 1
+                else:
+                    for start, end in ranges:
+                        if start <= cpu <= end:
+                            hist[f"{start}_{end}"] += 1
+            stats.update({
+                f"gunicorn_cpu_hist_{range_key}": count
+                for range_key, count in hist.items()
+            })
+            logger.info(f"Monitor ({json.dumps(stats)})")
+
+        while time.monotonic() < next_collection_time:
+            time.sleep(1)
+                
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We want more visibility into our production pods to see how much CPU each gunicorn worker process is using to allow us to more usefully tweak the number of workers that we have.

gunicorn's instrumentation module only reports response time, and not the CPU usage of any workers.
`kubectl top` allows us to see the total CPU usage of a pod but not of each individual process inside it. Our prod platform doesn't easily allow us to run `kubectl exec` in a running pod, so we probably need to have a long-running process.

We decided to then directly measure this CPU usage in the web pod 

Still to complete:

- [x] install psutil (requirements)
- [x] configure prod launcher to set the necessary env variable to start the collector from our entrypoint (freesound-deploy)
- [x] add tini init process to our launch (freesound-deploy)
- [x] ~How do we send from this script to graylog? Set up a graylog connection manually and submit? Use the prod logger config but set it up manually, or run inside a django management command? A django command has a startup cost which we may not want~ it looks like we can just import freesound.logger and set up a logger in python without needing to use a django management command, so we can use the logger to send a json message to graylog, and don't need any other configuration when running the script
- [x] What format do we send this data in? Currently we have 10 workers per pod and 10 pods, so we'll have 100 numbers per cycle sent in 10 messages (1 from each pod replica), but can't guarantee that they'll all arrive at the same time. Is there a way that we can format the message and process it to get show a useful graph? Perhaps we want "number of workers with 0% cpu, number with 1-10, 11-20", over time
