### PR TITLE
create download link on demand and backfill more slowly

### DIFF
--- a/sounds/management/commands/create_cdn_symlinks.py
+++ b/sounds/management/commands/create_cdn_symlinks.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 
 from django.conf import settings
 
@@ -24,13 +25,27 @@ def get_existing_symlinks():
     return existing
 
 
+CONSECUTIVE_ERROR_LIMIT = 20
+
+
 class Command(LoggingBaseCommand):
     help = "Create CDN symlinks for all processed sounds that don't have one yet."
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--sleep",
+            type=float,
+            default=0.0,
+            help="Seconds to sleep between each sound to throttle I/O load (e.g. --sleep=0.01).",
+        )
+
     def handle(self, *args, **options):
         self.log_start()
+        sleep_seconds = options["sleep"]
         num_created = 0
         num_skipped = 0
+        num_errors = 0
+        consecutive_errors = 0
 
         existing = get_existing_symlinks()
         console_logger.info(f"Found {len(existing)} existing CDN symlinks")
@@ -43,17 +58,31 @@ class Command(LoggingBaseCommand):
             symlink_name = f"{sound.id}.{sound.type}"
             if symlink_name in existing:
                 num_skipped += 1
+                consecutive_errors = 0
             else:
                 try:
                     if create_cdn_symlink(sound):
                         num_created += 1
                     else:
                         num_skipped += 1
+                    consecutive_errors = 0
                 except Exception:
-                    num_skipped += 1
+                    num_errors += 1
+                    consecutive_errors += 1
+                    console_logger.exception(f"Error creating symlink for sound {sound.id}")
+                    if consecutive_errors >= CONSECUTIVE_ERROR_LIMIT:
+                        console_logger.error(
+                            f"Aborting: {consecutive_errors} consecutive errors — likely a systemic issue"
+                        )
+                        break
 
-            if (count + 1) % 10000 == 0:
-                console_logger.info(f"[{count + 1}/{total}] Created {num_created}, skipped {num_skipped}")
+            if (count + 1) % 5000 == 0:
+                console_logger.info(
+                    f"[{count + 1}/{total}] Created {num_created}, skipped {num_skipped}, errors {num_errors}"
+                )
 
-        console_logger.info(f"Done! Created {num_created} symlinks, skipped {num_skipped}")
-        self.log_end({"created": num_created, "skipped": num_skipped})
+            if sleep_seconds:
+                time.sleep(sleep_seconds)
+
+        console_logger.info(f"Done! Created {num_created}, skipped {num_skipped}, errors {num_errors}")
+        self.log_end({"created": num_created, "skipped": num_skipped, "errors": num_errors})

--- a/utils/cdn.py
+++ b/utils/cdn.py
@@ -21,6 +21,11 @@ def generate_cdn_download_url(sound):
     if not os.path.exists(sound_path):
         return None
 
+    # Lazy materialization: ensures a symlink exists for any sound being downloaded,
+    # so the backfill command can run leisurely (or be skipped for cold sounds).
+    # Remove this call once backfill is complete and symlink coverage is verified.
+    create_cdn_symlink(sound)
+
     expires = int(time.time()) + settings.CDN_DOWNLOAD_URL_LIFETIME
     folder_id = str(sound.id // 1000)
     uri = f"/sounds/{folder_id}/{sound.id}.{sound.type}"
@@ -39,15 +44,17 @@ def create_cdn_symlink(sound):
 
     The symlink hides the user_id from the CDN URL. Uses relative paths so the
     symlink works across different mount points (web vs CDN container).
+    Idempotent: fast-path returns immediately if the symlink already exists,
+    so it is safe to call on every download.
     """
-    sound_path = sound.locations("path")
-    if not os.path.exists(sound_path):
-        return False
-
     folder_id = str(sound.id // 1000)
     symlink_dir = os.path.join(settings.CDN_SOUNDS_SYMLINKS_PATH, folder_id)
     symlink_path = os.path.join(symlink_dir, f"{sound.id}.{sound.type}")
 
+    if os.path.lexists(symlink_path):
+        return False
+
+    sound_path = sound.locations("path")
     os.makedirs(symlink_dir, exist_ok=True)
     # Relative target: ../../sounds/{folder}/{sound_id}_{user_id}.{type}
     target = os.path.relpath(sound_path, symlink_dir)

--- a/utils/tests/test_cdn.py
+++ b/utils/tests/test_cdn.py
@@ -26,8 +26,9 @@ class GenerateCdnDownloadUrlTestCase(TestCase):
         self.sound.processing_state = "OK"
         self.sound.save()
 
+    @mock.patch("utils.cdn.create_cdn_symlink")
     @mock.patch("utils.cdn.os.path.exists", return_value=True)
-    def test_generates_signed_url_with_correct_params(self, mock_exists):
+    def test_generates_signed_url_with_correct_params(self, mock_exists, mock_create_symlink):
         url = generate_cdn_download_url(self.sound)
         self.assertIsNotNone(url)
         self.assertIn("cdn.freesound.org", url)
@@ -35,9 +36,10 @@ class GenerateCdnDownloadUrlTestCase(TestCase):
         self.assertIn("expires=", url)
         self.assertIn("filename=", url)
 
+    @mock.patch("utils.cdn.create_cdn_symlink")
     @mock.patch("utils.cdn.os.path.exists", return_value=True)
     @mock.patch("utils.cdn.time.time", return_value=1700000000)
-    def test_md5_matches_nginx_secure_link_format(self, mock_time, mock_exists):
+    def test_md5_matches_nginx_secure_link_format(self, mock_time, mock_exists, mock_create_symlink):
         """Verify the generated MD5 matches what nginx secure_link would compute."""
         url = generate_cdn_download_url(self.sound)
 
@@ -64,8 +66,9 @@ class GenerateCdnDownloadUrlTestCase(TestCase):
         url = generate_cdn_download_url(self.sound)
         self.assertIsNone(url)
 
+    @mock.patch("utils.cdn.create_cdn_symlink")
     @mock.patch("utils.cdn.os.path.exists", return_value=True)
-    def test_url_contains_folder_and_sound_id_without_user_id(self, mock_exists):
+    def test_url_contains_folder_and_sound_id_without_user_id(self, mock_exists, mock_create_symlink):
         url = generate_cdn_download_url(self.sound)
         path = url.split("?")[0]
         folder_id = str(self.sound.id // 1000)


### PR DESCRIPTION
We found that the backfill is taking a long time and causing lots of disk io, so add some sleeps so that it is a bit nicer to the server. Also create symlink on download demand so that we can deploy sooner

**Issue(s)**
<!-- URL to issue(s) related to this PR -->

**Description**
<!-- Description of the contents of this PR -->

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
