### PR TITLE
Remove option to delete user in forum moderation

### DIFF
--- a/forum/forms.py
+++ b/forum/forms.py
@@ -19,6 +19,7 @@
 #
 
 from django import forms
+from django.db import models
 
 from utils.forms import HtmlCleaningCharField
 from utils.spam import is_spam
@@ -87,11 +88,13 @@ class NewThreadForm(forms.Form):
         self.fields["subscribe"].widget.attrs["class"] = "bw-checkbox"
 
 
-MODERATION_CHOICES = [(x, x) for x in ["Approve", "Delete User", "Delete Post"]]
+class ModerationAction(models.TextChoices):
+    APPROVE = "Approve", "Approve"
+    DELETE_POST = "Delete Post", "Delete Post"
 
 
 class PostModerationForm(forms.Form):
-    action = forms.ChoiceField(choices=MODERATION_CHOICES, required=True, widget=forms.RadioSelect(), label="")
+    action = forms.ChoiceField(choices=ModerationAction.choices, required=True, widget=forms.RadioSelect(), label="")
     post = forms.IntegerField(widget=forms.widgets.HiddenInput)
 
     def __init__(self, *args, **kwargs):

--- a/templates/forum/moderate.html
+++ b/templates/forum/moderate.html
@@ -9,9 +9,7 @@
 {% block page-title %}Moderate forum posts ({{ post_list|length }}){% endblock %}
 
 {% block page-content %}
-<div>Below is a list of forum posts that require moderation. You can either approve or reject them individually. Also you have the option to
-    delete the whole corresponding user object if it is believed to be a spammer.
-</div>
+<div>Below is a list of forum posts that require moderation. You can either approve or reject them individually.</div>
 <div class="v-spacing-top-6">
     {% for post in post_list %}
         <div class="row">
@@ -36,5 +34,4 @@
     {% endfor %}
 </div>
 {% endblock %}
-
 


### PR DESCRIPTION
**Issue(s)**
Fixes https://github.com/MTG/freesound/issues/1926

**Description**
moderators reported that this button was too close to the other buttons and could accidentally result in deleting a valid user.

New "spammer" functionality as suggested in this ticket isn't added yet, maybe we can wait until that's ready to remove this? or if the moderators think it's OK to go ahead with this then we can release it