### PR TITLE
Fix path join

### DIFF
--- a/accounts/management/commands/clean_old_tmp_upload_files.py
+++ b/accounts/management/commands/clean_old_tmp_upload_files.py
@@ -32,10 +32,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         for f in os.listdir(settings.FILE_UPLOAD_TEMP_DIR):
-            f_mod_date = datetime.datetime.fromtimestamp(
-                os.path.getmtime(settings.FILE_UPLOAD_TEMP_DIR + f), tz=datetime.timezone.utc
-            )
+            filepath = os.path.join(settings.FILE_UPLOAD_TEMP_DIR, f)
+            f_mod_date = datetime.datetime.fromtimestamp(os.path.getmtime(filepath), tz=datetime.timezone.utc)
             now = timezone.now()
             if (now - f_mod_date).total_seconds() > 3600 * 24:
                 print(f"Deleting {f}")
-                os.remove(settings.FILE_UPLOAD_TEMP_DIR + f)
+                os.remove(filepath)

--- a/accounts/tests/test_upload.py
+++ b/accounts/tests/test_upload.py
@@ -55,14 +55,14 @@ class UserUploadAndDescribeSounds(TestCase):
         f = SimpleUploadedFile(filename, b"file_content")
         resp = self.client.post("/home/upload/html/", {"file": f})
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(os.path.exists(settings.UPLOADS_PATH + "/%i/%s" % (user.id, filename)), True)
+        self.assertEqual(os.path.exists(os.path.join(settings.UPLOADS_PATH, str(user.id), filename)), True)
 
         # Test file upload that should fail
         filename = "filè.xyz"
         f = SimpleUploadedFile(filename, b"file_content")
         resp = self.client.post("/home/upload/html/", {"file": f})
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(os.path.exists(settings.UPLOADS_PATH + "/%i/%s" % (user.id, filename)), False)
+        self.assertEqual(os.path.exists(os.path.join(settings.UPLOADS_PATH, str(user.id), filename)), False)
 
     @override_uploads_path_with_temp_directory
     def test_select_uploaded_files_to_describe(self):
@@ -70,7 +70,7 @@ class UserUploadAndDescribeSounds(TestCase):
         filenames = ["file1.wav", "file2.wav", "file3.wav", "filè4.wav"]
         user = User.objects.create_user("testuser", password="testpass")
         self.client.force_login(user)
-        user_upload_path = settings.UPLOADS_PATH + "/%i/" % user.id
+        user_upload_path = os.path.join(settings.UPLOADS_PATH, str(user.id))
         os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(filenames, user_upload_path)
 
@@ -147,7 +147,7 @@ class UserUploadAndDescribeSounds(TestCase):
         filenames = ["file1.wav", "filè2.wav"]
         user = User.objects.create_user("testuser", email="1@xmpl.com", password="testpass")
         self.client.force_login(user)
-        user_upload_path = settings.UPLOADS_PATH + "/%i/" % user.id
+        user_upload_path = os.path.join(settings.UPLOADS_PATH, str(user.id))
         os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(filenames, user_upload_path)
         _, _, sound_sources = create_user_and_sounds(
@@ -163,8 +163,8 @@ class UserUploadAndDescribeSounds(TestCase):
         session[f"{session_key_prefix}-describe_pack"] = False
         session[f"{session_key_prefix}-len_original_describe_sounds"] = 2
         session[f"{session_key_prefix}-describe_sounds"] = [
-            File(1, filenames[0], user_upload_path + filenames[0], False),
-            File(2, filenames[1], user_upload_path + filenames[1], False),
+            File(1, filenames[0], os.path.join(user_upload_path, filenames[0]), False),
+            File(2, filenames[1], os.path.join(user_upload_path, filenames[1]), False),
         ]
         session.save()
 

--- a/sounds/management/commands/clean_tmp_pcm_analysis_files.py
+++ b/sounds/management/commands/clean_tmp_pcm_analysis_files.py
@@ -48,7 +48,7 @@ class Command(LoggingBaseCommand):
         self.log_start()
 
         data_to_log = {}
-        wav_files_in_analysis_path = glob.glob(os.path.join(settings.ANALYSIS_PATH, "**/*.wav"))
+        wav_files_in_analysis_path = glob.glob(os.path.join(settings.ANALYSIS_PATH, "*", "*.wav"))
         files_to_remove = []
         for filepath in wav_files_in_analysis_path:
             try:

--- a/sounds/management/commands/clean_tmp_pcm_analysis_files.py
+++ b/sounds/management/commands/clean_tmp_pcm_analysis_files.py
@@ -48,7 +48,7 @@ class Command(LoggingBaseCommand):
         self.log_start()
 
         data_to_log = {}
-        wav_files_in_analysis_path = glob.glob(settings.ANALYSIS_PATH + "**/*.wav")
+        wav_files_in_analysis_path = glob.glob(os.path.join(settings.ANALYSIS_PATH, "**/*.wav"))
         files_to_remove = []
         for filepath in wav_files_in_analysis_path:
             try:

--- a/utils/mirror_files.py
+++ b/utils/mirror_files.py
@@ -49,7 +49,7 @@ def copy_files_to_mirror_locations(object, source_location_keys, source_base_pat
         for location_path in source_location_keys:
             source_path = object.locations(location_path)
             source_destination_tuples.append(
-                (source_path, source_path.replace(source_base_path, destination_base_path))
+                (source_path, os.path.join(destination_base_path, os.path.relpath(source_path, source_base_path)))
             )
 
     copy_files(source_destination_tuples)  # Do the actual copying of the files
@@ -60,7 +60,10 @@ def copy_uploaded_file_to_mirror_locations(source_file_path):
     if settings.MIRROR_UPLOADS:
         for destination_base_path in settings.MIRROR_UPLOADS:
             source_destination_tuples.append(
-                (source_file_path, source_file_path.replace(settings.UPLOADS_PATH, destination_base_path))
+                (
+                    source_file_path,
+                    os.path.join(destination_base_path, os.path.relpath(source_file_path, settings.UPLOADS_PATH)),
+                )
             )
         copy_files(source_destination_tuples)
 
@@ -70,7 +73,10 @@ def remove_uploaded_file_from_mirror_locations(source_file_path):
     if settings.MIRROR_UPLOADS:
         for destination_base_path in settings.MIRROR_UPLOADS:
             source_destination_tuples.append(
-                (source_file_path, source_file_path.replace(settings.UPLOADS_PATH, destination_base_path))
+                (
+                    source_file_path,
+                    os.path.join(destination_base_path, os.path.relpath(source_file_path, settings.UPLOADS_PATH)),
+                )
             )
         for _, destination_path in source_destination_tuples:
             try:
@@ -83,7 +89,9 @@ def remove_uploaded_file_from_mirror_locations(source_file_path):
 def remove_empty_user_directory_from_mirror_locations(user_uploads_path):
     if settings.MIRROR_UPLOADS:
         for destination_base_path in settings.MIRROR_UPLOADS:
-            remove_directory_if_empty(user_uploads_path.replace(settings.UPLOADS_PATH, destination_base_path))
+            remove_directory_if_empty(
+                os.path.join(destination_base_path, os.path.relpath(user_uploads_path, settings.UPLOADS_PATH))
+            )
 
 
 def copy_sound_to_mirror_locations(sound):

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -115,7 +115,8 @@ def get_processing_before_describe_sound_folder(audio_file_path):
 
 def get_processing_before_describe_sound_base_url(audio_file_path):
     path = get_processing_before_describe_sound_folder(audio_file_path)
-    return settings.PROCESSING_BEFORE_DESCRIPTION_URL + "/".join(path.split("/")[-2:]) + "/"
+    relative = os.path.relpath(path, settings.PROCESSING_BEFORE_DESCRIPTION_DIR)
+    return settings.PROCESSING_BEFORE_DESCRIPTION_URL + relative + "/"
 
 
 def create_sound(user, sound_fields, apiv2_client=None, bulk_upload_progress=None, process=True, remove_exists=False):

--- a/utils/sound_upload.py
+++ b/utils/sound_upload.py
@@ -439,8 +439,11 @@ def validate_input_csv_file(csv_header, csv_lines, sounds_base_dir, username=Non
                     if not filename_has_valid_extension(audio_filename):
                         line_errors["audio_filename"] = "Invalid file extension."
                     else:
-                        src_path = os.path.join(sounds_base_dir, audio_filename)
-                        if not os.path.exists(src_path):
+                        sounds_base_real = os.path.realpath(sounds_base_dir)
+                        src_path = os.path.realpath(os.path.join(sounds_base_real, audio_filename))
+                        if os.path.commonpath([sounds_base_real, src_path]) != sounds_base_real:
+                            line_errors["audio_filename"] = "audio_filename must be a single filename."
+                        elif not os.path.exists(src_path):
                             line_errors["audio_filename"] = (
                                 "Audio file does not exist. This should be the name of "
                                 "one of the audio files you previously uploaded."

--- a/utils/tests/tests.py
+++ b/utils/tests/tests.py
@@ -338,6 +338,25 @@ class BulkDescribeUtils(TestCase):
         self.assertTrue("audio_filename" in lines_validated[4]["line_errors"])  # File already described error reported
         self.assertTrue("bst_category" in lines_validated[5]["line_errors"])  # Missing category reported
 
+        # Test path-traversing audio_filename is rejected (must stay under user uploads directory)
+        csv_file_path = self.create_file_with_lines(
+            "test_descriptions.csv",
+            [
+                "audio_filename,name,tags,geotag,description,license,pack_name,is_explicit,bst_category",
+                '../somewhere/file.wav,,"tag1 tag2 tag3",,"Description",Creative Commons 0,,0,fx-h',  # Relative escape
+                '/etc/passwd.wav,,"tag1 tag2 tag3",,"Description",Creative Commons 0,,0,fx-h',  # Absolute path
+            ],
+            csv_file_base_path,
+        )
+        header, lines = get_csv_lines(csv_file_path)
+        lines_validated, global_errors = validate_input_csv_file(
+            header, lines, user_upload_path, username=user.username
+        )
+        self.assertEqual(len(global_errors), 0)  # No global errors
+        self.assertEqual(len([line for line in lines_validated if line["line_errors"]]), 2)  # Both lines rejected
+        self.assertTrue("audio_filename" in lines_validated[0]["line_errors"])  # Relative traversal rejected
+        self.assertTrue("audio_filename" in lines_validated[1]["line_errors"])  # Absolute path rejected
+
         # Test validation errors in individual fields
         csv_file_path = self.create_file_with_lines(
             "test_descriptions.csv",

--- a/utils/tests/tests.py
+++ b/utils/tests/tests.py
@@ -74,14 +74,14 @@ class UtilsTest(TestCase):
         # create new sound files
         filenames = ["file1.wav", "file2.wav"]
         user = User.objects.create_user("testuser", password="testpass")
-        user_upload_path = settings.UPLOADS_PATH + "/%i/" % user.id
+        user_upload_path = os.path.join(settings.UPLOADS_PATH, str(user.id))
         os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(filenames, user_upload_path)
-        shutil.copyfile(user_upload_path + filenames[0], user_upload_path + "copy.wav")
+        shutil.copyfile(os.path.join(user_upload_path, filenames[0]), os.path.join(user_upload_path, "copy.wav"))
         license = License.objects.all()[0]
         sound_fields = {
             "name": "new sound",
-            "dest_path": user_upload_path + filenames[0],
+            "dest_path": os.path.join(user_upload_path, filenames[0]),
             "license": license.name,
             "description": "new sound",
             "tags": clean_and_split_tags("tag1, tag2, tag3"),
@@ -94,7 +94,7 @@ class UtilsTest(TestCase):
             create_sound(user, sound_fields, process=False)
         except NoAudioException:
             # If we try to upload the same file again it should also fail
-            sound_fields["dest_path"] = user_upload_path + "copy.wav"
+            sound_fields["dest_path"] = os.path.join(user_upload_path, "copy.wav")
             try:
                 create_sound(user, sound_fields, process=False)
             except AlreadyExistsException:
@@ -102,7 +102,7 @@ class UtilsTest(TestCase):
         self.assertEqual(user.sounds.all().count(), 1)
 
         # Upload file with geotag and pack
-        sound_fields["dest_path"] = user_upload_path + filenames[1]
+        sound_fields["dest_path"] = os.path.join(user_upload_path, filenames[1])
         sound_fields["geotag"] = "41.2222,31.0000,17"
         sound_fields["pack"] = "new pack"
         sound_fields["name"] = filenames[1]
@@ -227,7 +227,7 @@ class BulkDescribeUtils(TestCase):
 
     @staticmethod
     def create_file_with_lines(filename, lines, base_path):
-        csv_file_path = f"{base_path}/{filename}"
+        csv_file_path = os.path.join(base_path, filename)
         csv_fid = open(csv_file_path, "w")
         for line in lines:
             csv_fid.write(line + "\n")
@@ -272,14 +272,14 @@ class BulkDescribeUtils(TestCase):
     def test_validate_input_csv_file(self):
         # Create user uploads folder and test audio files
         user = User.objects.create_user("testuser", password="testpass")
-        user_upload_path = settings.UPLOADS_PATH + "/%i/" % user.id
+        user_upload_path = os.path.join(settings.UPLOADS_PATH, str(user.id))
         os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(
             ["file1.wv", "file2.wav", "file3.wav", "file4.wav", "file5.wav", "file7.wav", "file8.wav"], user_upload_path
         )
 
         # Create CSV files folder with descriptions
-        csv_file_base_path = settings.CSV_PATH + "/%i/" % user.id
+        csv_file_base_path = os.path.join(settings.CSV_PATH, str(user.id))
         os.makedirs(csv_file_base_path, exist_ok=True)
 
         # Test CSV with all lines and metadata ok
@@ -435,14 +435,14 @@ class BulkDescribeUtils(TestCase):
     def test_bulk_describe_from_csv(self):
         # Create user uploads folder and test audio files
         user = User.objects.create_user("testuser", password="testpass")
-        user_upload_path = settings.UPLOADS_PATH + "/%i/" % user.id
+        user_upload_path = os.path.join(settings.UPLOADS_PATH, str(user.id))
         os.makedirs(user_upload_path, exist_ok=True)
         create_test_files(
             ["file1.wav", "file2.wav", "file3.wav", "file4.wav", "file5.wav", "file6.wav"], user_upload_path
         )
 
         # Create CSV files folder with descriptions
-        csv_file_base_path = settings.CSV_PATH + "/%i/" % user.id
+        csv_file_base_path = os.path.join(settings.CSV_PATH, str(user.id))
         os.makedirs(csv_file_base_path, exist_ok=True)
 
         # Create Test CSV with some lines ok and some wrong lines


### PR DESCRIPTION
**Issue(s)**
Inspired by https://github.com/MTG/freesound/pull/2135

**Description**
We had a number of places in the codebase where we use string concatenation to construct paths on disk. This has a few issues
 * we have to ensure that we always add a trailing slash to config items that represent directories
 * We had 2 different ways to remove a common prefix from a path, which can be done directly with os.path.relpath
 * In some cases, malicious user input might be able to escape a path and do something bad.

Here we replace all uses of string concatenation/truncating with methods from os.path. Additional fix the one case we found where a user provided path is unsafely concatenated (would have been a problem with os.path.join too)

**Deployment steps**:
After this is deployed we can remove the trailing `/` from all location settings