### PR TITLE
Improve calculation of sorting target

### DIFF
--- a/utils/search/__init__.py
+++ b/utils/search/__init__.py
@@ -246,7 +246,7 @@ class SearchEngineBase:
         textual_query="",
         query_fields=None,
         query_filter="",
-        field_list=["id", "score"],
+        field_list=None,
         offset=0,
         current_page=None,
         num_sounds=settings.SOUNDS_PER_PAGE,

--- a/utils/search/backends/solr_common.py
+++ b/utils/search/backends/solr_common.py
@@ -104,16 +104,12 @@ class SolrQuery:
         filter_query: filter the returned results by this query
         field_list: ['field1', 'field2', ...] or ['*'] these fields will be returned, default: *
         """
+        if sort is not None and not isinstance(sort, (list, tuple)):
+            raise ValueError("sort must be a list of sort clauses or None")
         self.params["sort"] = ",".join(sort) if sort else sort
         self.params["start"] = start
         self.params["rows"] = rows
         self.params["fq"] = filter_query
-        self.params["sort"]
-        if sort is not None and "dist" in self.params["sort"]:
-            # If we are sorting by distance, make sure we also get the distance value returned as a field (note we use Solr rename field feature here)
-            if field_list is None:
-                field_list = []
-            field_list.append("dist:" + sort[0].replace(" desc", "").replace(" asc", ""))
         self.params["fl"] = ",".join(field_list) if field_list else field_list
 
     def add_facet_fields(self, *args):

--- a/utils/tests/test_solr_query.py
+++ b/utils/tests/test_solr_query.py
@@ -1,0 +1,80 @@
+import pytest
+from django.conf import settings
+
+from utils.search import SearchEngineException
+from utils.search.backends.solr555pysolr import Solr555PySolrSearchEngine
+from utils.search.backends.solr_common import SolrQuery
+
+
+def test_search_process_sort_default():
+    sort = Solr555PySolrSearchEngine().search_process_sort(settings.SEARCH_SOUNDS_SORT_OPTION_AUTOMATIC)
+    assert sort == ["score desc"]
+
+
+def test_search_process_sort_rating_highest_adds_num_ratings():
+    sort = Solr555PySolrSearchEngine().search_process_sort(settings.SEARCH_SOUNDS_SORT_OPTION_RATING_HIGHEST_FIRST)
+    assert sort == ["avg_rating desc", "num_ratings desc"]
+
+
+def test_search_process_sort_rating_lowest_adds_num_ratings():
+    sort = Solr555PySolrSearchEngine().search_process_sort(settings.SEARCH_SOUNDS_SORT_OPTION_RATING_LOWEST_FIRST)
+    assert sort == ["avg_rating asc", "num_ratings desc"]
+
+
+def test_set_query_options_sort_none():
+    query = SolrQuery()
+    query.set_query_options(field_list=["id"])
+    assert query.params["sort"] is None
+    assert query.params["fl"] == "id"
+
+
+def test_set_query_options_sort_explicit_none():
+    query = SolrQuery()
+    query.set_query_options(sort=None, field_list=["id"])
+    assert query.params["sort"] is None
+    assert query.params["fl"] == "id"
+
+
+def test_set_query_options_sort_dist_adds_field():
+    query = SolrQuery()
+    sort, dist_field = Solr555PySolrSearchEngine().search_process_sort_distance("bpm:0.5")
+    assert sort == ["dist(2,bpm_d,0.5) asc"]
+    assert dist_field == "dist:dist(2,bpm_d,0.5)"
+    query.set_query_options(sort=sort, field_list=["id", dist_field])
+    assert query.params["sort"] == ",".join(sort)
+    assert query.params["fl"] == "id,dist:dist(2,bpm_d,0.5)"
+
+
+def test_set_query_options_sort_dist_without_ordering():
+    query = SolrQuery()
+    sort = ["dist(2,foo,1.0)"]
+    dist_field = "dist:dist(2,foo,1.0)"
+    query.set_query_options(sort=sort, field_list=["id", dist_field])
+    assert query.params["sort"] == "dist(2,foo,1.0)"
+    assert query.params["fl"] == "id,dist:dist(2,foo,1.0)"
+
+
+def test_set_query_options_sort_type_error():
+    # If sort is not a list, raise a ValueError
+    query = SolrQuery()
+    with pytest.raises(ValueError):
+        query.set_query_options(sort="dist(2,foo,1.0) asc", field_list=["id"])
+
+
+def test_set_query_options_sort_score_desc_for_similarity():
+    # Similarity search always uses score desc and should not append extra fields.
+    query = SolrQuery()
+    query.set_query_options(sort=["score desc"], field_list=["id"])
+    assert query.params["sort"] == "score desc"
+    assert query.params["fl"] == "id"
+
+
+def test_search_process_sort_distance_multiple_fields():
+    sort, dist_field = Solr555PySolrSearchEngine().search_process_sort_distance("bpm:0.5,beat_count:2")
+    assert sort == ["dist(2,bpm_d,beat_count_i,0.5,2.0) asc"]
+    assert dist_field == "dist:dist(2,bpm_d,beat_count_i,0.5,2.0)"
+
+
+def test_search_process_sort_distance_invalid_target():
+    with pytest.raises(SearchEngineException):
+        Solr555PySolrSearchEngine().search_process_sort_distance("bpm:not-a-number")


### PR DESCRIPTION
Split sort field and target value into different methods, as they don't share any common functionality. Return sort field and additional field names as separate values to avoid string replacement.

Don't check for "dist" in params["sort"] unless it is non-None

**Issue(s)**
Fixes search test bug introduced in https://github.com/MTG/freesound/pull/2021