### PR TITLE
Collections url fix

### DIFF
--- a/fscollections/models.py
+++ b/fscollections/models.py
@@ -56,6 +56,44 @@ class Collection(models.Model):
     def get_collection_sounds_in_search_url(self):
         return f"{reverse('sounds-search')}?f=collection:{self.collection_filter_value()}"
 
+    @property
+    def url_kwargs(self):
+        return {"collection_id": self.id, "collection_name": slugify(self.name)}
+
+    def get_url(self, url_name="collection"):
+        return reverse(url_name, kwargs=self.url_kwargs)
+
+    def get_absolute_url(self):
+        return self.get_url()
+
+    @property
+    def edit_url(self):
+        return self.get_url("edit-collection")
+
+    @property
+    def delete_url(self):
+        return self.get_url("delete-collection")
+
+    @property
+    def download_url(self):
+        return self.get_url("download-collection")
+
+    @property
+    def licenses_url(self):
+        return self.get_url("collection-licenses")
+
+    @property
+    def add_sounds_modal_url(self):
+        return self.get_url("add-sounds-modal-collection")
+
+    @property
+    def add_maintainers_modal_url(self):
+        return self.get_url("add-maintainers-modal")
+
+    @property
+    def stats_section_url(self):
+        return self.get_url("collection-stats-section")
+
     def get_attribution(self, sound_qs=None):
         # If no queryset of sounds is provided, take it from the collection
         if sound_qs is None:

--- a/fscollections/urls.py
+++ b/fscollections/urls.py
@@ -4,25 +4,25 @@ from . import views
 
 urlpatterns = [
     path("", views.collections_for_user, name="your-collections"),
-    path("<str:collection_name>-<int:collection_id>/", views.collection, name="collection"),
+    path("<int:collection_id>-<slug:collection_name>/", views.collection, name="collection"),
     path("<int:sound_id>/add/", views.add_sound_to_collection, name="add-sound-to-collection"),
     path("create/", views.create_collection, name="create-collection"),
-    path("<str:collection_name>-<int:collection_id>/edit", views.edit_collection, name="edit-collection"),
-    path("<str:collection_name>-<int:collection_id>/delete", views.delete_collection, name="delete-collection"),
-    path("<str:collection_name>-<int:collection_id>/download/", views.download_collection, name="download-collection"),
-    path("<str:collection_name>-<int:collection_id>/licenses/", views.collection_licenses, name="collection-licenses"),
+    path("<int:collection_id>-<slug:collection_name>/edit", views.edit_collection, name="edit-collection"),
+    path("<int:collection_id>-<slug:collection_name>/delete", views.delete_collection, name="delete-collection"),
+    path("<int:collection_id>-<slug:collection_name>/download/", views.download_collection, name="download-collection"),
+    path("<int:collection_id>-<slug:collection_name>/licenses/", views.collection_licenses, name="collection-licenses"),
     path(
-        "<str:collection_name>-<int:collection_id>/addsoundsmodal",
+        "<int:collection_id>-<slug:collection_name>/addsoundsmodal",
         views.add_sounds_modal_for_collection_edit,
         name="add-sounds-modal-collection",
     ),
     path(
-        "<str:collection_name>-<int:collection_id>/addmaintainersmodal",
+        "<int:collection_id>-<slug:collection_name>/addmaintainersmodal",
         views.add_maintainer_modal,
         name="add-maintainers-modal",
     ),
     path(
-        "<str:collection_name>-<int:collection_id>/section/stats",
+        "<int:collection_id>-<slug:collection_name>/section/stats",
         views.collection_stats_section,
         name="collection-stats-section",
     ),

--- a/templates/collections/collection.html
+++ b/templates/collections/collection.html
@@ -12,15 +12,15 @@
     <div class="row no-gutters">
         <div class="col-lg-3 offset-lg-1 order-lg-last v-spacing-3">
             <section class="bw-profile__section_stats v-spacing-top-4 async-section"
-            data-async-section-content-url="{% url 'collection-stats-section' collection.name|slugify collection.id %}?ajax=1">
+            data-async-section-content-url="{{ collection.stats_section_url }}?ajax=1">
             <img width="12px" height="12px" src="{% static 'bw-frontend/public/bw_indicator.gif' %}">
         </section>
         <div class="v-spacing-top-4">
             {% if is_owner or is_maintainer%}
-            <a class="no-hover btn-secondary display-inline-block w-100 text-center v-spacing-top-3" href="{% url 'edit-collection' collection.name|slugify collection.id %}" title="Edit collection">Edit collection</a>
+            <a class="no-hover btn-secondary display-inline-block w-100 text-center v-spacing-top-3" href="{{ collection.edit_url }}" title="Edit collection">Edit collection</a>
             {% endif %}
             {% if collection.num_sounds > 0%}
-            <a class="no-hover btn-primary display-inline-block w-100 text-center v-spacing-top-3" href="{% url 'download-collection' collection.name|slugify collection.id %}" title="Download collection">Download Collection</a> 
+            <a class="no-hover btn-primary display-inline-block w-100 text-center v-spacing-top-3" href="{{ collection.download_url }}" title="Download collection">Download Collection</a> 
             {% endif %}
         </div>
     </div>    

--- a/templates/collections/display_collection.html
+++ b/templates/collections/display_collection.html
@@ -15,7 +15,7 @@
     {% endif %}
     <div class="between v-spacing-top-1">
         <div>
-            <h5><span class="bw-icon-bookmark h-spacing-1 text-light-grey"></span><a class="bw-link--black ellipsis" href="{% url "collection" collection.name|slugify collection.id %}" title="{{ collection.name }}">{{ collection.name }}</a></h5>
+            <h5><span class="bw-icon-bookmark h-spacing-1 text-light-grey"></span><a class="bw-link--black ellipsis" href="{{ collection.get_absolute_url }}" title="{{ collection.name }}">{{ collection.name }}</a></h5>
         </div>
     </div>
     <div class="between">
@@ -45,7 +45,7 @@
                 <span class="bw-icon-wave"></span> {{ collection.num_sounds|formatnumber }}
             </div>
             <div class="h-spacing-left-2" title="{{ collection.num_downloads|bw_intcomma }} download{{ collection.num_downloads|pluralize }}">
-                <a href="{% url 'download-collection' collection.name|slugify collection.id %}" class="bw-link--grey-light">
+                <a href="{{ collection.download_url }}" class="bw-link--grey-light">
                     <span class="bw-icon-download"></span> {{ collection.num_downloads|formatnumber }}
                 </a>
             </div>

--- a/templates/collections/edit_collection.html
+++ b/templates/collections/edit_collection.html
@@ -49,7 +49,7 @@
                     {% endif %}
                 {% users_selector form.collection_maintainers_objects%}
                 <div class="between v-spacing-top-4">
-                    <button class="btn-inverse" {% if collection.is_default_collection %}disabled="disabled" {% endif %} data-toggle="add-maintainers-modal" data-selected-maintainers-hidden-input-id="{{form.maintainers.id_for_label}}" data-modal-url="{% url 'add-maintainers-modal' collection.name|slugify collection.id %}?ajax=1" data-reload-on-success="false" title="Add maintainers" aria-label="Add maintainers">Add maintainers</button>
+                    <button class="btn-inverse" {% if collection.is_default_collection %}disabled="disabled" {% endif %} data-toggle="add-maintainers-modal" data-selected-maintainers-hidden-input-id="{{form.maintainers.id_for_label}}" data-modal-url="{{ collection.add_maintainers_modal_url }}?ajax=1" data-reload-on-success="false" title="Add maintainers" aria-label="Add maintainers">Add maintainers</button>
                     <button class="btn-inverse">{% bw_icon 'trash' %}Remove selected maintainers from collection</button>
                 </div>
             </div>
@@ -59,7 +59,7 @@
                 <div> {{form.collection_sounds.errors}}</div>
                 {% sounds_selector form.collection_sound_objects max_sounds=max_sounds_per_collection%}
                 <div class="between v-spacing-top-4">
-                    <button class="btn-inverse" data-toggle="add-sounds-modal" data-selected-sounds-hidden-input-id="{{ form.collection_sounds.id_for_label }}" data-modal-url="{% url 'add-sounds-modal-collection' collection.name|slugify collection.id %}">{% bw_icon 'plus' %}Add sounds</button>
+                    <button class="btn-inverse" data-toggle="add-sounds-modal" data-selected-sounds-hidden-input-id="{{ form.collection_sounds.id_for_label }}" data-modal-url="{{ collection.add_sounds_modal_url }}">{% bw_icon 'plus' %}Add sounds</button>
                     <button class="btn-inverse">{% bw_icon 'trash' %}Remove selected sounds from collection</button>
                 </div>
                 <div class="between v-spacing-top-5">
@@ -71,7 +71,7 @@
             {% endif %}
         </form>
         {% if is_owner%}
-            <button class="btn-secondary w-100 v-spacing-top-3" data-toggle="confirmation-modal" data-modal-confirmation-title="Are you sure you want to delete this collection?" data-modal-confirmation-help-text="Note that all sounds inside this collection will also be removed" data-modal-confirmation-url="{% url "delete-collection" collection.name|slugify collection.id %}">Delete Collection</button>
+            <button class="btn-secondary w-100 v-spacing-top-3" data-toggle="confirmation-modal" data-modal-confirmation-title="Are you sure you want to delete this collection?" data-modal-confirmation-help-text="Note that all sounds inside this collection will also be removed" data-modal-confirmation-url="{{ collection.delete_url }}">Delete Collection</button>
         {% endif %}
     </div>
 </div>

--- a/templates/collections/modal_add_maintainer.html
+++ b/templates/collections/modal_add_maintainer.html
@@ -11,7 +11,7 @@
 <div class="col-12">
     <div class="text-center">
         <h4 class="v-spacing-5">Add maintainer to collection</h4>
-        <form method="post" action="{% url 'add-maintainers-modal' collection.name|slugify collection.id %}?ajax=1" class = "disable-on-submit">{% csrf_token %}
+        <form method="post" action="{{ collection.add_maintainers_modal_url }}?ajax=1" class = "disable-on-submit">{% csrf_token %}
             {{form}}
             {% if not_found_msg %}
                 <div class="text-grey">{% bw_icon "notification" %}{{not_found_msg}}</div>


### PR DESCRIPTION
**Issue(s)**
The collection related urls only contained the id of a collection which is good for uniqueness but not as meaningful for the user.

**Description**
now the url bases look like this:
`"<str:collection_name>-<int:collection_id>/"`

The 'id' is still the collection resolver and if somehow you typed wrongly the name part of the url it finds the good one and redirects to the correct page. The implementation is done with a custom decorator which also fetches the collection object from the url.
