### PR TITLE
Fix Open Graph meta tags

### DIFF
--- a/templates/geotags/geotags.html
+++ b/templates/geotags/geotags.html
@@ -29,7 +29,7 @@
             {% elif sound %}
                 Map for sound <a href="{% url "sound" sound.user.username sound.id %}">{{ sound.original_filename }}</a>
             {% elif query_params %}
-                Map for query <a href="{{ query_search_page_url }}">{{ query_description}}</a
+                Map for query <a href="{{ query_search_page_url }}">{{ query_description}}</a>
             {% else %}
                 Map of sounds
             {% endif %}

--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -14,7 +14,7 @@
 
 {% block title %}{{sound.original_filename}} by {{sound.user.username}}{% endblock title %}
 
-{% block head %}
+{% block extrahead %}
     {{ block.super }}
     <meta property="og:title" content="{{ sound.original_filename }} by {{ sound.user.username }}" />
     <meta property="og:type" content="song" />
@@ -35,7 +35,7 @@
     <meta name="twitter:player:height" content="{{ sizes.twitter_card.1 }}" />
     <meta name="twitter:player:stream" content="{{ sound.get_preview_abs_url }}" />
     <meta name="twitter:player:stream:content_type" content="audio/mp4" />
-{% endblock head %}
+{% endblock extrahead %}
 
 {% block content %}
     <div class="container">

--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -24,6 +24,8 @@
     <meta property="og:url" content="{% absurl 'sound' sound.user.username sound.id %}" />
     <meta property="og:audio:type" content="application/mp3" />
     <meta property="og:site_name" content="Freesound" />
+    <meta property="og:image" content="{{sound.get_large_thumbnail_abs_url}}" />
+    <meta property="og:image:alt" content="A waveform image of the sound" />
     <meta property="fb:admins" content="100002130282170" />
     <meta name="twitter:card" content="player" />
     <meta name="twitter:site" content="@freesound_dev" />


### PR DESCRIPTION
**Issue(s)**
<!-- URL to issue(s) related to this PR -->

**Description**

Fixes and enhancements in HTML templates:

* `templates/geotags/geotags.html`: Fixed a typo in the closing tag for the query description link.
* `templates/sounds/sound.html`: Renamed the block from `head` to `extrahead`. Block was not loaded with the old name.
* `templates/sounds/sound.html`: Added new Open Graph metadata properties `og:image` and `og:image:alt` to improve the display of sound previews on social media platforms.

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section.  -->
