### PR TITLE
Add option to log solr slow queries

### DIFF
--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -688,6 +688,8 @@ SEARCH_CACHE_EMPTY_QUERIES = True
 SEARCH_EMPTY_QUERY_CACHE_KEY = 'search_empty_query_results_paginator'
 SEARCH_EMPTY_QUERY_CACHE_TIME = 60 * 10  # 10 minutes, although we manually invalidate this cache when the search index is updated so this time could theoretically be longer
 
+SEARCH_LOG_SLOW_QUERIES_MS_THRESHOLD = 1000  # Log search queries that take longer than this threshold in milliseconds. Set it to -1 to disable logging of slow queries.
+
 # -------------------------------------------------------------------------------
 # Similarity client settings
 SIMILARITY_ADDRESS = 'similarity'

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -689,6 +689,8 @@ SEARCH_EMPTY_QUERY_CACHE_KEY = 'search_empty_query_results_paginator'
 SEARCH_EMPTY_QUERY_CACHE_TIME = 60 * 10  # 10 minutes, although we manually invalidate this cache when the search index is updated so this time could theoretically be longer
 
 SEARCH_LOG_SLOW_QUERIES_MS_THRESHOLD = 1000  # Log search queries that take longer than this threshold in milliseconds. Set it to -1 to disable logging of slow queries.
+SEARCH_LOG_SLOW_QUERIES_BASE_ADMIN_URL = "http://localhost:8983/solr/#/freesound/query"
+
 
 # -------------------------------------------------------------------------------
 # Similarity client settings

--- a/utils/search/backends/solr_common.py
+++ b/utils/search/backends/solr_common.py
@@ -18,9 +18,14 @@
 #     Bram de Jong
 #
 import json
-import urllib.request, urllib.parse, urllib.error
+import logging
+import urllib.parse
+
+from django.conf import settings
 
 from utils.search import SearchEngineException
+
+search_logger = logging.getLogger("search")
 
 
 class SolrQuery:
@@ -324,3 +329,10 @@ class SolrResponseInterpreter:
             self.highlighting = response["highlighting"]
         except KeyError:
             self.highlighting = {}
+
+        # If query is slow, log its SOLR parameters so we can debug it later
+        if settings.SEARCH_LOG_SLOW_QUERIES_MS_THRESHOLD > -1 and self.q_time > settings.SEARCH_LOG_SLOW_QUERIES_MS_THRESHOLD:
+            search_logger.info(f"SOLR slow query detected: {self.q_time}ms. SOLR query params: {str(response['responseHeader']['params'])}")
+
+
+

--- a/utils/search/backends/solr_common.py
+++ b/utils/search/backends/solr_common.py
@@ -332,7 +332,6 @@ class SolrResponseInterpreter:
 
         # If query is slow, log its SOLR parameters so we can debug it later
         if settings.SEARCH_LOG_SLOW_QUERIES_MS_THRESHOLD > -1 and self.q_time > settings.SEARCH_LOG_SLOW_QUERIES_MS_THRESHOLD:
-            search_logger.info(f"SOLR slow query detected: {self.q_time}ms. SOLR query params: {str(response['responseHeader']['params'])}")
-
-
-
+            query_params = urllib.parse.urlencode(response['responseHeader']['params'], doseq=True, safe=':/?&",\{\}*^')
+            solr_admin_query_url = f"{settings.SEARCH_LOG_SLOW_QUERIES_BASE_ADMIN_URL}?{query_params}"
+            search_logger.info(f"SOLR slow query detected: {self.q_time}ms. URL: {solr_admin_query_url}")


### PR DESCRIPTION
**Description**
This PR adds a django setting `SEARCH_LOG_SLOW_QUERIES_MS_THRESHOLD` to enable logging of Solr slow queries. The log includes Solr response header, which has the parameters used for the Solr query. This can be used to later replicate the query in the Solr admin. By default `SEARCH_LOG_SLOW_QUERIES_MS_THRESHOLD=1000`. 

