### PR TITLE
Don't build freesound image twice for web and celery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
             target: freesound
             platforms:
               - linux/amd64
+        image: freesound
         command: python manage.py runserver 0.0.0.0:8000
         volumes:
             - .:/code
@@ -91,12 +92,7 @@ services:
 
     # Worker for async tasks and sound processing
     worker_celery:
-        build:
-            context: ./
-            dockerfile: ./docker/Dockerfile.workers_web
-            target: freesound
-            platforms:
-              - linux/amd64
+        image: freesound
         init: true
         command: celery -A freesound worker --concurrency=2 -l info -Q async_tasks_queue,sound_processing_queue,sound_analysis_old_queue,clustering_queue
         volumes:


### PR DESCRIPTION
We can just build once and reuse the same image
