### PR TITLE
Fix faceting for multi-valued solr fields

### DIFF
--- a/search/management/commands/reindex_search_engine_sounds.py
+++ b/search/management/commands/reindex_search_engine_sounds.py
@@ -45,6 +45,12 @@ class Command(BaseCommand):
             default=5000,
             type=int,
             help='How many sounds to add at once')
+        parser.add_argument(
+            '--immediately-create-alias',
+            action='store_true',
+            dest='immediately_create_alias',
+            default=False,
+            help='Immediately create the alias for the new index before indexing')
 
         group = parser.add_mutually_exclusive_group(required=False)
         group.add_argument(
@@ -81,6 +87,10 @@ class Command(BaseCommand):
         solr_api = solrapi.SolrManagementAPI(search_engine.solr_base_url, collection_name)
         if not only_similarity_vectors:
             solr_api.create_collection_and_schema(delete_default_fields_definition, freesound_schema_definition, "username")
+
+        if options['immediately_create_alias']:
+            console_logger.info("Creating the freesound alias to point to the new index")
+            solr_api.create_collection_alias("freesound")
 
         # Get all sounds moderated and processed ok and add them to the search engine
         # Don't delete existing sounds in each loop because we clean up in the final step

--- a/search/templatetags/search.py
+++ b/search/templatetags/search.py
@@ -24,7 +24,7 @@ from django.conf import settings
 
 from sounds.models import License
 from utils.search import search_query_processor_options
-from utils.search.backends.solr555pysolr import FIELD_NAMES_MAP
+from utils.search.backends.solr555pysolr import get_solr_fieldname_from_freesound_fieldname
 from utils.tags import annotate_tags
 
 register = template.Library()
@@ -34,7 +34,8 @@ register = template.Library()
 def display_facet(context, facet_name, facet_title=None, beta_facet=False):
     sqp = context['sqp']
     facets = context['facets']
-    solr_fieldname = FIELD_NAMES_MAP.get(facet_name, facet_name)
+    solr_fieldname = get_solr_fieldname_from_freesound_fieldname(facet_name)  
+    # Note that "solr_fieldname" does not need the facet version of solr fieldname, but the normal one that can be used for filtering
     if facet_name in facets:
         facet_title = sqp.facets[facet_name].get('title', facet_name.capitalize())
         facet_type = sqp.facets[facet_name].get('widget', 'list')

--- a/tags/views.py
+++ b/tags/views.py
@@ -31,7 +31,6 @@ from search.views import search_view_helper
 from tags.models import Tag, FS1Tag
 from utils.search import SearchEngineException
 from utils.search.search_sounds import perform_search_engine_query
-from utils.search.backends.solr555pysolr import get_solr_fieldname, get_solr_fieldname_for_facet
 
 search_logger = logging.getLogger("search")
 
@@ -69,11 +68,10 @@ def tag_cloud(request):
             sentry_sdk.capture_exception(e)
             tvars.update({"error_text": "The search server could not be reached, please try again later."})
         else:
-            solr_tags_facet_fieldname = get_solr_fieldname_for_facet(get_solr_fieldname(settings.SEARCH_SOUNDS_FIELD_TAGS))
-            if solr_tags_facet_fieldname in results.facets:
+            if settings.SEARCH_SOUNDS_FIELD_TAGS in results.facets:
                 initial_tagcloud = [
                     dict(name=f[0], count=f[1], browse_url=reverse("tags", args=[f[0]]))
-                    for f in results.facets.get(solr_tags_facet_fieldname, [])
+                    for f in results.facets.get(settings.SEARCH_SOUNDS_FIELD_TAGS, [])
                 ]
                 cache.set("initial_tagcloud", initial_tagcloud, 60 * 60 * 12)  # cache for 12 hours
                 tvars.update({"initial_tagcloud": initial_tagcloud})

--- a/tags/views.py
+++ b/tags/views.py
@@ -31,6 +31,7 @@ from search.views import search_view_helper
 from tags.models import Tag, FS1Tag
 from utils.search import SearchEngineException
 from utils.search.search_sounds import perform_search_engine_query
+from utils.search.backends.solr555pysolr import get_solr_fieldname, get_solr_fieldname_for_facet
 
 search_logger = logging.getLogger("search")
 
@@ -68,10 +69,11 @@ def tag_cloud(request):
             sentry_sdk.capture_exception(e)
             tvars.update({"error_text": "The search server could not be reached, please try again later."})
         else:
-            if settings.SEARCH_SOUNDS_FIELD_TAGS in results.facets:
+            solr_tags_facet_fieldname = get_solr_fieldname_for_facet(get_solr_fieldname(settings.SEARCH_SOUNDS_FIELD_TAGS))
+            if solr_tags_facet_fieldname in results.facets:
                 initial_tagcloud = [
                     dict(name=f[0], count=f[1], browse_url=reverse("tags", args=[f[0]]))
-                    for f in results.facets.get(settings.SEARCH_SOUNDS_FIELD_TAGS, [])
+                    for f in results.facets.get(solr_tags_facet_fieldname, [])
                 ]
                 cache.set("initial_tagcloud", initial_tagcloud, 60 * 60 * 12)  # cache for 12 hours
                 tvars.update({"initial_tagcloud": initial_tagcloud})

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -67,7 +67,7 @@ FACET_FIELD_NAMES_MAP = {
 
 def get_solr_fieldname_for_facet(solr_field_name):
     if solr_field_name.endswith('_ls'):
-        return solr_field_name + '_f'
+        return solr_field_name + SOLR_DYNAMIC_FIELD_FACET_EXTRA_SUFFIX
     return FACET_FIELD_NAMES_MAP.get(solr_field_name, solr_field_name)
 
 # Create a reverse field name map that will be useful to get the original freesound field name from a solr field name

--- a/utils/search/schema/freesound.json
+++ b/utils/search/schema/freesound.json
@@ -464,6 +464,10 @@
       "stored": true,
       "multiValued": true,
       "required": false
+    },{
+      "name": "*_ls_f",
+      "type": "strings",
+      "stored": false
     }
   ],
   "copyFields": [


### PR DESCRIPTION
**Description**
The fix that was released yesterday for tag faceting included some issues which are addressed in this PR. The whole thing is a bit confusing because we define a Freesound name for the field "tags", which is eventually translated to the specific field name used in our solr schema (which is "tag"), but that when used for faceting, it should be named "tagfacet". In this PR, I added support for "custom facet fieldnames", and it works but the resulting code is a bit complicated with all these name changes. The previous fix was simply renaming the solr field name from "tag" to "tagfacet", but this might cause issues in places where we actually need to use the name "tag" (like filtering or specifying query field weights). I'm not 100% about this, so let's discuss that once we have some time and maybe try to find a better solution.

A remaining issue is still faceting for multi-valued dynamic fields. We have to investigate and make that work.