### PR TITLE
Security: Path Traversal in File Cleanup Command

### DIFF
--- a/accounts/management/commands/clean_old_tmp_upload_files.py
+++ b/accounts/management/commands/clean_old_tmp_upload_files.py
@@ -32,10 +32,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         for f in os.listdir(settings.FILE_UPLOAD_TEMP_DIR):
+            file_path = os.path.join(settings.FILE_UPLOAD_TEMP_DIR, f)
+            file_path = os.path.realpath(file_path)
+            temp_dir = os.path.realpath(settings.FILE_UPLOAD_TEMP_DIR)
+            if not file_path.startswith(temp_dir + os.sep):
+                continue
             f_mod_date = datetime.datetime.fromtimestamp(
-                os.path.getmtime(settings.FILE_UPLOAD_TEMP_DIR + f), tz=datetime.timezone.utc
+                os.path.getmtime(file_path), tz=datetime.timezone.utc
             )
             now = timezone.now()
             if (now - f_mod_date).total_seconds() > 3600 * 24:
                 print(f"Deleting {f}")
-                os.remove(settings.FILE_UPLOAD_TEMP_DIR + f)
+                os.remove(file_path)


### PR DESCRIPTION
## Summary

Security: Path Traversal in File Cleanup Command

## Problem

**Severity**: `High` | **File**: `accounts/management/commands/clean_old_tmp_upload_files.py:L37`

In `accounts/management/commands/clean_old_tmp_upload_files.py`, the code concatenates `settings.FILE_UPLOAD_TEMP_DIR` with `f` using simple string concatenation (`settings.FILE_UPLOAD_TEMP_DIR + f`). If `settings.FILE_UPLOAD_TEMP_DIR` does not end with a path separator, or if an attacker can influence the directory contents, this could lead to path traversal. More critically, the code iterates over all files in the directory and deletes them without proper validation, which could be exploited if the directory is not properly secured.

## Solution

Use `os.path.join()` instead of string concatenation for path construction. Add validation to ensure files are within the expected directory using `os.path.realpath()` or similar. Consider using `pathlib.Path` for safer path handling.

## Changes

- `accounts/management/commands/clean_old_tmp_upload_files.py` (modified)