### PR TITLE
remove docker-compose init from web service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
             context: ./
             dockerfile: ./docker/Dockerfile.workers_web
             target: freesound
-        init: true
         command: python manage.py runserver 0.0.0.0:8000
         volumes:
             - .:/code


### PR DESCRIPTION
We now install tini in Dockerfile because we use it to handle the gunicorn stats collector in prod. Therefore we don't need to inject a dev version in docker-compose.yml

**Issue(s)**
<!-- URL to issue(s) related to this PR -->

**Description**
<!-- Description of the contents of this PR -->

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
