### PR TITLE
Send user id to celery task instead of object

### DIFF
--- a/general/tasks.py
+++ b/general/tasks.py
@@ -53,7 +53,7 @@ DELETE_USER_KEEP_SOUNDS_ACTION_NAME = 'delete_user_keep_sounds'
 
 
 @shared_task(name=WHITELIST_USER_TASK_NAME, queue=settings.CELERY_ASYNC_TASKS_QUEUE_NAME)
-def whitelist_user(sender, ticket_ids=None, user_id=None):
+def whitelist_user(annotation_sender_id, ticket_ids=None, user_id=None):
     # Whitelist "sender" users from the tickets with given ids
     workers_logger.info("Start whitelisting users from tickets (%s)" % json.dumps({
         'task_name': WHITELIST_USER_TASK_NAME,
@@ -94,7 +94,7 @@ def whitelist_user(sender, ticket_ids=None, user_id=None):
             # Invalidate template caches for sender user
             invalidate_user_template_caches(whitelist_user.id)
             UserAnnotation.objects.create(
-                sender=sender,
+                sender_id=annotation_sender_id,
                 user=whitelist_user,
                 text="The user was whitelisted by a moderator",
                 automated=True

--- a/tickets/tests.py
+++ b/tickets/tests.py
@@ -196,7 +196,7 @@ class TicketTestsFromQueue(TicketTests):
     @mock.patch('general.tasks.whitelist_user.delay')
     def test_whitelist_from_queue(self, whitelist_task):
         self._perform_action('Whitelist')
-        whitelist_task.assert_called_once_with(sender=self.test_moderator, ticket_ids=[self.ticket.id])
+        whitelist_task.assert_called_once_with(annotation_sender_id=self.test_moderator.id, ticket_ids=[self.ticket.id])
 
     def _assert_ticket_and_sound_fields(self, status, assignee, moderation_state):
         self.ticket.refresh_from_db()

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -161,7 +161,7 @@ def ticket(request, ticket_key):
                     notification = ticket.NOTIFICATION_APPROVED
 
                 elif sound_action == 'Whitelist':
-                    whitelist_user_task.delay(sender=request.user, ticket_ids=[ticket.id])  # async job should take care of whitelisting
+                    whitelist_user_task.delay(annotation_sender_id=request.user.id, ticket_ids=[ticket.id])
                     comment += f'whitelisted all sounds from user {ticket.sender}'
                     notification = ticket.NOTIFICATION_WHITELISTED
 
@@ -559,7 +559,7 @@ def moderation_assigned(request, user_id):
 
             elif action == "Whitelist":
                 ticket_ids = list(tickets.values_list('id',flat=True))
-                whitelist_user_task.delay(sender=request.user, ticket_ids=ticket_ids)  # async job should take care of whitelisting
+                whitelist_user_task.delay(annotation_sender_id=request.user.id, ticket_ids=ticket_ids)  # async job should take care of whitelisting
                 notification = Ticket.NOTIFICATION_WHITELISTED
 
                 users = set(tickets.values_list('sender__username', flat=True))
@@ -729,7 +729,7 @@ def whitelist_user(request, user_id):
                              """The user you are trying to whitelist does not exist""")
         return HttpResponseRedirect(reverse('tickets-moderation-home'))
 
-    whitelist_user_task.delay(sender=request.user, user_id=user_id)
+    whitelist_user_task.delay(annotation_sender_id=request.user.id, user_id=user_id)
 
     messages.add_message(request, messages.INFO,
         f"""User {user.username} has been whitelisted. Note that some of tickets might


### PR DESCRIPTION
Rename parameter to make its role more clear (tickets also have a sender, which is distinct)

**Issue(s)**
https://logserver.mtg.upf.edu/organizations/sentry/issues/4302

**Description**
<!-- Description of the contents of this PR -->

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
