### PR TITLE
Make geotag a single value field in solr

### DIFF
--- a/geotags/views.py
+++ b/geotags/views.py
@@ -62,9 +62,9 @@ def generate_bytearray(sound_queryset_or_list):
                 num_sounds_in_bytearray += 1
         elif type(s) == dict:
             try:
-                lon, lat = s['geotag'][0].split(' ')
-                lat = max(min(float(lat), 90), -90) 
-                lon = max(min(float(lon), 180), -180) 
+                lon, lat = s['geotag'].split(' ')
+                lat = max(min(float(lat), 90), -90)
+                lon = max(min(float(lon), 180), -180)
                 packed_sounds.write(struct.pack("i", s['id']))
                 packed_sounds.write(struct.pack("i", int(lat * 1000000)))
                 packed_sounds.write(struct.pack("i", int(lon * 1000000)))

--- a/utils/search/solr9/cores/freesound/conf/schema.xml
+++ b/utils/search/solr9/cores/freesound/conf/schema.xml
@@ -211,7 +211,7 @@
   <copyField source="pack" dest="pack_tokenized" />
 
   <field name="is_geotagged" type="boolean" indexed="true" stored="true" required="false" />
-  <field name="geotag" type="location_rpt" indexed="true" stored="true" required="false"  multiValued="true"/>
+  <field name="geotag" type="location_rpt" indexed="true" stored="true" required="false" />
 
   <field name="type" type="alphaOnlySort" indexed="true" stored="true" required="false" />
   <field name="duration" type="pdouble" indexed="true" stored="true" required="false" />


### PR DESCRIPTION
This was probably due to us copying the definition of "tags". a sound has only one geotag
