### PR TITLE
Add a new string field for faceting tags

### DIFF
--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -44,7 +44,7 @@ SOLR_SOUNDS_URL = f"{settings.SOLR5_BASE_URL}/freesound"
 FIELD_NAMES_MAP = {
     settings.SEARCH_SOUNDS_FIELD_ID: 'id',
     settings.SEARCH_SOUNDS_FIELD_NAME: 'original_filename',
-    settings.SEARCH_SOUNDS_FIELD_TAGS: 'tag',
+    settings.SEARCH_SOUNDS_FIELD_TAGS: 'tagfacet',
     settings.SEARCH_SOUNDS_FIELD_DESCRIPTION: 'description',
     settings.SEARCH_SOUNDS_FIELD_USER_NAME: 'username',
     settings.SEARCH_SOUNDS_FIELD_PACK_NAME: 'pack_tokenized',

--- a/utils/search/schema/freesound.json
+++ b/utils/search/schema/freesound.json
@@ -198,6 +198,12 @@
       "multiValued": true
     },
     {
+      "name": "tagfacet",
+      "type": "strings",
+      "stored": true,
+      "required": false
+    },
+    {
       "name": "is_explicit",
       "type": "boolean",
       "indexed": true,
@@ -465,6 +471,12 @@
       "source": "created",
       "dest": [
         "created_range"
+      ]
+    },
+    {
+      "source": "tag",
+      "dest": [
+        "tagfacet"
       ]
     }
   ]


### PR DESCRIPTION
In solr 9.7, some changes were made to the way that faceting works (SOLR-12963). This means that to facet on a field, it must have docValues=true set, which means it must be a string.

Our tag field is still "text", which is good for searching but cannot have docValues=true set, so make a new field and copy tags to it. It doesn't need to be stored.

**Issue(s)**
<!-- URL to issue(s) related to this PR -->

**Description**
<!-- Description of the contents of this PR -->

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
