### PR TITLE
Enable sort in similarity/neural queries, fix bitdepth filter error

### DIFF
--- a/search/views.py
+++ b/search/views.py
@@ -195,6 +195,8 @@ def search_view_helper(request):
                     "ip": get_client_ip(request),
                     "query": query_params["textual_query"],
                     "filter": query_params["query_filter"],
+                    "similar_to": query_params["similar_to"],
+                    "similar_to_similarity_space": query_params["similar_to_similarity_space"],
                     "username": request.user.username,
                     "page": query_params["current_page"],
                     "sort": query_params["sort"],
@@ -232,11 +234,13 @@ def search_view_helper(request):
             % json.dumps(
                 {
                     "ip": get_client_ip(request),
-                    "query": query_params.get("textual_query"),
-                    "filter": query_params.get("query_filter"),
+                    "query": query_params["textual_query"],
+                    "filter": query_params["query_filter"],
+                    "similar_to": query_params["similar_to"],
+                    "similar_to_similarity_space": query_params["similar_to_similarity_space"],
                     "username": request.user.username,
-                    "page": query_params.get("current_page"),
-                    "sort": query_params.get("sort"),
+                    "page": query_params["current_page"],
+                    "sort": query_params["sort"],
                     "url": sqp.get_url(),
                     "tags_mode": sqp.tags_mode_active(),
                 }

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -78,12 +78,7 @@
                             {% comment %}sorting options{% endcomment %}
                             <div class="col-4 right browse__search-overview-sorter">
                                 <div class="{% if sqp.map_mode_active %}display-none{% endif %}">
-                                    {% if not sqp.similar_to_active and not sqp.neural_search_mode_active %}
-                                        {% display_search_option "sort_by" %}
-                                    {% else %}
-                                        <span class="font-weight-normal text-light-grey d-none d-md-inline">{{ sqp.options.sort_by.label }}:</span>
-                                        <span><b>Similarity to target</b></span>
-                                    {% endif %}
+                                    {% display_search_option "sort_by" %}
                                 </div>
                             </div>
                         </div>

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -270,7 +270,7 @@
                                 {% if sqp.grid_mode_active %}
                                     <div class="row">
                                         {% for result in docs %}
-                                            <div class="col-6 col-lg-4">
+                                            <div class="col-6 col-lg-4" data-score="{{ result.score }}">
                                                 {% if sqp.display_as_packs_active %}
                                                     {% display_pack result.pack %}
                                                     <p class="text-grey text-right v-spacing-top-negative-2">
@@ -289,7 +289,7 @@
                                     </div>
                                 {% else %}
                                     {% for result in docs %}
-                                        <div class="bw-search__result">
+                                        <div class="bw-search__result" data-score="{{ result.score }}">
                                             {% if sqp.display_as_packs_active %}
                                                 {% display_pack_big result.pack %}
                                                 <div class="text-grey text-right v-spacing-top-negative-1 v-spacing-2 padding-right-1">

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -453,7 +453,12 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
         field and how it should treat it.
         """
         for raw_fieldname, solr_fieldname in SOLR_DYNAMIC_FIELDS_MAP.items():
-            query_filter = query_filter.replace(f"{raw_fieldname}:", f"{solr_fieldname}:")
+            updated_query_filter_parts = []
+            for part in query_filter.split(" "):
+                if part.startswith(raw_fieldname + ":"):
+                    part = part.replace(f"{raw_fieldname}:", f"{solr_fieldname}:")
+                updated_query_filter_parts.append(part)
+            query_filter = " ".join(updated_query_filter_parts)
         return query_filter
 
     def search_process_sort(self, sort, forum=False):

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -707,9 +707,14 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
                     config_options["vector_size"], config_options.get("l2_norm", False)
                 )
                 if vector is not None and vector_field_name is not None:
+                    # We define a query which matched child documents (similarity vectors), but returns the parent document (sound) and uses the
+                    # score of the child document (similarity vector) as the score of the parent document. This way we can apply filters and
+                    # sorting on the parent documents (sounds) but use the similarity score for ranking.
+
                     serialized_vector = ",".join([f"{n:.4f}" for n in vector])
+                    sim_search_pre_filter = f"preFilter=similarity_space:{similar_to_similarity_space} preFilter=content_type:{SOLR_DOC_CONTENT_TYPES['similarity_vector']}"
                     query.set_query(
-                        f"{{!vectorSimilarity f={vector_field_name} minReturn={similar_to_min_similarity} }}[{serialized_vector}]"
+                        f"{{!parent which=content_type:{SOLR_DOC_CONTENT_TYPES['sound']} score=max}}{{!vectorSimilarity f={vector_field_name} minReturn={similar_to_min_similarity} {sim_search_pre_filter}}}[{serialized_vector}]"
                     )
 
         # Process filter
@@ -718,44 +723,25 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
         )
 
         if similar_to is not None:
-            # If doing a similarity query, the filter needs to be further processed so we perform filters based on parent documents
-            query_filter_modified = [
-                f"content_type:{SOLR_DOC_CONTENT_TYPES['similarity_vector']}",
-                f"similarity_space:{similar_to_similarity_space}",
-            ]  # Add basic filter to only get similarity vectors from selected similarity space and from child documents (this is because root documents can also have sim vectors)
-            top_similar_sounds_as_filter = query.as_kwargs()["q"]
+            # If the similarity target is specified as a sound ID, add a filter so the sound itself is not included in the results
             try:
-                # Also if target is specified as a sound ID, remove it from the list so it is not returned as a result
-                query_filter_modified.append(f"-_nest_parent_:{int(similar_to)}")
-            except TypeError:
-                # Target is not a sound id, so we don't need to add the filter
+                int_similar_to = int(similar_to)
+                query_filter = [query_filter, f"-id:{int(similar_to)}"]
+            except (TypeError, ValueError):
+                # Sound ID is not an integer, do not add any extra filter
                 pass
-
-            # Also add the NN query as a filter so we don't get past the first similar_to_min_similarity results when applying extra filters
-            query_filter_modified += [top_similar_sounds_as_filter]
-
-            # Now add the usual filter, but wrap it in "child of" modifier so it filters on parent documents instead of child documents
-            if query_filter:
-                query_filter_modified.append(
-                    f'{{!child of="content_type:{SOLR_DOC_CONTENT_TYPES["sound"]}"}}({query_filter})'
-                )
-
-            # Replace query_filter with the modified version
-            query_filter = query_filter_modified
 
         # Set query options
         if current_page is not None:
             offset = (current_page - 1) * num_sounds
-        if similar_to is None and sorting_target is not None:
+
+        if sorting_target is not None:
             # Custom sorting by distance to target
             sort, dist_field = self.search_process_sort_distance(sorting_target)
             field_list.append(dist_field)
-        elif similar_to is None:
-            # If not doing a similarity search, turn the param into a solr sort clause
-            sort = self.search_process_sort(sort)
         else:
-            # This is a similarity search, we always sort by score
-            sort = ["score desc"]
+            sort = self.search_process_sort(sort)
+
         query.set_query_options(
             start=offset,
             rows=num_sounds,
@@ -773,9 +759,6 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
             for field in facet_fields:
                 json_facets[field] = SOLR_SOUND_FACET_DEFAULT_OPTIONS.copy()
                 json_facets[field]["field"] = field
-                if similar_to is not None:
-                    # In similarity search we need to set the "domain" facet option to apply them to the parent documents of the child documents we will match
-                    json_facets[field]["domain"] = {"blockParent": f"content_type:{SOLR_DOC_CONTENT_TYPES['sound']}"}
             for field_name, extra_options in facets.items():
                 json_facets[get_solr_facet_fieldname_from_freesound_fieldname(field_name)].update(extra_options)
             query.set_facet_json_api(json_facets)
@@ -784,7 +767,7 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
         if group_by_pack:
             if USE_COLLAPSE_AND_EXPAND_QUERY_PARSER:
                 current_filter = query.params.get("fq", "")
-                field_name = "pack_grouping" if similar_to is None else "pack_grouping_child"
+                field_name = "pack_grouping"
                 group_by_pack_filter = f"{{!collapse field={field_name} sort='created desc' nullPolicy=expand}}"
                 if current_filter:
                     if type(current_filter) is list:
@@ -862,8 +845,7 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
             # Solr uses a string for the id field, but django uses an int. Convert the id in all results to int
             # before use to avoid issues
             for d in results.docs:
-                # Get the sound ids from the results
-                d["id"] = int(d["id"] if similar_to is None else d["id"].split("/")[0])
+                d["id"] = int(d["id"])
 
             return SearchResults(
                 docs=results.docs,

--- a/utils/search/search_query_processor.py
+++ b/utils/search/search_query_processor.py
@@ -88,13 +88,12 @@ class SearchQueryProcessor:
                 query_param_name="s",
                 label="Sort",
                 choices=[(option, option) for option in settings.SEARCH_SOUNDS_SORT_OPTIONS_WEB],
-                should_be_disabled=lambda option: (
-                    bool(option.sqp.get_option_value_to_apply("similar_to"))
-                    or option.sqp.get_option_value_to_apply("neural_search_mode")
-                ),
                 get_default_value=lambda option: (
                     settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST
-                    if option.sqp.get_option_value_to_apply("query") == ""
+                    if (
+                        option.sqp.get_option_value_to_apply("query") == ""
+                        and not option.sqp.get_option_value_to_apply("similar_to")
+                    )
                     else settings.SEARCH_SOUNDS_SORT_DEFAULT
                 ),
             ),
@@ -425,6 +424,11 @@ class SearchQueryProcessor:
         # Pass the reference to the SearchQueryProcessor object to all search options, and load the search option values from the request
         for option in self.options.values():
             option.set_search_query_processor(self)
+            option.load_value()
+
+        # Do a second pass of loading values as some default values might depend on the values of other options, so we need to have all options
+        # loaded before being able to load the value of some of them.
+        for option in self.options.values():
             option.load_value()
 
         # Some of the filters included in the search query (in f_parsed) might belong to filters which are added by SearchOption objects, but some others might
@@ -837,9 +841,6 @@ class SearchQueryProcessor:
             else:
                 return similar_to
         return similar_to
-
-    def neural_search_mode_active(self):
-        return self.options["neural_search_mode"].value_to_apply
 
     def compute_clusters_active(self):
         return self.options["compute_clusters"].value_to_apply

--- a/utils/tests/test_search_query_processor.py
+++ b/utils/tests/test_search_query_processor.py
@@ -262,14 +262,14 @@ class SearchQueryProcessorTests(TestCase):
         # With similar to option
         sqp, url = self.run_fake_search_query_processor(params={"st": "1234"})  # Passing similarity target as sound ID
         self.assertExpectedParams(
-            sqp.as_query_params(), {"similar_to": "1234", "sort": settings.SEARCH_SOUNDS_SORT_DEFAULT}
+            sqp.as_query_params(), {"similar_to": 1234, "sort": settings.SEARCH_SOUNDS_SORT_DEFAULT}
         )
         self.assertGetUrlAsExpected(sqp, url)
         sqp, url = self.run_fake_search_query_processor(
             params={"st": "[1.34,3.56,5.78]"}
         )  # Passing similarity target as sound ID
         self.assertExpectedParams(
-            sqp.as_query_params(), {"similar_to": "[1.34, 3.56, 5.78]", "sort": settings.SEARCH_SOUNDS_SORT_DEFAULT}
+            sqp.as_query_params(), {"similar_to": [1.34, 3.56, 5.78], "sort": settings.SEARCH_SOUNDS_SORT_DEFAULT}
         )
         self.assertGetUrlAsExpected(sqp, url)
 
@@ -288,7 +288,7 @@ class SearchQueryProcessorTests(TestCase):
         self.assertExpectedParams(
             sqp.as_query_params(),
             {
-                "similar_to": "[1.34, 3.56, 5.78]",
+                "similar_to": [1.34, 3.56, 5.78],
                 "similar_to_similarity_space": settings.SIMILARITY_SPACE_LAION_CLAP,
                 "textual_query": "test query",
                 "sort": settings.SEARCH_SOUNDS_SORT_DEFAULT,

--- a/utils/tests/test_search_query_processor.py
+++ b/utils/tests/test_search_query_processor.py
@@ -44,7 +44,7 @@ class SearchQueryProcessorTests(TestCase):
         "query_filter": "",
         "similar_to": None,
         "similar_to_similarity_space": settings.SIMILARITY_SPACE_DEFAULT,
-        "sort": settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST,  # Empty query should sort by date added, so use this as expected default
+        "sort": settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST,  # Empty query should sort by date added, so use this as expected default because most of the tests will be like that
         "textual_query": "",
     }
 
@@ -261,12 +261,16 @@ class SearchQueryProcessorTests(TestCase):
 
         # With similar to option
         sqp, url = self.run_fake_search_query_processor(params={"st": "1234"})  # Passing similarity target as sound ID
-        self.assertExpectedParams(sqp.as_query_params(), {"similar_to": 1234})
+        self.assertExpectedParams(
+            sqp.as_query_params(), {"similar_to": "1234", "sort": settings.SEARCH_SOUNDS_SORT_DEFAULT}
+        )
         self.assertGetUrlAsExpected(sqp, url)
         sqp, url = self.run_fake_search_query_processor(
             params={"st": "[1.34,3.56,5.78]"}
         )  # Passing similarity target as sound ID
-        self.assertExpectedParams(sqp.as_query_params(), {"similar_to": [1.34, 3.56, 5.78]})
+        self.assertExpectedParams(
+            sqp.as_query_params(), {"similar_to": "[1.34, 3.56, 5.78]", "sort": settings.SEARCH_SOUNDS_SORT_DEFAULT}
+        )
         self.assertGetUrlAsExpected(sqp, url)
 
         # Using a pack filter, sounds should not be grouped by pack
@@ -284,12 +288,24 @@ class SearchQueryProcessorTests(TestCase):
         self.assertExpectedParams(
             sqp.as_query_params(),
             {
-                "similar_to": [1.34, 3.56, 5.78],
+                "similar_to": "[1.34, 3.56, 5.78]",
                 "similar_to_similarity_space": settings.SIMILARITY_SPACE_LAION_CLAP,
                 "textual_query": "test query",
-                "sort": settings.SEARCH_SOUNDS_SORT_OPTION_AUTOMATIC,
+                "sort": settings.SEARCH_SOUNDS_SORT_DEFAULT,
             },
         )
+
+    def test_search_query_processor_default_sort_options(self):
+        # Test that, if unspecified, the sort option is the default one, except the case in which
+        # there is an empty query and no similar_to parameter set.
+        sqp, _ = self.run_fake_search_query_processor(params={"q": "test"})
+        self.assertEqual(sqp.options["sort_by"].value_to_apply, settings.SEARCH_SOUNDS_SORT_DEFAULT)
+
+        sqp, _ = self.run_fake_search_query_processor(params={"q": ""})
+        self.assertEqual(sqp.options["sort_by"].value_to_apply, settings.SEARCH_SOUNDS_SORT_OPTION_DATE_NEW_FIRST)
+
+        sqp, url = self.run_fake_search_query_processor(params={"q": "", "st": "1234"})
+        self.assertEqual(sqp.options["sort_by"].value_to_apply, settings.SEARCH_SOUNDS_SORT_DEFAULT)
 
     def test_search_query_processor_disabled_options(self):
         # Test that some search options are marked as disabled depending on the state of some other options
@@ -298,10 +314,6 @@ class SearchQueryProcessorTests(TestCase):
         # query if similarity on
         sqp, _ = self.run_fake_search_query_processor(params={"st": "1234"})
         self.assertTrue(sqp.options["query"].disabled)
-
-        # sort if similarity on
-        sqp, _ = self.run_fake_search_query_processor(params={"st": "1234"})
-        self.assertTrue(sqp.options["sort_by"].disabled)
 
         # group_by_pack if display_as_packs or map_mode
         sqp, _ = self.run_fake_search_query_processor(params={"dp": "1"})


### PR DESCRIPTION
**Description**
This PR enables the sorting option for similarity/neural search queries.
The way it is implemented is that vector-based queries now return the parent documents instead of the child ones, and therefore sorting/filtering/faceting can be applied just as it it was a normal query. In the past, when solr-based similarity search was added, it was implemented in a different way because I did not know that using the `score=max` param to `{!parent---}` would copy the score of the matching child documents (sim vectors) to the parents (and therefore be able to sort by similarity or return the similarity value in the API). With that option, the whole logic becomes much simpler.  There is a drawback though, which is that queries seem to be slower. I'm unsure about why so this will need further investigation.

This PR also embeds the search result score in the HTML responses, as a `data-score` attribute of the `div`s wrapping sound results. This can be useful for our own testing and debugging purposes.