### PR TITLE
Downgrade html for backwards compatibility

### DIFF
--- a/freesound/static/bw-frontend/src/htmx-init.js
+++ b/freesound/static/bw-frontend/src/htmx-init.js
@@ -4,8 +4,9 @@ window.htmx = htmx;
 
 (function () {
   document.body.addEventListener('htmx:configRequest', event => {
+    const csrfTokenMatch = document.cookie.match(/csrftoken=([^;]+)/);
     event.detail.headers['X-CSRFToken'] =
-      document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '';
+      (csrfTokenMatch && csrfTokenMatch[1]) || '';
   });
 
   // htmx:load fires for every new subtree added to the DOM by htmx (including after swap).

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "classlist-polyfill": "^1.2.0",
         "core-js": "^3.6.1",
         "element-closest": "^3.0.1",
+        "htmx.org": "1.9.12",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
         "normalize.css": "^8.0.1",
@@ -500,7 +501,6 @@
       "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.15.4.tgz",
       "integrity": "sha512-+TXxTm58lFwXXObFAEclwKX1p1AdixcD+M7T4NeFIQzQ4F20Vr+6oybCSqW1exNA3uHqVDDFLx7TT78seVjvkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.15.4",
@@ -2461,7 +2461,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2771,7 +2770,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3449,7 +3447,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3584,7 +3581,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -4096,6 +4092,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/htmx.org": {
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.9.12.tgz",
+      "integrity": "sha512-VZAohXyF7xPGS52IM8d1T1283y+X4D+Owf3qY1NZ9RuBypyu9l8cGsxUMAG5fEAb/DhT7rDoJ9Hpu5/HxFD3cw==",
+      "license": "0BSD"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "classlist-polyfill": "^1.2.0",
     "core-js": "^3.6.1",
     "element-closest": "^3.0.1",
-    "htmx.org": "^2.0.0",
+    "htmx.org": "1.9.12",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
A user complained that after our recent release, Freesound is having JS errors for him. He uses an old browser that has some "special" screen reading capabilities. Errors happen because of having added html. With this PR I'm downgrading htmx for better compatibility with old-browsers. I tested locally and htmx-based functions seem to work fine so this could be a solution for now.