### PR TITLE
Don't fail if similar_to parameter is invalid

### DIFF
--- a/apiv2/forms.py
+++ b/apiv2/forms.py
@@ -221,10 +221,16 @@ class SoundCombinedSearchFormAPI(forms.Form):
         if similar_to != "":
             # If it stars with '[', then we assume this is a serialized vector passed as target for similarity
             if similar_to.startswith("["):
-                similar_to = json.loads(similar_to)
+                try:
+                    similar_to = json.loads(similar_to)
+                except json.JSONDecodeError:
+                    raise BadRequestException("The 'similar_to' parameter is not a valid serialized vector")
             else:
                 # Otherwise, we assume it is a sound id and we pass it as integer
-                similar_to = int(similar_to)
+                try:
+                    similar_to = int(similar_to)
+                except ValueError:
+                    raise BadRequestException("The 'similar_to' parameter is not a valid sound ID")
         else:
             similar_to = None
         return similar_to

--- a/search/views.py
+++ b/search/views.py
@@ -107,6 +107,7 @@ def search_view_helper(request):
 
     # Run the query and post-process the results
     try:
+        query_params = {}  # Initialize to avoid reference before assignment if exception occurs at sqp.as_query_params()
         query_params = sqp.as_query_params()
 
         empty_query_cache_key = get_empty_query_cache_key(request, use_beta_features=use_beta_features)

--- a/utils/search/search_query_processor.py
+++ b/utils/search/search_query_processor.py
@@ -32,6 +32,7 @@ from luqum.pretty import prettify
 from sounds.models import Sound
 from utils.clustering_utilities import get_clusters_for_query, get_ids_in_cluster
 from utils.encryption import create_hash
+from utils.search import SearchEngineException
 from utils.search.search_sounds import allow_beta_search_features
 
 from .search_query_processor_options import (
@@ -680,13 +681,13 @@ class SearchQueryProcessor:
                 try:
                     similar_to = json.loads(similar_to)
                 except json.JSONDecodeError:
-                    similar_to = None
+                    raise SearchEngineException("The 'similar_to' parameter is not a valid serialized vector")
             else:
                 # Otherwise, we assume it is a sound id and we pass it as integer
                 try:
                     similar_to = int(similar_to)
                 except ValueError:
-                    similar_to = None
+                    raise SearchEngineException("The 'similar_to' parameter is not a valid sound ID")
         else:
             similar_to = None
 


### PR DESCRIPTION
If we think it's json but it isn't, or if it's not an int then don't fail

Reported at https://logserver.mtg.upf.edu/organizations/sentry/issues/4721/

This fix just treats an invalid value as if there was no value set. Not sure if we want to explicitly return that the value is invalid to the user?