### PR TITLE
Fix N+1 query on profile in hot threads view

### DIFF
--- a/forum/views.py
+++ b/forum/views.py
@@ -189,7 +189,14 @@ def get_hot_threads(n=None, days=15):
             )
         )
         .select_related(
-            "author", "forum", "last_post", "last_post__author", "last_post__thread", "last_post__thread__forum"
+            "author",
+            "author__profile",
+            "forum",
+            "last_post",
+            "last_post__author",
+            "last_post__author__profile",
+            "last_post__thread",
+            "last_post__thread__forum",
         )[:n]
     )
 


### PR DESCRIPTION
Add missing author__profile and last_post__author__profile to select_related

**Issue(s)**
<!-- URL to issue(s) related to this PR -->

**Description**
<!-- Description of the contents of this PR -->

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
