### PR TITLE
Make old uname redirect decorator not raise 404

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -86,14 +86,14 @@ account a number of things:
 * In case a user object exists, is the user marked as having been deleted? (check `user.profile.is_anonymized_user`) 
 * In case there's no `User` object with such username, is there any `OldUsername` object which maps the username in the
   URL with a `User` object in DB?
-  
-To deal with these checks, we use the `utils.username.raise_404_if_user_is_deleted` and 
-`utils.username.redirect_if_old_username_or_404` decorators in view functions. The first one will try to find a user
+
+To deal with these checks, we use the `utils.username.raise_404_if_user_is_deleted` and
+`utils.username.redirect_if_old_username` decorators in view functions. The first one will try to find a user
 object (checking for old usernames as well) and if it can't find it or the user is marked as deleted, it will raise
 HTTP 404 error. The second one will try to find a user object (also considering old usernames) and do an HTTP redirect
 with an updated username if user was found in the old usernames table.
 
-In general, we should use `utils.username.redirect_if_old_username_or_404` in **all public views** that have username
+In general, we should use `utils.username.redirect_if_old_username` in **all public views** that have username
 in the URL path. For login-required views (using `@login_required` decorator) we are not supposed to use that decorator
 because most of them won't include username in the URL and also there should be no links pointing to these URLs with
 old usernames. In addition, **if these public views should should not be reachable in case users have been anonymized**,
@@ -101,7 +101,7 @@ then we should also use `utils.username.raise_404_if_user_is_deleted`. When usin
 to use them in that order:
 
 ```
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def view_function(request, username, ...):
     ...

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -88,7 +88,7 @@ from utils.mirror_files import copy_avatar_to_mirror_locations, \
     copy_uploaded_file_to_mirror_locations, remove_uploaded_file_from_mirror_locations, \
     remove_empty_user_directory_from_mirror_locations
 from utils.pagination import paginate
-from utils.username import redirect_if_old_username_or_404, raise_404_if_user_is_deleted
+from utils.username import redirect_if_old_username, raise_404_if_user_is_deleted
 
 sounds_logger = logging.getLogger('sounds')
 upload_logger = logging.getLogger('file_upload')
@@ -934,7 +934,7 @@ def download_attribution(request):
         return HttpResponseRedirect(reverse('accounts-attribution'))
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def downloaded_sounds(request, username):
     if not request.GET.get('ajax'):
@@ -960,7 +960,7 @@ def downloaded_sounds(request, username):
     return render(request, 'accounts/modal_downloads.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def downloaded_packs(request, username):
     if not request.GET.get('ajax'):
@@ -1121,7 +1121,7 @@ def charts(request):
     return render(request, 'accounts/charts.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def account(request, username):
     user = request.parameter_user
     latest_sounds = list(Sound.objects.bulk_sounds_for_user(user.id, settings.SOUNDS_PER_PAGE_PROFILE_PACK_PAGE))
@@ -1170,13 +1170,13 @@ def account(request, username):
         'following_modal_page': request.GET.get('following', 1),
         'followers_modal_page': request.GET.get('followers', 1),
         'following_tags_modal_page': request.GET.get('followingTags', 1),
-        'last_geotags_serialized': last_geotags_serialized, 
+        'last_geotags_serialized': last_geotags_serialized,
         'user_downloads_public': settings.USER_DOWNLOADS_PUBLIC,
     }
     return render(request, 'accounts/account.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def account_stats_section(request, username):
     if not request.GET.get('ajax'):
         raise Http404  # Only accessible via ajax
@@ -1188,7 +1188,7 @@ def account_stats_section(request, username):
     return render(request, 'accounts/account_stats_section.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def account_latest_packs_section(request, username):
     if not request.GET.get('ajax'):
         raise Http404  # Only accessible via ajax

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -32,7 +32,7 @@ from bookmarks.models import Bookmark, BookmarkCategory
 from sounds.models import Sound
 from utils.downloads import download_sounds
 from utils.pagination import paginate
-from utils.username import redirect_if_old_username_or_404, raise_404_if_user_is_deleted
+from utils.username import redirect_if_old_username, raise_404_if_user_is_deleted
 
 
 @login_required
@@ -59,7 +59,7 @@ def bookmarks(request, category_id=None):
     tvars['page_bookmarks_and_sound_objects'] = zip(paginator['page'].object_list, page_sounds)
     return render(request, 'bookmarks/bookmarks.html', tvars)
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def bookmarks_for_user(request, username, category_id=None):
     user = request.parameter_user

--- a/comments/views.py
+++ b/comments/views.py
@@ -30,7 +30,7 @@ from django.urls import reverse
 from comments.models import Comment
 from sounds.models import Sound
 from utils.pagination import paginate
-from utils.username import redirect_if_old_username_or_404, raise_404_if_user_is_deleted
+from utils.username import redirect_if_old_username, raise_404_if_user_is_deleted
 
 
 @login_required
@@ -53,7 +53,7 @@ def delete(request, comment_id):
     return HttpResponseRedirect(next + "#comments")
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def for_user(request, username):
     """ Display all comments for the sounds of the user """
@@ -81,7 +81,7 @@ def for_user(request, username):
     return render(request, 'accounts/modal_comments.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def by_user(request, username):
     if not request.GET.get('ajax'):
@@ -107,7 +107,7 @@ def by_user(request, username):
     return render(request, 'accounts/modal_comments.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def for_sound(request, username, sound_id):
     if not request.GET.get('ajax'):

--- a/follow/views.py
+++ b/follow/views.py
@@ -34,10 +34,10 @@ from follow.models import FollowingQueryItem
 from follow.models import FollowingUserItem
 from utils.cache import invalidate_user_template_caches
 from utils.pagination import paginate
-from utils.username import redirect_if_old_username_or_404, raise_404_if_user_is_deleted
+from utils.username import redirect_if_old_username, raise_404_if_user_is_deleted
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def following_users(request, username):
     """List of users that are being followed by user with "username"
@@ -64,7 +64,7 @@ def following_users(request, username):
     return render(request, 'accounts/modal_follow.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def followers(request, username):
     """List of users that are following user with "username"
@@ -91,7 +91,7 @@ def followers(request, username):
     return render(request, 'accounts/modal_follow.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def following_tags(request, username):
     """List of tags that are being followed by user with "username"

--- a/geotags/views.py
+++ b/geotags/views.py
@@ -39,7 +39,7 @@ from sounds.models import Sound, Pack
 from utils.logging_filters import get_client_ip
 from utils.search.search_query_processor import SearchQueryProcessor
 from utils.search.search_sounds import perform_search_engine_query
-from utils.username import redirect_if_old_username_or_404, raise_404_if_user_is_deleted
+from utils.username import redirect_if_old_username, raise_404_if_user_is_deleted
 
 web_logger = logging.getLogger('web')
 
@@ -94,7 +94,7 @@ def geotags_barray(request, tag=None):
             return HttpResponse(generated_bytearray, content_type='application/octet-stream')
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 @cache_page(60 * 15)
 def geotags_for_user_barray(request, username):
@@ -111,7 +111,7 @@ def geotags_for_user_barray(request, username):
     return HttpResponse(generated_bytearray, content_type='application/octet-stream')
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def geotags_for_user_latest_barray(request, username):
     sounds = Sound.public.filter(user__username__iexact=username).exclude(geotag=None)[0:10]
@@ -201,7 +201,7 @@ def geotags(request, tag=None):
     return render(request, 'geotags/geotags.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @raise_404_if_user_is_deleted
 def for_user(request, username):
     tvars = _get_geotags_query_params(request)
@@ -216,7 +216,7 @@ def for_user(request, username):
     return render(request, 'geotags/geotags.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def for_sound(request, username, sound_id):
     sound = get_object_or_404(
         Sound.objects.select_related('geotag', 'user'), id=sound_id)
@@ -242,7 +242,7 @@ def for_sound(request, username, sound_id):
         return render(request, 'geotags/geotags.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def for_pack(request, username, pack_id):
     pack = get_object_or_404(Pack.objects.select_related('user'), id=pack_id)
     tvars = _get_geotags_query_params(request)

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -74,7 +74,7 @@ from utils.sound_upload import create_sound, NoAudioException, AlreadyExistsExce
     get_duration_from_processing_before_describe_files, \
     get_samplerate_from_processing_before_describe_files
 from utils.text import remove_control_chars
-from utils.username import redirect_if_old_username_or_404
+from utils.username import redirect_if_old_username
 
 web_logger = logging.getLogger('web')
 sounds_logger = logging.getLogger('sounds')
@@ -206,7 +206,7 @@ def front_page(request):
     return render(request, 'front.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def sound(request, username, sound_id):
     try:
         sound = Sound.objects.prefetch_related("tags")\
@@ -308,7 +308,7 @@ def after_download_modal(request):
         return HttpResponse()
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @transaction.atomic()
 def sound_download(request, username, sound_id):
     if not request.user.is_authenticated:
@@ -342,7 +342,7 @@ def sound_download(request, username, sound_id):
     return sendfile(*prepare_sendfile_arguments_for_sound_download(sound))
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @transaction.atomic()
 def pack_download(request, username, pack_id):
     if not request.user.is_authenticated:
@@ -797,7 +797,7 @@ def _remix_group_view_helper(request, group_id):
     }
     return tvars
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def remixes(request, username, sound_id):
     if not request.GET.get('ajax'):
         # If not loaded as modal, redirect to sound page with parameter to open modal
@@ -816,7 +816,7 @@ def remixes(request, username, sound_id):
     return render(request, 'sounds/modal_remix_group.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @ratelimit(key=key_for_ratelimiting, rate=rate_per_ip, group=settings.RATELIMIT_SIMILARITY_GROUP, block=True)
 def similar(request, username, sound_id):
     if not request.GET.get('ajax'):
@@ -853,7 +853,7 @@ def similar(request, username, sound_id):
     return render(request, 'sounds/modal_similar_sounds.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 @transaction.atomic()
 def pack(request, username, pack_id):
     try:
@@ -890,7 +890,7 @@ def pack(request, username, pack_id):
     return render(request, 'sounds/pack.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def pack_stats_section(request, username, pack_id):
     if not request.GET.get('ajax'):
         raise Http404  # Only accessible via ajax
@@ -906,19 +906,20 @@ def pack_stats_section(request, username, pack_id):
     return render(request, 'sounds/pack_stats_section.html', tvars)
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def packs_for_user(request, username):
     user = request.parameter_user
     return HttpResponseRedirect(user.profile.get_user_packs_in_search_url())
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def for_user(request, username):
     user = request.parameter_user
     return HttpResponseRedirect(user.profile.get_user_sounds_in_search_url())
     
 
-@redirect_if_old_username_or_404
+
+@redirect_if_old_username
 @transaction.atomic()
 def flag(request, username, sound_id):
     if not request.GET.get('ajax'):
@@ -1001,7 +1002,7 @@ def old_pack_link_redirect(request):
     return __redirect_old_link(request, Pack, "pack")
 
 
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def display_sound_wrapper(request, username, sound_id):
     try:
         sound_obj = Sound.objects.bulk_query_id(sound_id)[0]

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -41,7 +41,7 @@ from tickets import TICKET_STATUS_ACCEPTED, TICKET_STATUS_CLOSED, TICKET_STATUS_
 from tickets.forms import AnonymousMessageForm, UserMessageForm, ModeratorMessageForm, \
     SoundStateForm, SoundModerationForm, ModerationMessageForm, UserAnnotationForm, IS_EXPLICIT_ADD_FLAG_KEY, IS_EXPLICIT_REMOVE_FLAG_KEY
 from utils.cache import invalidate_user_template_caches, invalidate_all_moderators_header_cache
-from utils.username import redirect_if_old_username_or_404
+from utils.username import redirect_if_old_username
 from utils.pagination import paginate
 from wiki.models import Content, Page
 
@@ -681,7 +681,7 @@ def add_user_annotation(request, user_id):
 
 
 @permission_required('tickets.can_moderate')
-@redirect_if_old_username_or_404
+@redirect_if_old_username
 def pending_tickets_per_user(request, username):
     if not request.GET.get('ajax'):
         # If not loaded as a modal, redirect to account page with parameter to open modal

--- a/utils/username.py
+++ b/utils/username.py
@@ -45,7 +45,7 @@ def get_user_or_404(username):
     return user
 
 
-def redirect_if_old_username_or_404(func):
+def redirect_if_old_username(func):
     """
     This is a decorator to return redirects when accessing a URL with the username in the pattern and that usernames
     corresponds to an old username. We re-build the URL with the current username of that user and return a redirect.
@@ -90,7 +90,7 @@ def raise_404_if_user_is_deleted(func):
             # Otherwise get the corresponding user object (considering OldUsernames) or raise 404
             user = get_user_or_404(kwargs['username'])
 
-        if user.profile.is_anonymized_user:
+        if user is None or user.profile.is_anonymized_user:
             raise Http404
 
         # Save user object in the request so it can be used by the view and/or other decorators

--- a/utils/username.py
+++ b/utils/username.py
@@ -42,8 +42,6 @@ def get_user_from_username_or_oldusername(username):
 def get_user_or_404(username):
     # Helper to get the user from an username or raise 404
     user = get_user_from_username_or_oldusername(username)
-    if user is None:
-        raise Http404
     return user
 
 
@@ -64,9 +62,10 @@ def redirect_if_old_username_or_404(func):
             # Otherwise get the corresponding user (considering OldUsernames) object or raise 404
             user = get_user_or_404(kwargs['username'])
 
-        if kwargs['username'] != user.username:
+        if user and kwargs['username'] != user.username:
             # If the the username is an old username of the user, do redirect
             kwargs['username'] = user.username
+
             return redirect(reverse(inner, args=args, kwargs=kwargs), permanent=True)
 
         # Save user object in the request so it can be used by the view and/or other decorators


### PR DESCRIPTION
**Description**
Our very appropriately named `redirect_if_old_username_or_404` decorator is used in all views that are triggered by URL patterns containing usernames (e.g., /people/UNAME/sounds/1234). This is incredibly nice, but:
* The decorator can raise exceptions if username URL part is malicious (easily solved by catching exceptions) 
* The decorator might be hiding the logic of some of our tests: if we expect a test to return 404 for whatever reason which is not a non-existing username, and yet we pass a non-existing username, then we would think the view logic correctly returns a 404 but it only does it for different reasons. Solution is to not make our decorator raise a 404 (and rename it), and pass this job to the views. That would be less magic and easier to understand. We will need to add a method like `get_parameter_user(request)` that raises `Http404` if `request.parameter_user is None` (which can happen if the decorator sets it this way because it did not find a suitable user).

This PR currently only modified the decorator to not raise 404, but the solutions to the two points above are still pending, and also a rename.
