### PR TITLE
If replying to a message that doesn't exist, redirect

### DIFF
--- a/messages/views.py
+++ b/messages/views.py
@@ -191,7 +191,8 @@ def new_message(request, username=None, message_id=None):
 
                 form = form_class(request, initial={"to": to, "subject": subject, "body": body})
             except Message.DoesNotExist:
-                pass
+                messages.add_message(request, messages.INFO, "That message doesn't exist")
+                return HttpResponseRedirect(reverse("messages"))
         elif username:
             form = form_class(request, initial={"to": username})
         else:


### PR DESCRIPTION
Doesn't make sense to reply to anything here

**Issue(s)**
Resolves https://logserver.mtg.upf.edu/organizations/sentry/issues/4704/

maybe we could do a toast notification too? "This message doesn't exist"