### PR TITLE
Show a user's previous usernames to admins and moderators

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1323,6 +1323,10 @@ def account(request, username):
     else:
         num_sounds_pending = None
         num_mod_annotations = None
+    if request.user.has_perm("tickets.can_moderate") or request.user.is_staff:
+        old_usernames = list(user.old_usernames.order_by("-created").values_list("username", flat=True))
+    else:
+        old_usernames = None
 
     show_about = (
         (request.user == user)  # user is looking at own page
@@ -1359,6 +1363,7 @@ def account(request, username):
         "following_tags_modal_page": request.GET.get("followingTags", 1),
         "last_geotags_serialized": last_geotags_serialized,
         "user_downloads_public": settings.USER_DOWNLOADS_PUBLIC,
+        "old_usernames": old_usernames,
     }
     return render(request, "accounts/account.html", tvars)
 

--- a/templates/accounts/account.html
+++ b/templates/accounts/account.html
@@ -109,6 +109,17 @@
                     <div><a id="user-following-users-button" data-modal-activation-param="following" data-modal-content-url="{% url 'user-following-users' user.username %}?ajax=1&page={{ following_modal_page }}" href="javascript:void(0);">{% cache 43200 bw_user_profile_following_count user.id %}{{ following.count }}{% endcache %} following</a></div>
                     <div><a id="user-following-tags-button" data-modal-activation-param="followingTags" data-modal-content-url="{% url 'user-following-tags' user.username %}?ajax=1&page={{ following_tags_modal_page }}" href="javascript:void(0);">{% cache 43200 bw_user_profile_following_tags_count user.id %}{% with following_tags.count as following_tags_count %}{{ following_tags.count|bw_intcomma }} tag{{ following_tags_count|pluralize }} following{% endwith %}{% endcache %}</a></div>
                 </div>
+                {% if old_usernames %}
+                <div class="bw-profile__stats v-spacing-top-1 padding-left-4 padding-right-4">
+                    <div class="text-grey">
+                        <i class="bw-icon-flag h-spacing-right-1" title="Visible to moderators only"></i>
+                        Previous usernames:
+                        {% for old_username in old_usernames %}
+                            <span class="bg-white text-black border-grey-light padding-1 h-spacing-1 no-text-wrap display-inline-block">{{ old_username }}</span>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
                 {% if user_downloads_public %}
                 <div class="bw-profile__stats v-spacing-top-1 padding-left-4 padding-right-4">
                     <div><a data-toggle="modal-default" data-modal-content-url="{% url "user-downloaded-sounds" user.username %}?ajax=1" data-modal-activation-param="downloaded_sounds" href="javascript:void(0);" >{{ user.profile.num_sound_downloads }} sound{{ user.profile.num_sound_downloads|pluralize}} downloaded</a></div>


### PR DESCRIPTION
**Issue(s)**
Fixes https://github.com/MTG/freesound/issues/1993

**Description**
Show a user's previous usernames to admins and moderators
<img width="886" height="403" alt="Screenshot 2025-12-28 at 5 07 14 PM" src="https://github.com/user-attachments/assets/597ee827-a65c-4960-b754-19ab36948366" />
