### PR TITLE
Prohibit the text "freesound" from appearing in usernames

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -188,6 +188,9 @@ def username_taken_by_other_user(username):
         bool: True if the username is already taken (not available), False otherwise
 
     """
+    # For security reasons, we don't allow the username "freesound" to be used anywhere in a username.
+    if "freesound" in username.lower():
+        return True
     try:
         User.objects.get(username__iexact=username)
     except User.DoesNotExist:

--- a/accounts/tests/test_user.py
+++ b/accounts/tests/test_user.py
@@ -120,6 +120,22 @@ class UserRegistrationAndActivation(TestCase):
         self.assertEqual(User.objects.filter(username=username).count(), 0)
         self.assertEqual(len(mail.outbox), 0)  # No email sent
 
+        # Try registration with reserved username
+        resp = self.client.post(
+            reverse("accounts-registration-modal"),
+            data={
+                "username": ["myFreeSoundName"],
+                "password1": ["123456!@"],
+                "accepted_tos": ["on"],
+                "email1": ["example@email.com"],
+                "email2": ["example@email.com"],
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "You cannot use this username to create an account")
+        self.assertEqual(User.objects.filter(username="myFreeSoundName").count(), 0)
+        self.assertEqual(len(mail.outbox), 0)  # No email sent
+
         # Try registration with different email addresses
         resp = self.client.post(
             reverse("accounts-registration-modal"),


### PR DESCRIPTION
This is for security reasons to prevent malicious users from pretending to act as us

**Issue(s)**
Fixes https://github.com/MTG/freesound/issues/2008
