### PR TITLE
Set a specific version of uv to prevent cache invalidation

### DIFF
--- a/docker/Dockerfile.workers_web
+++ b/docker/Dockerfile.workers_web
@@ -15,7 +15,7 @@ FROM freesound:2025-03 AS freesound
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.9.15 /uv /uvx /bin/
 
 # Install specific dependencies needed for processing, building static files and for ssh
 RUN apt-get update \


### PR DESCRIPTION
Because we copied from uv:latest as almost the first command in the dockerfile, any time that uv released a new version our build cache would be invalidated and we'd need to run the build process again

This should prevent issues where performing a docker build unexpectedly builds everything from scrach again after a uv update.