### PR TITLE
Fix potentially wrong SearchOption values in SearchQueryProcessor instanced

### DIFF
--- a/search/tests.py
+++ b/search/tests.py
@@ -18,19 +18,15 @@
 #     See AUTHORS file.
 #
 
-from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.conf import settings
-from django.test import TestCase, RequestFactory
+from django.test import TestCase
 from django.test.utils import skipIf, override_settings
 from django.urls import reverse
-from utils.search import search_query_processor
 from sounds.models import Sound
 from utils.search import SearchResults, SearchResultsPaginator
 from utils.test_helpers import create_user_and_sounds
-from utils.url import ComparableUrl
 from unittest import mock
-from django.contrib.auth.models import AnonymousUser
 
 
 def create_fake_search_engine_results():

--- a/search/views.py
+++ b/search/views.py
@@ -67,7 +67,7 @@ def search_view_helper(request):
     open_in_map_url = None
     map_mode_query_results_cache_key = None
     map_bytearray_url = ''
-    if sqp.map_mode:
+    if sqp.map_mode_active():
         current_query_params = request.get_full_path().split("?")[-1]
         open_in_map_url = reverse('geotags-query') + f'?{current_query_params}'
         map_mode_query_results_cache_key = f'map-query-results-{create_hash(current_query_params, 10)}'

--- a/utils/search/search_query_processor.py
+++ b/utils/search/search_query_processor.py
@@ -201,8 +201,7 @@ class SearchQueryProcessor:
             self.facets.update(settings.SEARCH_SOUNDS_BETA_FACETS)
 
         # Iterate over option_definitions and instantiate corresponding SearchOption objectss in a self.options dictionary so we 
-        # can easily iterate and access options through self.options attribute. In this way SearchOption objects are accessible in 
-        # a similar way as Django form fields are accessible in form objects
+        # can easily iterate and access options through self.options attribute. 
         self.options = {}
         for option_name, option_class, option_kwargs in self.option_definitions:
             option = option_class(**option_kwargs)


### PR DESCRIPTION
**Issue(s)**
Fixes https://github.com/MTG/freesound/issues/1884

**Description**
Because of the way in which `SearchQueryProcessor` object defined different available `SearchOption` properties, it would happen that `SearchOption` would save state in class variables that would be shared across different instances of `SearchQueryProcessor` objects. This PR solves the issue by instantiating `SearchOption` at `SearchQueryProcessor` init time.  
