### PR TITLE
Optimise create remixgroups

### DIFF
--- a/sounds/forms.py
+++ b/sounds/forms.py
@@ -59,7 +59,7 @@ class RemixForm(forms.Form):
 
     def save(self):
         new_sources = self.cleaned_data["sources"]
-        self.sound.set_sources(new_sources)
+        self.sound.change_sources_and_propagate(new_sources)
 
 
 class PackChoiceField(forms.ModelChoiceField):

--- a/sounds/management/commands/create_remix_groups.py
+++ b/sounds/management/commands/create_remix_groups.py
@@ -72,17 +72,17 @@ class Command(BaseCommand):
         n_groups_created = 0
         for sg_nodes in subgraphs:
             sg = dg.subgraph(sg_nodes).copy()
-            _create_and_save_remixgroup(sg, RemixGroup())
+            _create_and_save_remixgroup(sg)
             n_groups_created += 1
 
         web_logger.info("Finished creating remix groups (%i groups created)" % n_groups_created)
 
 
 def _create_nodes(dg):
-    for node in dg.nodes():
-        sound = Sound.objects.get(id=node)
+    sounds = Sound.objects.filter(id__in=list(dg.nodes())).select_related("user")
+    for sound in sounds:
         dg.add_node(
-            node,
+            sound.id,
             date=sound.created,
             nodeName=sound.original_filename,
             username=sound.user.username,
@@ -93,35 +93,19 @@ def _create_nodes(dg):
     return dg
 
 
-def _create_and_save_remixgroup(sg, remixgroup):
-    # print ' ========================================= '
+def _create_and_save_remixgroup(sg):
     # add to list the subgraphs(connected components) with the extra data
     node_list = list(sg.nodes(data=True))
-    # pp(node_list)
 
     # sort by date (holds all subgraph nodes sorted by date)
     # we need this since we go forward in time (source older than remix)
     node_list.sort(key=lambda x: x[1]["date"])  # I think ['date'] is not necessary
-    # print ' ========== SORTED NODE_LIST ========= '
-    # pp(node_list)
 
     # dict with key=sound_id, value=index, nodeName=original_filename
     # in the previous sorted by date list
     # FIXME: no need for all this data, can be simple dict, key=value
     container = {val[0]: {"index": idx, "nodeName": val[1]["nodeName"]} for (idx, val) in enumerate(node_list)}
-    # print ' ========== CONTAINER ========= '
-    # pp(container)
 
-    links = []
-    remixgroup.save()  # need to save to have primary key before ManyToMany
-    # FIXME: no idea why nx.weakly_connected_components(sg) return list in list...
-    remixgroup.sounds.set(max(nx.weakly_connected_components(sg), key=len))
-
-    for sound in remixgroup.sounds.all():
-        sound.invalidate_template_caches()
-        sound.mark_index_dirty(commit=True)
-
-    remixgroup.group_size = len(node_list)
     # FIXME: seems like double work here, maybe convert container to list and sort?
     nodes = [
         {
@@ -135,8 +119,8 @@ def _create_and_save_remixgroup(sg, remixgroup):
         }
         for (idx, val) in enumerate(node_list)
     ]
+    links = []
     for line in nx.generate_adjlist(sg):
-        # print line
         if len(line.split()) > 1:
             for i, l in enumerate(line.strip().split(" ")):
                 # index 0 is the source, which we already know
@@ -144,12 +128,12 @@ def _create_and_save_remixgroup(sg, remixgroup):
                     link = {"target": container[int(line.split(" ")[0])]["index"], "source": container[int(l)]["index"]}
                     links.append(link)
 
-    remixgroup.protovis_data = (
+    protovis_data = (
         '{"color": "#F1D9FF",'
         '"length":' + str(len(node_list)) + ","
         '"nodes": ' + json.dumps(nodes) + ","
         '"links": ' + json.dumps(links) + "}"
     )
 
-    remixgroup.networkx_data = json.dumps(dict(nodes=list(sg.nodes()), edges=list(sg.edges())))
-    remixgroup.save()
+    remixgroup = RemixGroup.objects.create(protovis_data=protovis_data, group_size=len(node_list))
+    remixgroup.sounds.set(sg.nodes())

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -1029,29 +1029,42 @@ class Sound(models.Model):
         """
         Returns a set object with the integer sound IDs of the current sources of the sound
         """
-        return {source["id"] for source in self.sources.all().values("id")}
+        return set(self.sources.values_list("id", flat=True))
 
-    def set_sources(self, new_sources):
+    def change_sources_and_propagate(self, new_sources):
         """
-        :param set new_sources: set object with the integer IDs of the sounds which should be set as sources of the sound
+        Replace this sound's remix sources with ``new_sources`` and propagate the change to
+        dependent systems:
+          * sends "added as remix source" emails to the owners of newly-added source sounds
+          * invalidates template caches for this sound and for each added/removed source
+          * bulk-marks added/removed sources as ``is_index_dirty`` so Solr reindexes their
+            ``is_remix`` / ``was_remixed`` fields (this sound is dirtied by the caller —
+            either via ``Sound.is_index_dirty=True`` on creation or the unconditional
+            ``mark_index_dirty`` in the edit view)
+
+        Sound deletions (the other code path that mutates ``sounds_sound_sources``) handle
+        their own counterparty dirtying in ``on_delete_sound``.
+
+        :param set new_sources: set of integer sound IDs that should become this sound's sources
         """
         new_sources.discard(self.id)  # stop the universe from collapsing :-D
         old_sources = self.get_sound_sources_as_set()
 
+        dirtied_source_ids = set()
+
         # process sources in old but not in new
-        for sid in old_sources - new_sources:
-            try:
-                source = Sound.objects.get(id=sid)
-                self.sources.remove(source)
-                source.invalidate_template_caches()
-            except Sound.DoesNotExist:
-                pass
+        sources_to_remove = list(Sound.objects.filter(id__in=old_sources - new_sources))
+        for source in sources_to_remove:
+            source.invalidate_template_caches()
+            dirtied_source_ids.add(source.id)
+        if sources_to_remove:
+            self.sources.remove(*sources_to_remove)
 
         # process sources in new but not in old
-        for sid in new_sources - old_sources:
-            source = Sound.objects.get(id=sid)
+        sources_to_add = list(Sound.objects.filter(id__in=new_sources - old_sources))
+        for source in sources_to_add:
             source.invalidate_template_caches()
-            self.sources.add(source)
+            dirtied_source_ids.add(source.id)
             send_mail_template(
                 settings.EMAIL_SUBJECT_SOUND_ADDED_AS_REMIX,
                 "emails/email_remix_update.txt",
@@ -1059,6 +1072,12 @@ class Sound(models.Model):
                 user_to=source.user,
                 email_type_preference_check="new_remix",
             )
+        if sources_to_add:
+            self.sources.add(*sources_to_add)
+
+        # Counterparties' was_remixed/is_remix may have flipped: bulk-mark them for Solr re-indexing.
+        if dirtied_source_ids:
+            Sound.objects.filter(id__in=dirtied_source_ids).update(is_index_dirty=True)
 
         if old_sources != new_sources:
             self.invalidate_template_caches()
@@ -1834,6 +1853,15 @@ def on_delete_sound(sender, instance, **kwargs):
     instance.unlink_moderation_ticket()
 
     delete_cdn_symlink(instance)
+
+    # If this sound was used in a remix or was a remix, then
+    # Mark remix counterparties as index-dirty: their was_remixed/is_remix may flip when the M2M
+    # cascade clears sounds_sound_sources. M2M relations are still queryable in pre_delete.
+    counterparty_ids = set(instance.sources.values_list("id", flat=True)) | set(
+        instance.remixes.values_list("id", flat=True)
+    )
+    if counterparty_ids:
+        Sound.objects.filter(id__in=counterparty_ids).update(is_index_dirty=True)
 
 
 def post_delete_sound(sender, instance, **kwargs):

--- a/sounds/tests/test_create_remix_groups.py
+++ b/sounds/tests/test_create_remix_groups.py
@@ -1,0 +1,81 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+
+import pytest
+from django.core.management import call_command
+
+from sounds.models import RemixGroup, Sound
+from utils.test_helpers import create_user_and_sounds
+
+
+@pytest.mark.django_db
+class TestCreateRemixGroups:
+    @pytest.fixture(autouse=True)
+    def _fixtures(self):
+        call_command("loaddata", "licenses", "email_preference_type")
+
+    def test_idempotent_run_does_not_dirty_sounds(self):
+        # Build a single component {A,B,C,D} via three edges
+        _, _, sounds = create_user_and_sounds(num_sounds=4, username="remixuser1")
+        a, b, c, d = sounds
+        a.change_sources_and_propagate({b.id})  # A -> B
+        b.change_sources_and_propagate({c.id})  # B -> C
+        d.change_sources_and_propagate({a.id})  # D -> A
+
+        call_command("create_remix_groups")
+        # Reset is_index_dirty introduced by change_sources_and_propagate / first cron run
+        Sound.objects.filter(id__in=[a.id, b.id, c.id, d.id]).update(is_index_dirty=False)
+
+        # Second cron run on identical graph must not re-dirty any sound
+        call_command("create_remix_groups")
+        assert Sound.objects.filter(id__in=[a.id, b.id, c.id, d.id], is_index_dirty=True).count() == 0
+
+        # Group structure preserved
+        assert RemixGroup.objects.count() == 1
+        rg = RemixGroup.objects.first()
+        assert rg is not None
+        assert set(rg.sounds.values_list("id", flat=True)) == {a.id, b.id, c.id, d.id}
+
+    def test_change_sources_marks_counterparties_dirty(self):
+        _, _, sounds = create_user_and_sounds(num_sounds=2, username="remixuser2")
+        a, b = sounds
+
+        # Adding B as a source of A flips B.was_remixed False -> True
+        Sound.objects.filter(id__in=[a.id, b.id]).update(is_index_dirty=False)
+        a.change_sources_and_propagate({b.id})
+        b.refresh_from_db()
+        assert b.is_index_dirty is True
+
+        # Removing B as a source of A flips B.was_remixed True -> False
+        Sound.objects.filter(id__in=[a.id, b.id]).update(is_index_dirty=False)
+        a.change_sources_and_propagate(set())
+        b.refresh_from_db()
+        assert b.is_index_dirty is True
+
+    def test_sound_deletion_marks_counterparties_dirty(self):
+        _, _, sounds = create_user_and_sounds(num_sounds=2, username="remixuser3")
+        a, b = sounds
+        a.change_sources_and_propagate({b.id})
+
+        Sound.objects.filter(id__in=[a.id, b.id]).update(is_index_dirty=False)
+        a.delete()
+        b.refresh_from_db()
+        assert b.is_index_dirty is True

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -485,7 +485,7 @@ def edit_and_describe_sounds_helper(request, describing=False, session_key_prefi
                 sound = create_sound(user, sound_fields, process=False)
                 sound_sources = form.cleaned_data["sources"]
                 if sound_sources:
-                    sound.set_sources(sound_sources)
+                    sound.change_sources_and_propagate(sound_sources)
                 sounds_to_process.append(sound)
                 if user.profile.is_whitelisted:
                     messages.add_message(
@@ -575,7 +575,7 @@ def edit_and_describe_sounds_helper(request, describing=False, session_key_prefi
 
         sound_sources = data["sources"]
         if sound_sources != sound.get_sound_sources_as_set():
-            sound.set_sources(sound_sources)
+            sound.change_sources_and_propagate(sound_sources)
 
         if category_has_changed:
             # Some descriptors in the consolidated analysis change depending on the bst category, so we need to


### PR DESCRIPTION
**Issue(s)**
<!-- URL to issue(s) related to this PR -->

**Description**
create_remix_groups deletes all remix groups, recreates them, and then marks
every sound that is part of a remix group as dirty. This causes a spike
of 10,000 sounds to be reindexed every hour, when these items almost
never change.

Instead, just mark a sound's sources/remixes as dirty if they are edited/deleted and update them the next time the reindex script runs.
