### PR TITLE
Fix password reset timeout in email activation template

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -356,7 +356,8 @@ def send_activation(user):
     tvars = {
         'user': user,
         'username': username,
-        'hash': token
+        'hash': token,
+        'pw_reset_timeout_days': int(settings.PASSWORD_RESET_TIMEOUT / (60 * 60 * 24)),
     }
     send_mail_template(settings.EMAIL_SUBJECT_ACTIVATION_LINK, 'emails/email_activation.txt', tvars, user_to=user)
 

--- a/templates/emails/email_activation.txt
+++ b/templates/emails/email_activation.txt
@@ -11,7 +11,7 @@ In order to activate your Freesound account, please click this link:
 
 {% absurl 'accounts-activate' username hash %}
 
-The link is only valid for {{ settings.PASSWORD_RESET_TIMEOUT_DAYS }} days.
+The link is only valid for {{ pw_reset_timeout_days }} days.
 
 If for some reason this fails, try copy-pasting the complete link into you browser. Some mail clients break up long lines, or do strange things to URLs!
 {% endblock %}


### PR DESCRIPTION
**Issue(s)**
Closes #1986 

**Description**
PASSWORD_RESET_TIMEOUT_DAYS was deprecated in Django 3.1 https://docs.djangoproject.com/en/5.2/releases/4.0/#features-removed-in-4-0

**Deployment steps**:
None
