### PR TITLE
Revert "If a user's cookie for last forum visit has no tz, add it"

### DIFF
--- a/forum/views.py
+++ b/forum/views.py
@@ -69,12 +69,8 @@ def last_action(view_func):
 
         if key not in request.COOKIES or not request.session.get(key, False):
             request.session[key] = now_as_string
-        else:
-            cookie_value = datetime.datetime.fromisoformat(request.COOKIES[key])
-            if cookie_value.tzinfo is None:
-                cookie_value = cookie_value.replace(tzinfo=timezone.utc)
-            if now - cookie_value > datetime.timedelta(minutes=30):
-                request.session[key] = request.COOKIES[key]
+        elif now - datetime.datetime.fromisoformat(request.COOKIES[key]) > datetime.timedelta(minutes=30):
+            request.session[key] = request.COOKIES[key]
 
         request.last_action_time = datetime.datetime.fromisoformat(request.session.get(key, now_as_string))
 


### PR DESCRIPTION
Reverts MTG/freesound#1843

We only wanted to have this change for 30 days after switching to `USE_TZ = True`