### PR TITLE
Reload a ticket page with GET after submitting something

### DIFF
--- a/tickets/views.py
+++ b/tickets/views.py
@@ -198,6 +198,9 @@ def ticket(request, ticket_key):
                                     moderator_only=False)
                     tc.save()
 
+                # Prevent multiple submissions if a user reloads the page
+                return redirect(reverse('tickets-ticket', args=[ticket.key]))
+
     if clean_status_forms:
         default_action = 'Return' if ticket.sound and ticket.sound.moderation_state == 'OK' else 'Approve'
         sound_form = SoundStateForm(initial={'action': default_action}, prefix="ss")


### PR DESCRIPTION
Fixes #1770
Some mods notice that users send duplicate messages, likely as a result of them reloading this page and the browser asking to re-submit the POST data.

**Issue(s)**
<!-- URL to issue(s) related to this PR -->

**Description**
<!-- Description of the contents of this PR -->

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
