### PR TITLE
Larger clickable area for pagination arrows

### DIFF
--- a/templates/molecules/paginator.html
+++ b/templates/molecules/paginator.html
@@ -18,7 +18,9 @@
 
     {% for num in page_numbers %}
         {% if num == current_page %}
-            <li class="bw-pagination_circle bw-pagination_selected"><a class="text-white" href="{{ url }}{{ num }}{% if anchor %}#{{anchor}}{% endif %}" title="Page {{ num }}">{{ num }}</a></li>
+            <li class="bw-pagination_circle bw-pagination_selected">
+                {{ num }}
+            </li>
         {% else %}
             <li><a href="{{ url }}{{ num }}{% if anchor %}#{{anchor}}{% endif %}" title="Page {{ num }}">{{ num }}</a></li>
         {% endif %}


### PR DESCRIPTION
**Issue(s)**
Closes #1997

**Description**
1. Added the CSS styling to the `<a>` to get the full circle of the paging arrows clickable
2. Removed the link on the current page indicator since I did not understand why we would link to the same page.

**Deployment steps**:
Build static
