### PR TITLE
Implement "group by pack" with Collapse and Expand query parser

### DIFF
--- a/freesound/logger.py
+++ b/freesound/logger.py
@@ -58,7 +58,7 @@ LOGGING = {
         },
         'search': {
             'handlers': ['stdout'],
-            'level': 'ERROR',
+            'level': 'INFO',
             'propagate': False,
         },
         'file_upload': {

--- a/general/templatetags/util.py
+++ b/general/templatetags/util.py
@@ -131,6 +131,6 @@ def strip_unnecessary_br(value):
 
 @register.filter
 def format_json(value):
-    value = json.dumps(value, sort_keys=True, indent=4)
+    value = json.dumps(value, indent=4)
     value = '<pre>' + value + '</pre>'
     return mark_safe(value)


### PR DESCRIPTION
**Description**
In recent experiments we found out that grouping by pack cause SOLR queries to be very slow, specially queries that return many results. This PR implements the grouping functionality using a more modern SOLR approach - https://solr.apache.org/guide/solr/latest/query-guide/collapse-and-expand-results.html

Pending:

- [ ] One drawback of using this strategy is that we do not have access to the total number of ungrouped matches for a query, therefore we should modify some things in the UI so that we don't provide misleading feedback to users (we should hint somehow that the total number of results corresponds to "groups" and not sounds)
- [ ] Test that the num of matches per grouped pack is correct (e.g. the text "see X more sounds from pack"), also make sure that applying the resulting pack filter works, as it did not seem to work in my local tests.
- [ ] Test the speed of this method with a big index. So far I've only tested in my local collection, where traditional grouped queries would take only a few ms to complete anyway. I've seen that using new method seems to halve the time, but it remains to be seen how it operates with the large index.
- [ ] Test that the method works in similarity queries as well. Queries that involve similarity search and grouping by pack use a different grouping field. I added support for that, but have not tested it. Maybe we should add a test for that :)


