### PR TITLE
Add timeAllowed limit for Solr queries, Use a separate request handler for similarity searches 

### DIFF
--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -1172,7 +1172,14 @@ SEARCH_FORUM_SORT_DEFAULT = SEARCH_FORUM_SORT_OPTION_THREAD_DATE_FIRST
 SEARCH_ENGINE_BACKEND_CLASS = "utils.search.backends.solr9pysolr.Solr9PySolrSearchEngine"
 SOLR5_BASE_URL = "http://search:8983/solr"
 SOLR9_BASE_URL = "http://search:8983"
-SEARCH_SOLR_TIMEOUT_SECONDS = 5
+# If a request to solr takes longer than this, give up
+SEARCH_SOLR_TIMEOUT_SECONDS = 2.0
+# Tell solr that it shouldn't take more than this on a search
+# it should return after this long (before our timeout)
+SEARCH_SOLR_TIME_ALLOWED_MS = 1000
+# Similarity searches can take a bit longer
+SEARCH_SOLR_SIMILARITY_TIMEOUT_SECONDS = 4.0
+SEARCH_SOLR_SIMILARITY_TIME_ALLOWED_MS = 3000
 
 SIMILARITY_SPACE_LAION_CLAP = "laion_clap"
 SIMILARITY_FREESOUND_CLASSIC = "freesound_classic"

--- a/search/solrapi.py
+++ b/search/solrapi.py
@@ -200,6 +200,9 @@ class SolrManagementAPI:
         if copyfields:
             self.create_copyfields(copyfields)
 
+        for handler in schema_definition.get("requestHandlers", []):
+            self.upsert_request_handler(handler["name"], handler["class"], defaults=handler.get("defaults"))
+
     def collection_exists(self):
         if self.logging_verbose >= 1:
             logger.info(f"Checking if collection {self.collection} exists")
@@ -236,6 +239,36 @@ class SolrManagementAPI:
         self._make_post(url, data)
         if self.logging_verbose >= 1:
             logger.info(f"Disabled auto data driven schema for collection {self.collection}")
+
+    def upsert_request_handler(self, name, class_name, defaults=None):
+        """Idempotently add or update a Solr request handler.
+
+        Tries add-requesthandler first. Solr's Config API returns HTTP 200 with
+        an errorMessages payload (rather than 4xx) when a command is rejected —
+        e.g. when the handler already exists — so we detect that and retry with
+        update-requesthandler. No separate GET, so no TOCTOU window between the
+        existence check and the write.
+        """
+        handler_def = {"name": name, "class": class_name}
+        if defaults is not None:
+            handler_def["defaults"] = defaults
+
+        url = urljoin(self.base_url, f"api/collections/{self.collection}/config")
+        body = self._make_post(url, {"add-requesthandler": handler_def})
+        if not body.get("errorMessages"):
+            if self.logging_verbose >= 1:
+                logger.info(f"add-requesthandler {name} on collection {self.collection}")
+            return
+
+        # Add was rejected — most likely because the handler already exists.
+        # Retry as update; if that also reports errorMessages, surface the failure.
+        if self.logging_verbose >= 2:
+            logger.info(f"add-requesthandler {name} rejected by Solr ({body['errorMessages']}); retrying as update")
+        body = self._make_post(url, {"update-requesthandler": handler_def})
+        if body.get("errorMessages"):
+            raise SolrAPIError(f"Failed to upsert request handler {name}: {body['errorMessages']}")
+        if self.logging_verbose >= 1:
+            logger.info(f"update-requesthandler {name} on collection {self.collection}")
 
     def delete_collection(self):
         """Delete a Solr collection."""

--- a/search/test_solrapi.py
+++ b/search/test_solrapi.py
@@ -1,0 +1,66 @@
+from unittest import mock
+
+import pytest
+
+from search.solrapi import SolrAPIError, SolrManagementAPI
+
+
+def _mock_response(json_payload):
+    resp = mock.Mock()
+    resp.json.return_value = json_payload
+    resp.raise_for_status = mock.Mock()
+    return resp
+
+
+@mock.patch("search.solrapi.requests")
+def test_upsert_request_handler_adds_when_absent(mock_requests):
+    # Successful add → 200 with no errorMessages.
+    mock_requests.post.return_value = _mock_response({})
+
+    api = SolrManagementAPI("http://search:8983", "freesound1234")
+    api.upsert_request_handler("/select_similarity", "solr.SearchHandler")
+
+    assert mock_requests.post.call_count == 1
+    _, kwargs = mock_requests.post.call_args
+    assert kwargs["json"] == {"add-requesthandler": {"name": "/select_similarity", "class": "solr.SearchHandler"}}
+
+
+@mock.patch("search.solrapi.requests")
+def test_upsert_request_handler_falls_back_to_update_on_duplicate(mock_requests):
+    # Solr returns 200 with errorMessages when the handler already exists; we
+    # then retry with update, which succeeds.
+    mock_requests.post.side_effect = [
+        _mock_response({"errorMessages": [{"add-requesthandler": "'/select_similarity' already exists"}]}),
+        _mock_response({}),
+    ]
+
+    api = SolrManagementAPI("http://search:8983", "freesound1234")
+    api.upsert_request_handler("/select_similarity", "solr.SearchHandler")
+
+    assert mock_requests.post.call_count == 2
+    second_call_json = mock_requests.post.call_args_list[1].kwargs["json"]
+    assert second_call_json == {"update-requesthandler": {"name": "/select_similarity", "class": "solr.SearchHandler"}}
+
+
+@mock.patch("search.solrapi.requests")
+def test_upsert_request_handler_raises_when_update_also_fails(mock_requests):
+    # Both add and update return errorMessages → surface as SolrAPIError.
+    mock_requests.post.side_effect = [
+        _mock_response({"errorMessages": [{"add-requesthandler": "boom"}]}),
+        _mock_response({"errorMessages": [{"update-requesthandler": "boom too"}]}),
+    ]
+
+    api = SolrManagementAPI("http://search:8983", "freesound1234")
+    with pytest.raises(SolrAPIError):
+        api.upsert_request_handler("/select_similarity", "solr.SearchHandler")
+
+
+@mock.patch("search.solrapi.requests")
+def test_upsert_request_handler_includes_defaults(mock_requests):
+    mock_requests.post.return_value = _mock_response({})
+
+    api = SolrManagementAPI("http://search:8983", "freesound1234")
+    api.upsert_request_handler("/select_similarity", "solr.SearchHandler", defaults={"defType": "dismax"})
+
+    _, kwargs = mock_requests.post.call_args
+    assert kwargs["json"]["add-requesthandler"]["defaults"] == {"defType": "dismax"}

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -687,6 +687,8 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
                 if similar_to is not None
                 else settings.SEARCH_SOLR_TIMEOUT_SECONDS
             )
+        # Use a separate request handler for similarity to have separate metrics
+        search_handler = "select_similarity" if similar_to is not None else None
 
         if field_list is None:
             # We generally only want the sound IDs of the results as we load data from DB
@@ -890,7 +892,9 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
                 if not group_counts_as_one_in_facets and "json.facet" in query_as_kwargs:
                     facets_kwarg = query_as_kwargs["json.facet"]
                     query_as_kwargs["json.facet"] = {}
-                results = self.get_sounds_index(timeout=timeout).search(**query_as_kwargs)
+                results = self.get_sounds_index(timeout=timeout, search_handler=search_handler).search(
+                    **query_as_kwargs
+                )
 
                 # Now make the second query in which we get the facets and the total number of results, and remove the "collapse" filter.
                 fq = [fq_element for fq_element in query_as_kwargs["fq"] if "collapse field" not in fq_element]
@@ -899,13 +903,17 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
                 query_as_kwargs["expand"] = False
                 if not group_counts_as_one_in_facets and facets_kwarg is not None:
                     query_as_kwargs["json.facet"] = facets_kwarg
-                results_extra_query = self.get_sounds_index(timeout=timeout).search(**query_as_kwargs)
+                results_extra_query = self.get_sounds_index(timeout=timeout, search_handler=search_handler).search(
+                    **query_as_kwargs
+                )
                 if not group_counts_as_one_in_facets:
                     results.facets = results_extra_query.facets
                 results.non_grouped_number_of_results = results_extra_query.num_found
             else:
                 # If we are not using collapse and expand query parser (and/or not grouping by pack), just run the query.
-                results = self.get_sounds_index(timeout=timeout).search(**query_as_kwargs)
+                results = self.get_sounds_index(timeout=timeout, search_handler=search_handler).search(
+                    **query_as_kwargs
+                )
 
             # Facets returned in results use the corresponding solr fieldnames as keys. We want to convert them to the
             # original fieldnames so that the rest of the code can use them without knowing about the solr fieldnames.

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -643,6 +643,7 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
                 offset=(current_page - 1) * page_size,
                 num_sounds=page_size,
                 timeout=60,
+                enforce_time_allowed=False,
             )
             solr_ids += [int(element["id"]) for element in response.docs]
             solr_count = response.num_found
@@ -669,9 +670,23 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
         similar_to=None,
         similar_to_min_similarity=settings.SIMILARITY_MIN_THRESHOLD,
         similar_to_similarity_space=settings.SIMILARITY_SPACE_DEFAULT,
-        timeout=settings.SEARCH_SOLR_TIMEOUT_SECONDS,
+        timeout=None,
+        enforce_time_allowed=True,
     ):
-        query = SolrQuery()
+        # Tell solr to stop after this time. Give similarity a bit more time
+        if not enforce_time_allowed:
+            query = SolrQuery(time_allowed=None)
+        elif similar_to is not None:
+            query = SolrQuery(time_allowed=settings.SEARCH_SOLR_SIMILARITY_TIME_ALLOWED_MS)
+        else:
+            query = SolrQuery(time_allowed=settings.SEARCH_SOLR_TIME_ALLOWED_MS)
+        # Just in case timeAllowed above doesn't stick
+        if timeout is None:
+            timeout = (
+                settings.SEARCH_SOLR_SIMILARITY_TIMEOUT_SECONDS
+                if similar_to is not None
+                else settings.SEARCH_SOLR_TIMEOUT_SECONDS
+            )
 
         if field_list is None:
             # We generally only want the sound IDs of the results as we load data from DB
@@ -940,7 +955,7 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
     def get_num_sim_vectors_indexed_per_similarity_space(self):
         results = {}
         for similarity_space_name in settings.SIMILARITY_SPACES.keys():
-            query = SolrQuery()
+            query = SolrQuery(time_allowed=None)
             filter_query = f'similarity_space:"{similarity_space_name}" content_type:"v"'
             query.set_query("*:*")
             query.set_query_options(start=0, rows=1, field_list=["id"], filter_query=filter_query)
@@ -964,7 +979,7 @@ class Solr555PySolrSearchEngine(SearchEngineBase):
             solr_count = None
             current_page = 1
             while solr_count is None or len(solr_ids) < solr_count:
-                query = SolrQuery()
+                query = SolrQuery(time_allowed=None)
                 filter_query = f'similarity_space:"{similarity_space_name}" content_type:"v"'
                 query.set_query("*:*")
                 query.set_query_options(

--- a/utils/search/backends/solr9pysolr.py
+++ b/utils/search/backends/solr9pysolr.py
@@ -41,13 +41,16 @@ class Solr9PySolrSearchEngine(solr555pysolr.Solr555PySolrSearchEngine):
         self.forum_index_url = forum_index_url
         self.solr_base_url = settings.SOLR9_BASE_URL
 
-    def get_sounds_index(self, timeout=settings.SEARCH_SOLR_TIMEOUT_SECONDS):
+    def get_sounds_index(self, timeout=settings.SEARCH_SOLR_TIMEOUT_SECONDS, search_handler=None):
+        # Only forward search_handler when set
+        extra = {"search_handler": search_handler} if search_handler is not None else {}
         return pysolr.Solr(
             self.sounds_index_url,
             encoder=solr555pysolr.FreesoundSoundJsonEncoder(),
             results_cls=solr555pysolr.SolrResponseInterpreter,
             always_commit=True,
             timeout=timeout,
+            **extra,
         )
 
     def get_forum_index(self, timeout=settings.SEARCH_SOLR_TIMEOUT_SECONDS):

--- a/utils/search/backends/solr9pysolr.py
+++ b/utils/search/backends/solr9pysolr.py
@@ -42,26 +42,22 @@ class Solr9PySolrSearchEngine(solr555pysolr.Solr555PySolrSearchEngine):
         self.solr_base_url = settings.SOLR9_BASE_URL
 
     def get_sounds_index(self, timeout=settings.SEARCH_SOLR_TIMEOUT_SECONDS):
-        if self.sounds_index is None:
-            self.sounds_index = pysolr.Solr(
-                self.sounds_index_url,
-                encoder=solr555pysolr.FreesoundSoundJsonEncoder(),
-                results_cls=solr555pysolr.SolrResponseInterpreter,
-                always_commit=True,
-                timeout=timeout,
-            )
-        return self.sounds_index
+        return pysolr.Solr(
+            self.sounds_index_url,
+            encoder=solr555pysolr.FreesoundSoundJsonEncoder(),
+            results_cls=solr555pysolr.SolrResponseInterpreter,
+            always_commit=True,
+            timeout=timeout,
+        )
 
     def get_forum_index(self, timeout=settings.SEARCH_SOLR_TIMEOUT_SECONDS):
-        if self.forum_index is None:
-            self.forum_index = pysolr.Solr(
-                self.forum_index_url,
-                encoder=solr555pysolr.FreesoundSoundJsonEncoder(),
-                results_cls=solr555pysolr.SolrResponseInterpreter,
-                always_commit=True,
-                timeout=timeout,
-            )
-        return self.forum_index
+        return pysolr.Solr(
+            self.forum_index_url,
+            encoder=solr555pysolr.FreesoundSoundJsonEncoder(),
+            results_cls=solr555pysolr.SolrResponseInterpreter,
+            always_commit=True,
+            timeout=timeout,
+        )
 
     def search_process_filter(self, query_filter, only_sounds_within_ids=False, only_sounds_with_pack=False):
         """Process the filter to make a number of adjustments

--- a/utils/search/backends/solr_common.py
+++ b/utils/search/backends/solr_common.py
@@ -24,7 +24,7 @@ import urllib.parse
 from django.conf import settings
 from django.core.cache import cache
 
-from utils.search import SearchEngineException
+from utils.search import SearchEngineException, SearchEngineTimeoutException
 
 search_logger = logging.getLogger("search")
 
@@ -32,15 +32,21 @@ search_logger = logging.getLogger("search")
 class SolrQuery:
     """A wrapper around a lot of Solr query functionality."""
 
-    def __init__(self):
-        """Creates a SolrQuery object"""
-        # some default parameters
+    def __init__(self, time_allowed=settings.SEARCH_SOLR_TIME_ALLOWED_MS):
+        """Creates a SolrQuery object.
+
+        Args:
+            time_allowed (int | None): Solr-side per-query budget in ms. Pass None to
+              drop the cap entirely (None values are stripped by as_kwargs). Defaults
+              to settings.SEARCH_SOLR_TIME_ALLOWED_MS.
+        """
         self.params = {
             "wt": "json",
             "indent": "true",
             "debugQuery": "true" if settings.DEBUG else "false",
             "q.op": "AND",
             "echoParams": "explicit",
+            "timeAllowed": time_allowed,
         }
 
     def set_query(self, query):
@@ -326,6 +332,25 @@ def make_solr_query_url(solr_query_params, debug=False):
 
 class SolrResponseInterpreter:
     def __init__(self, response, next_page_query=None):
+        # Check for partialResults before parsing — a grouped/expanded response cut off
+        # by timeAllowed may be structurally incomplete (e.g. missing ngroups), and we
+        # want a structured timeout exception rather than a KeyError downstream.
+        response_header = response.get("responseHeader", {})
+        if response_header.get("partialResults"):
+            q_time = response_header.get("QTime", -1)
+            solr_query_url = make_solr_query_url(response_header.get("params", {}), debug=True)
+            search_logger.warning(
+                "SOLR partial results returned (timeAllowed exceeded) %s"
+                % json.dumps(
+                    {
+                        "q_time": q_time,
+                        "url": solr_query_url,
+                        "partial_results_details": response_header.get("partialResultsDetails"),
+                    }
+                )
+            )
+            raise SearchEngineTimeoutException(f"Solr returned partial results (timeAllowed exceeded after {q_time}ms)")
+
         if "grouped" in response and "expanded" in response:
             raise SearchEngineException("Response contains both grouped and expanded results, this is not supported")
 

--- a/utils/search/schema/freesound.json
+++ b/utils/search/schema/freesound.json
@@ -531,5 +531,11 @@
         "type_facet"
       ]
     }
+  ],
+  "requestHandlers": [
+    {
+      "name": "/select_similarity",
+      "class": "solr.SearchHandler"
+    }
   ]
 }

--- a/utils/tests/test_solr_query.py
+++ b/utils/tests/test_solr_query.py
@@ -1,7 +1,10 @@
+from unittest import mock
+
 import pytest
 from django.conf import settings
 
 from utils.search import SearchEngineException, SearchEngineTimeoutException
+from utils.search.backends.solr9pysolr import Solr9PySolrSearchEngine
 from utils.search.backends.solr555pysolr import Solr555PySolrSearchEngine
 from utils.search.backends.solr_common import SolrQuery, SolrResponseInterpreter
 
@@ -108,3 +111,19 @@ def test_solr_response_partial_results_grouped_missing_ngroups():
     }
     with pytest.raises(SearchEngineTimeoutException):
         SolrResponseInterpreter(response)
+
+
+@mock.patch("utils.search.backends.solr9pysolr.pysolr.Solr")
+def test_get_sounds_index_default_omits_search_handler(mock_solr):
+    # When no search_handler is provided, we don't pass it to pysolr at all so
+    # pysolr's own default kicks in (the falsy-fallback to "select").
+    Solr9PySolrSearchEngine().get_sounds_index()
+    _, kwargs = mock_solr.call_args
+    assert "search_handler" not in kwargs
+
+
+@mock.patch("utils.search.backends.solr9pysolr.pysolr.Solr")
+def test_get_sounds_index_passes_explicit_search_handler(mock_solr):
+    Solr9PySolrSearchEngine().get_sounds_index(search_handler="select_similarity")
+    _, kwargs = mock_solr.call_args
+    assert kwargs["search_handler"] == "select_similarity"

--- a/utils/tests/test_solr_query.py
+++ b/utils/tests/test_solr_query.py
@@ -1,9 +1,9 @@
 import pytest
 from django.conf import settings
 
-from utils.search import SearchEngineException
+from utils.search import SearchEngineException, SearchEngineTimeoutException
 from utils.search.backends.solr555pysolr import Solr555PySolrSearchEngine
-from utils.search.backends.solr_common import SolrQuery
+from utils.search.backends.solr_common import SolrQuery, SolrResponseInterpreter
 
 
 def test_search_process_sort_default():
@@ -78,3 +78,33 @@ def test_search_process_sort_distance_multiple_fields():
 def test_search_process_sort_distance_invalid_target():
     with pytest.raises(SearchEngineException):
         Solr555PySolrSearchEngine().search_process_sort_distance("bpm:not-a-number")
+
+
+def test_solr_query_default_params_include_time_allowed():
+    query = SolrQuery()
+    assert query.params["timeAllowed"] == settings.SEARCH_SOLR_TIME_ALLOWED_MS
+
+
+def test_solr_response_partial_results_raises_timeout():
+    response = {
+        "responseHeader": {
+            "QTime": 1001,
+            "partialResults": True,
+            "params": {"start": "0"},
+        },
+        "response": {"docs": [], "start": 0, "numFound": 0},
+    }
+    with pytest.raises(SearchEngineTimeoutException):
+        SolrResponseInterpreter(response)
+
+
+def test_solr_response_partial_results_grouped_missing_ngroups():
+    # Grouped responses with partialResults may be structurally incomplete (no `ngroups`).
+    # The check must run before the grouped-parsing block so we get a structured timeout
+    # rather than a KeyError.
+    response = {
+        "responseHeader": {"QTime": 1001, "partialResults": True, "params": {"start": "0"}},
+        "grouped": {"pack_grouping": {"groups": []}},
+    }
+    with pytest.raises(SearchEngineTimeoutException):
+        SolrResponseInterpreter(response)


### PR DESCRIPTION
**Description**
It's still possible to overload our web workers if they are all stuck waiting for solr requests and timing out after 5 seconds.

If we just use timeout on the request to solr, even if django gives up
and disconnects, solr is still doing work. This forces solr to stop
after a certain amount of time.

With our new infrastructure search is much faster, so lower the limits
from the previous values. Give the timeout a bit of head room over
timeAllowed to let solr finish up.
Similarity searches are anecdotally slower so give them a bit more space

Solr can return partial results if timeAllowed finishes. for now we just
treat this as a failed search.

Remove the pysolr cache in get_sounds_index. This cache is only
per backend index anyway, and we create a new backend index per request
anyway. This change makes it easier to set a specific timeout. There
is only one non-standard flow where we make two solr requests in a
single search request, so we might see a <1ms slowdown in that case.

---

Register a /select_similarity request handler on the freesound
collection and use it from search_sounds when similar_to is not None

This allows us to check metrics for normal search or similarity search
in grafana

**Deployment steps**:
Requires a solr deploy
