### PR TITLE
Not possible to use negation operator in search filter

### DIFF
--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -408,7 +408,8 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
         # that allows us to define our own filter syntax and then represent filters as some intermediate structure that can later
         # be converted to valid lucene/dismax syntax.
         query_filter = re.sub(r'\b([a-zA-Z_]+:)', r'+\1', query_filter)
-        query_filter = re.sub(r"(\+)\1+", r"\1", query_filter)  # This is to avoid having multiple + in a row if user already has added them
+        query_filter = re.sub(r'(\+)\1+', r'\1', query_filter)  # This is to avoid having multiple + in a row if user already has added them
+        query_filter = re.sub(r'(-)\+', r'\1', query_filter) # Removes added '+' when user has included a negation '-'
         if len(query_filter) > 0 and query_filter[-1] == '+':
             query_filter = query_filter[:-1]
         return query_filter

--- a/utils/search/backends/tests/test_solr555pysolr.py
+++ b/utils/search/backends/tests/test_solr555pysolr.py
@@ -12,3 +12,7 @@ class Solr555PySolrTest(TestCase):
         filter_query = "username:alastairp license:(a OR b)"
         updated = solr555pysolr.Solr555PySolrSearchEngine().search_filter_make_intersection(filter_query)
         self.assertEqual(updated, "+username:alastairp +license:(a OR b)")
+
+        filter_query = "-username:alastairp"
+        updated = solr555pysolr.Solr555PySolrSearchEngine().search_filter_make_intersection(filter_query)
+        self.assertEqual(updated, "-username:alastairp")

--- a/utils/search/backends/tests/test_solr555pysolr.py
+++ b/utils/search/backends/tests/test_solr555pysolr.py
@@ -16,3 +16,7 @@ class Solr555PySolrTest(TestCase):
         filter_query = "-username:alastairp"
         updated = solr555pysolr.Solr555PySolrSearchEngine().search_filter_make_intersection(filter_query)
         self.assertEqual(updated, "-username:alastairp")
+
+        filter_query = "username:alastairp -license:(a OR b)"
+        updated = solr555pysolr.Solr555PySolrSearchEngine().search_filter_make_intersection(filter_query)
+        self.assertEqual(updated, "+username:alastairp -license:(a OR b)")


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1870

**Description**
Bug fix and tests to allow negation operator in queries
Adds an additional regex to remove the extraneous '+' when the user includes a '-' for negation filtering
Adds two tests for single and multiple query filters

**Deployment steps**:
None - just make sure all tests pass, specifically `freesound/utils/search/backends/tests/test_solr555pysolr.py`
