### PR TITLE
Don't send a ticket email to the user if the message is moderator-only

### DIFF
--- a/tickets/forms.py
+++ b/tickets/forms.py
@@ -42,11 +42,6 @@ class UserMessageForm(forms.Form):
     message = HtmlCleaningCharField(widget=forms.Textarea)
 
 
-class AnonymousMessageForm(forms.Form):
-    message = HtmlCleaningCharField(widget=forms.Textarea)
-    recaptcha = ReCaptchaField(label="")
-
-
 # Sound moderation forms
 MODERATION_CHOICES = [(x, x) for x in
                       ['Approve',

--- a/tickets/models.py
+++ b/tickets/models.py
@@ -55,7 +55,6 @@ class Ticket(models.Model):
 
     MODERATOR_ONLY = 1
     USER_ONLY = 2
-    USER_AND_MODERATOR = 3
 
     def get_n_last_non_moderator_only_comments(self, n):
         """
@@ -66,7 +65,7 @@ class Ticket(models.Model):
 
     def send_notification_emails(self, notification_type, sender_moderator):
         # send message to assigned moderator
-        if sender_moderator in [Ticket.MODERATOR_ONLY, Ticket.USER_AND_MODERATOR]:
+        if sender_moderator in [Ticket.MODERATOR_ONLY]:
             if self.assignee:
                 tvars = {'ticket': self,
                          'user_to': self.assignee}
@@ -75,7 +74,7 @@ class Ticket(models.Model):
                                    tvars,
                                    user_to=self.assignee)
         # send message to user
-        if sender_moderator in [Ticket.USER_ONLY, Ticket.USER_AND_MODERATOR]:
+        if sender_moderator in [Ticket.USER_ONLY]:
             if self.sender:
                 tvars = {'ticket': self,
                          'user_to': self.sender}

--- a/tickets/models.py
+++ b/tickets/models.py
@@ -63,9 +63,9 @@ class Ticket(models.Model):
         ticket_comments = self.messages.all().filter(moderator_only=False).order_by('-created')
         return list(ticket_comments)[:n] # converting from Django QuerySet to python list in order to use negative indexing
 
-    def send_notification_emails(self, notification_type, sender_moderator):
+    def send_notification_emails(self, notification_type, send_ticket_to):
         # send message to assigned moderator
-        if sender_moderator in [Ticket.MODERATOR_ONLY]:
+        if send_ticket_to == Ticket.MODERATOR_ONLY:
             if self.assignee:
                 tvars = {'ticket': self,
                          'user_to': self.assignee}
@@ -74,7 +74,7 @@ class Ticket(models.Model):
                                    tvars,
                                    user_to=self.assignee)
         # send message to user
-        if sender_moderator in [Ticket.USER_ONLY]:
+        if send_ticket_to == Ticket.USER_ONLY:
             if self.sender:
                 tvars = {'ticket': self,
                          'user_to': self.sender}

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -81,14 +81,7 @@ def ticket(request, ticket_key):
         # First try to get the ticket matching the key, but if it fails, try also matching the id
         ticket = Ticket.objects.select_related('sound__license', 'sound__user').get(key=ticket_key)
     except Ticket.DoesNotExist:
-        try:
-            ticket_id = int(ticket_key)
-            ticket = Ticket.objects.select_related('sound__license', 'sound__user').get(id=ticket_id)
-            return HttpResponseRedirect(reverse('tickets-ticket', args=[ticket.key]))
-        except ValueError:
-            raise Http404
-        except Ticket.DoesNotExist:
-            raise Http404
+        raise Http404
 
     if not (ticket.sender == request.user or _can_view_mod_msg(request)):
         raise Http404

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -32,13 +32,13 @@ from django.http import HttpResponseRedirect, JsonResponse, Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils import timezone
-from django.shortcuts import render 
+from django.shortcuts import render
 from general.tasks import whitelist_user as whitelist_user_task, post_moderation_assigned_tickets as post_moderation_assigned_tickets_task
 
 from .models import Ticket, TicketComment, UserAnnotation
 from sounds.models import Sound
 from tickets import TICKET_STATUS_ACCEPTED, TICKET_STATUS_CLOSED, TICKET_STATUS_DEFERRED, TICKET_STATUS_NEW, MODERATION_TEXTS
-from tickets.forms import AnonymousMessageForm, UserMessageForm, ModeratorMessageForm, \
+from tickets.forms import UserMessageForm, ModeratorMessageForm, \
     SoundStateForm, SoundModerationForm, ModerationMessageForm, UserAnnotationForm, IS_EXPLICIT_ADD_FLAG_KEY, IS_EXPLICIT_REMOVE_FLAG_KEY
 from utils.cache import invalidate_user_template_caches, invalidate_all_moderators_header_cache
 from utils.username import redirect_if_old_username_or_404
@@ -47,22 +47,15 @@ from wiki.models import Content, Page
 
 
 def _get_tc_form(request, use_post=True):
-    return _get_anon_or_user_form(request, 
-                                  AnonymousMessageForm, 
-                                  UserMessageForm, 
-                                  use_post)
-
-
-def _get_anon_or_user_form(request, anonymous_form, user_form, use_post=True):
     if _can_view_mod_msg(request):
-        user_form = ModeratorMessageForm
-    if len(request.POST.keys()) > 0 and use_post:
-        if request.user.is_authenticated:
-            return user_form(request.POST)
-        else:
-            return anonymous_form(request.POST)
+        form = ModeratorMessageForm
     else:
-        return user_form() if request.user.is_authenticated else anonymous_form()
+        form = UserMessageForm
+
+    if len(request.POST.keys()) > 0 and use_post:
+        return form(request.POST)
+    else:
+        return form()
 
 
 def _can_view_mod_msg(request):
@@ -106,8 +99,8 @@ def ticket(request, ticket_key):
         invalidate_all_moderators_header_cache()
 
         # Left ticket message
-        if is_selected(request, 'recaptcha') or (request.user.is_authenticated and is_selected(request, 'message')):
-            tc_form = _get_tc_form(request)
+        if is_selected(request, 'message'):
+            tc_form = _get_tc_form(request, use_post=True)
             if tc_form.is_valid():
                 tc = TicketComment()
                 tc.text = tc_form.cleaned_data['message']
@@ -117,9 +110,7 @@ def ticket(request, ticket_key):
                         tc.sender = request.user
                     tc.ticket = ticket
                     tc.save()
-                    if not request.user.is_authenticated:
-                        email_to = Ticket.MODERATOR_ONLY
-                    elif request.user == ticket.sender:
+                    if request.user == ticket.sender:
                         email_to = Ticket.MODERATOR_ONLY
                     else:
                         email_to = Ticket.USER_ONLY


### PR DESCRIPTION
**Issue(s)**
Fixes #1872

**Description**
If a moderator writes a moderator-only message, we sent an email to the user too! Skip it in this case

Also fixes some other issues reported in #1872
