### PR TITLE
Replace Model.filter(x=self) with self.model_set

### DIFF
--- a/forum/tests.py
+++ b/forum/tests.py
@@ -518,6 +518,7 @@ class ForumPageResponses(TestCase):
         self.assertEqual(resp.status_code, 302)
 
         self.assertEqual(Subscription.objects.filter(thread=thread, subscriber=user2).count(), 1)
+        self.assertTrue(thread.is_user_subscribed(user2))
 
         # Try to create another subscription for the same user and thread, it should not create it
         resp = self.client.get(reverse('forums-thread-subscribe', args=[forum.name_slug, thread.id]))
@@ -530,6 +531,7 @@ class ForumPageResponses(TestCase):
         self.assertEqual(resp.status_code, 302)
 
         self.assertEqual(Subscription.objects.filter(thread=thread, subscriber=user2).count(), 0)
+        self.assertFalse(thread.is_user_subscribed(user2))
 
     def test_emails_sent_for_subscription_to_thread(self):
         forum = Forum.objects.first()

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -1824,10 +1824,10 @@ class Pack(models.Model):
             # Comes from the bulk_query_id method in PackManager
             return self.num_ratings_precomputed
         else:
-            return Sound.objects.filter(pack=self, num_ratings__gte=settings.MIN_NUMBER_RATINGS).count()
+            return self.sounds.filter(num_ratings__gte=settings.MIN_NUMBER_RATINGS).count()
 
     def get_total_pack_sounds_length(self):
-        result = Sound.objects.filter(pack=self).aggregate(total_duration=Sum('duration'))
+        result = self.sounds.aggregate(total_duration=Sum('duration'))
         return result['total_duration'] or 0
 
     def num_sounds_unpublished(self):
@@ -1841,7 +1841,7 @@ class Pack(models.Model):
         if hasattr(self, 'licenses_data_precomputed'):
             return self.licenses_data_precomputed  # If precomputed from PackManager.bulk_query_id method
         else:
-            licenses_data = list(Sound.objects.select_related('license').filter(pack=self).values_list('license__name', 'license_id'))
+            licenses_data = list(self.sounds.select_related('license').values_list('license__name', 'license_id'))
             license_ids = [lid for _, lid in licenses_data]
             license_names = [lname for lname, _ in licenses_data]
             return license_ids, license_names
@@ -1887,8 +1887,8 @@ class Pack(models.Model):
         if hasattr(self, "has_geotags_precomputed"):
             return self.has_geotags_precomputed
         else:
-            return Sound.objects.filter(pack=self).exclude(geotag=None).count() > 0
-        
+            return self.sounds.exclude(geotag=None).exists()
+
     @property
     def should_display_small_icons_in_second_line(self):
         # See same method in Sound class more more information

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -1821,9 +1821,10 @@ class Pack(models.Model):
     def num_ratings(self):
         # The number of ratings for a pack is the number of sounds that have >= 3 ratings
         if hasattr(self, 'num_ratings_precomputed'):
+            # Comes from the bulk_query_id method in PackManager
             return self.num_ratings_precomputed
         else:
-            return Sound.objects.filter(pack=self, num_ratings__gte=settings.MIN_NUMBER_RATINGS)
+            return Sound.objects.filter(pack=self, num_ratings__gte=settings.MIN_NUMBER_RATINGS).count()
 
     def get_total_pack_sounds_length(self):
         result = Sound.objects.filter(pack=self).aggregate(total_duration=Sum('duration'))

--- a/wiki/models.py
+++ b/wiki/models.py
@@ -30,7 +30,7 @@ class Page(models.Model):
         return self.name
 
     def content(self):
-        return Content.objects.filter(page=self).latest()
+        return self.content_set.latest()
 
     def get_absolute_url(self):
         return reverse("wiki-page", args=[smart_str(self.name)])


### PR DESCRIPTION
**Description**
In some places we weren't using the related objects on a model to find other objects. In my view it's a bit nicer because we can see how the relationship works.
This also allows us to use select_related or prefetch_related to load the items if we have many of them