### PR TITLE
Add get_parameter_user_or_404

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -91,7 +91,11 @@ To deal with these checks, we use the `utils.username.raise_404_if_user_is_delet
 `utils.username.redirect_if_old_username` decorators in view functions. The first one will try to find a user
 object (checking for old usernames as well) and if it can't find it or the user is marked as deleted, it will raise
 HTTP 404 error. The second one will try to find a user object (also considering old usernames) and do an HTTP redirect
-with an updated username if user was found in the old usernames table.
+with an updated username if user was found in the old usernames table. Note that when using this second decorator, a
+`parameter_user` property will be set to the request object so that the view can use the corresponding `User` object without
+doing an extra database query. In that case however, `request.parameter_user` can be `None` if no user exists. To that end,
+it is advisable to get the `parameter_user` object using a util function we provide, `user = get_parameter_user_or_404(request)`,
+which will raise 404 if the user does not exist.
 
 In general, we should use `utils.username.redirect_if_old_username` in **all public views** that have username
 in the URL path. For login-required views (using `@login_required` decorator) we are not supposed to use that decorator

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -88,7 +88,7 @@ from utils.mirror_files import copy_avatar_to_mirror_locations, \
     copy_uploaded_file_to_mirror_locations, remove_uploaded_file_from_mirror_locations, \
     remove_empty_user_directory_from_mirror_locations
 from utils.pagination import paginate
-from utils.username import redirect_if_old_username, raise_404_if_user_is_deleted
+from utils.username import redirect_if_old_username, get_parameter_user_or_404, raise_404_if_user_is_deleted
 
 sounds_logger = logging.getLogger('sounds')
 upload_logger = logging.getLogger('file_upload')
@@ -940,7 +940,7 @@ def downloaded_sounds(request, username):
     if not request.GET.get('ajax'):
         # If not loading as a modal, redirect to the account page with parameter to open modal
         return HttpResponseRedirect(reverse('account', args=[username]) + '?downloaded_sounds=1')
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     qs = Download.objects.filter(user_id=user.id).order_by('-created')
     num_items_per_page = settings.DOWNLOADED_SOUNDS_PACKS_PER_PAGE
     paginator = paginate(request, qs, num_items_per_page, object_count=user.profile.num_sound_downloads)
@@ -966,7 +966,7 @@ def downloaded_packs(request, username):
     if not request.GET.get('ajax'):
         # If not loaded as a modal, redirect to account page with parameter to open modal
         return HttpResponseRedirect(reverse('account', args=[username]) + '?downloaded_packs=1')
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     qs = PackDownload.objects.filter(user=user.id).order_by('-created')
     num_items_per_page = settings.DOWNLOADED_SOUNDS_PACKS_PER_PAGE
     paginator = paginate(request, qs, num_items_per_page, object_count=user.profile.num_pack_downloads)
@@ -1123,7 +1123,7 @@ def charts(request):
 
 @redirect_if_old_username
 def account(request, username):
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     latest_sounds = list(Sound.objects.bulk_sounds_for_user(user.id, settings.SOUNDS_PER_PAGE_PROFILE_PACK_PAGE))
     following = follow_utils.get_users_following_qs(user)
     followers = follow_utils.get_users_followers_qs(user)
@@ -1180,7 +1180,7 @@ def account(request, username):
 def account_stats_section(request, username):
     if not request.GET.get('ajax'):
         raise Http404  # Only accessible via ajax
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     tvars = {
         'user': user,
         'user_stats': user.profile.get_stats_for_profile_page(),
@@ -1193,7 +1193,7 @@ def account_latest_packs_section(request, username):
     if not request.GET.get('ajax'):
         raise Http404  # Only accessible via ajax
     
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     tvars = {
         'user': user,
         # Note we don't pass latest packs data because it is requested from the template

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -32,7 +32,7 @@ from bookmarks.models import Bookmark, BookmarkCategory
 from sounds.models import Sound
 from utils.downloads import download_sounds
 from utils.pagination import paginate
-from utils.username import redirect_if_old_username, raise_404_if_user_is_deleted
+from utils.username import redirect_if_old_username, get_parameter_user_or_404, raise_404_if_user_is_deleted
 
 
 @login_required
@@ -62,7 +62,7 @@ def bookmarks(request, category_id=None):
 @redirect_if_old_username
 @raise_404_if_user_is_deleted
 def bookmarks_for_user(request, username, category_id=None):
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     is_owner = request.user.is_authenticated and user == request.user
     if is_owner:
         # If accessing own bookmarks using the people/xx/bookmarks URL, redirect to the /home/bookmarks URL

--- a/follow/views.py
+++ b/follow/views.py
@@ -34,7 +34,7 @@ from follow.models import FollowingQueryItem
 from follow.models import FollowingUserItem
 from utils.cache import invalidate_user_template_caches
 from utils.pagination import paginate
-from utils.username import redirect_if_old_username, raise_404_if_user_is_deleted
+from utils.username import redirect_if_old_username, get_parameter_user_or_404, raise_404_if_user_is_deleted
 
 
 @redirect_if_old_username
@@ -46,7 +46,7 @@ def following_users(request, username):
         # If not loaded as a modal, redirect to account page with parameter to open modal
         return HttpResponseRedirect(reverse('account', args=[username]) + '?following=1')
 
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     following = follow_utils.get_users_following_qs(user)
     tvars = {
         'user': user
@@ -73,7 +73,7 @@ def followers(request, username):
         # If not loaded as a modal, redirect to account page with parameter to open modal
         return HttpResponseRedirect(reverse('account', args=[username]) + '?followers=1')
 
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     followers = follow_utils.get_users_followers_qs(user)
     tvars = {
         'user': user
@@ -100,7 +100,7 @@ def following_tags(request, username):
         # If not loaded as a modal, redirect to account page with parameter to open modal
         return HttpResponseRedirect(reverse('account', args=[username]) + '?followingTags=1')
 
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     following_tags = follow_utils.get_tags_following_qs(user)
     tvars = {
         'user': user,

--- a/geotags/views.py
+++ b/geotags/views.py
@@ -207,7 +207,7 @@ def for_user(request, username):
     tvars = _get_geotags_query_params(request)
     tvars.update({  # Overwrite tag and username query params (if present)
         'tag': None,
-        'username': request.parameter_user.username,
+        'username': username,
         'pack': None,
         'sound': None,
         'url': reverse('geotags-for-user-barray', args=[username]),

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -74,7 +74,7 @@ from utils.sound_upload import create_sound, NoAudioException, AlreadyExistsExce
     get_duration_from_processing_before_describe_files, \
     get_samplerate_from_processing_before_describe_files
 from utils.text import remove_control_chars
-from utils.username import redirect_if_old_username
+from utils.username import redirect_if_old_username, get_parameter_user_or_404
 
 web_logger = logging.getLogger('web')
 sounds_logger = logging.getLogger('sounds')
@@ -912,13 +912,13 @@ def pack_stats_section(request, username, pack_id):
 
 @redirect_if_old_username
 def packs_for_user(request, username):
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     return HttpResponseRedirect(user.profile.get_user_packs_in_search_url())
 
 
 @redirect_if_old_username
 def for_user(request, username):
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     return HttpResponseRedirect(user.profile.get_user_sounds_in_search_url())
     
 

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -41,7 +41,7 @@ from tickets import TICKET_STATUS_ACCEPTED, TICKET_STATUS_CLOSED, TICKET_STATUS_
 from tickets.forms import UserMessageForm, ModeratorMessageForm, \
     SoundStateForm, SoundModerationForm, ModerationMessageForm, UserAnnotationForm, IS_EXPLICIT_ADD_FLAG_KEY, IS_EXPLICIT_REMOVE_FLAG_KEY
 from utils.cache import invalidate_user_template_caches, invalidate_all_moderators_header_cache
-from utils.username import redirect_if_old_username
+from utils.username import redirect_if_old_username, get_parameter_user_or_404
 from utils.pagination import paginate
 from wiki.models import Content, Page
 
@@ -675,7 +675,7 @@ def pending_tickets_per_user(request, username):
         # If not loaded as a modal, redirect to account page with parameter to open modal
         return HttpResponseRedirect(reverse('account', args=[username]) + '?pending_moderation=1')
     
-    user = request.parameter_user
+    user = get_parameter_user_or_404(request)
     tickets, _ = _get_pending_tickets_for_user(user, include_mod_messages=True)
     _add_sound_objects_to_tickets(tickets)
     mods = set()

--- a/utils/username.py
+++ b/utils/username.py
@@ -45,6 +45,12 @@ def get_user_or_404(username):
     return user
 
 
+def get_parameter_user_or_404(request):
+    if request.parameter_user:
+        raise Http404
+    return request.parameter_user
+
+
 def redirect_if_old_username(func):
     """
     This is a decorator to return redirects when accessing a URL with the username in the pattern and that usernames
@@ -57,7 +63,7 @@ def redirect_if_old_username(func):
     def inner(request, *args, **kwargs):
         if hasattr(request, 'parameter_user'):
             # If request.parameter_user already exists because it was added by some other decorator, reuse it
-            user = request.parameter_user
+            user = request.parameter_user 
         else:
             # Otherwise get the corresponding user (considering OldUsernames) object or raise 404
             user = get_user_or_404(kwargs['username'])

--- a/utils/username.py
+++ b/utils/username.py
@@ -46,7 +46,7 @@ def get_user_or_404(username):
 
 
 def get_parameter_user_or_404(request):
-    if request.parameter_user:
+    if request.parameter_user is None:
         raise Http404
     return request.parameter_user
 


### PR DESCRIPTION
After updating the `redirect_if_old_username` decorator, we were no longer raising 404 if users do not exist. This PR adds this functionality back. Some tests need to be updated, we suspect tests were not previously doing quite what we thought in the past...
