### PR TITLE
Collection page finalization

### DIFF
--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -1286,7 +1286,7 @@ RABBITMQ_API_PORT = "5673"
 
 # -------------------------------------------------------------------------------
 # Collections
-ENABLE_COLLECTIONS = True
+ENABLE_COLLECTIONS = False
 MAX_SOUNDS_PER_COLLECTION = 250
 MAX_FEATURED_SOUNDS_PER_COLLECTION = 6
 COLLECTION_SORT_OPTIONS = {

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -1286,7 +1286,7 @@ RABBITMQ_API_PORT = "5673"
 
 # -------------------------------------------------------------------------------
 # Collections
-ENABLE_COLLECTIONS = False
+ENABLE_COLLECTIONS = True
 MAX_SOUNDS_PER_COLLECTION = 250
 MAX_FEATURED_SOUNDS_PER_COLLECTION = 6
 COLLECTION_SORT_OPTIONS = {

--- a/freesound/static/bw-frontend/styles/atoms/selectableObject.scss
+++ b/freesound/static/bw-frontend/styles/atoms/selectableObject.scss
@@ -27,7 +27,29 @@
 }
 
 .featured-highlight {
-  background-color: rgba(253, 221, 68, 0.24);
+  position: relative;
+  margin-bottom: $smedium-spacing;
+  padding: $tiny-spacing $tiny-spacing 0;
+  border: 2px solid $orange;
+  border-radius: 4px;
+  background-color: rgba($orange, 0.05);
+
+  // fold the sound display's own bottom spacing into the card
+  > div {
+    margin-bottom: 0;
+  }
+
+  .featured-badge {
+    position: absolute;
+    top: -16px;
+    left: 0;
+    color: $orange;
+    font-size: 10px;
+    font-weight: bold;
+    line-height: 14px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
 }
 
 .featured-counter-label {

--- a/freesound/static/bw-frontend/styles/variables/colors.scss
+++ b/freesound/static/bw-frontend/styles/variables/colors.scss
@@ -9,6 +9,7 @@ $almost-white: #f4f4fa;
 $almost-white-border: #efeff8;
 $almost-white-less-white: #dfdfe8;
 $yellow: #fd4;
+$orange: #ff9e35; // same orange as the busy map clusters (mapsMapbox.js)
 $blue: #0064af;
 $blue-hover: #2f74b1;
 $green: #01ae01;

--- a/fscollections/forms.py
+++ b/fscollections/forms.py
@@ -191,15 +191,12 @@ class SelectCollectionOrNewCollectionForm(forms.Form):
                                 f"The chosen collection has reached the maximum number of sounds allowed ({settings.MAX_SOUNDS_PER_COLLECTION})"
                             )
 
-                        maintainers_list = list(collection.maintainers.all().values_list("id", flat=True))
-                        if (
-                            self.user_saving_sound.id not in maintainers_list
-                            and self.user_saving_sound != collection.user
-                        ):
+                        if not collection.user_is_owner_or_maintainer(self.user_saving_sound):
                             raise forms.ValidationError("You do not have permission to edit this collection.")
 
-                        collection_sounds = Sound.objects.filter(collections=collection)
-                        if sound in collection_sounds:
+                        # Check the through model directly: pending/refused sounds also occupy
+                        # the unique (sound, collection) slot
+                        if CollectionSound.objects.filter(collection=collection, sound=sound).exists():
                             raise forms.ValidationError("This sound already exists in this collection")
 
                     except Collection.DoesNotExist:
@@ -371,7 +368,7 @@ class CollectionEditFormAsMaintainer(CollectionEditForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for field in self.fields:
-            if field not in ("added_sounds", "removed_sounds"):
+            if field not in ("added_sounds", "removed_sounds", "featured_sounds"):
                 self.fields[field].disabled = True
 
     def clean(self):
@@ -382,8 +379,6 @@ class CollectionEditFormAsMaintainer(CollectionEditForm):
         # in the form but disabled (to allow the user to view but not to modify the field), the original collection maintainers
         # are retrieved from DB to ensure no changes are applied to this attribute.
         cleaned_data["maintainers"] = set(self.instance.maintainers.values_list("id", flat=True))
-        # Preserve featured_sounds from the original instance (maintainers cannot edit)
-        cleaned_data["featured_sounds"] = list(self.instance.featured_sound_ids)
         for field in CollectionEditForm.Meta.fields:
             if cleaned_data[field] != getattr(self.instance, field):
                 self.add_error(field, forms.ValidationError("You don't have permissions to edit this field"))
@@ -395,20 +390,20 @@ class CreateCollectionForm(forms.ModelForm):
 
     class Meta:
         model = Collection
-        fields = ("name", "description")
+        fields = ("name", "description", "public")
         widgets = {
             "name": TextInput(),
             "description": Textarea(attrs={"rows": 5, "cols": 50}),
+            "public": forms.RadioSelect(choices=[(True, "Public"), (False, "Private")], attrs={"class": "bw-radio"}),
         }
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
-        self.fields["name"].label = False
         self.fields["name"].widget.attrs["placeholder"] = "Fill in the name for the new collection"
         self.fields["name"].widget.attrs["autocomplete"] = "off"
-        self.fields["description"].label = False
         self.fields["description"].widget.attrs["placeholder"] = "Write a description for the new collection"
+        self.fields["public"].label = "Visibility"
 
     def clean(self):
         if Collection.objects.filter(user=self.user, name=self.cleaned_data["name"]).exists():

--- a/fscollections/models.py
+++ b/fscollections/models.py
@@ -23,19 +23,21 @@ from urllib.parse import quote
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import F, Sum
+from django.db.models import Avg, Count, F, Sum
 from django.db.models.functions import Greatest
-from django.db.models.signals import m2m_changed, post_delete, post_save
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.text import slugify
 
 from freesound import settings
-from sounds.models import License, Sound
+from sounds.models import License, LicenseSummaryMixin, Sound
+from tags.models import Tag
 
 
-class Collection(models.Model):
+class Collection(LicenseSummaryMixin, models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
     created = models.DateTimeField(db_index=True, auto_now_add=True)
@@ -95,16 +97,20 @@ class Collection(models.Model):
     def add_maintainers_modal_url(self):
         return self.get_url("add-maintainers-modal")
 
-    @property
-    def stats_section_url(self):
-        return self.get_url("collection-stats-section")
+    def user_is_owner_or_maintainer(self, user):
+        if not user or not user.is_authenticated:
+            return False
+        return user == self.user or self.maintainers.filter(id=user.id).exists()
+
+    def update_num_sounds(self):
+        # Single source of truth for the num_sounds recount
+        self.num_sounds = Sound.objects.sounds_for_collection(self.id).count()
+        Collection.objects.filter(id=self.id).update(num_sounds=self.num_sounds)
 
     def get_attribution(self, sound_qs=None):
         # If no queryset of sounds is provided, take it from the collection
         if sound_qs is None:
-            sound_qs = self.sounds.filter(processing_state="OK", moderation_state="OK").select_related(
-                "user", "license"
-            )
+            sound_qs = Sound.objects.bulk_sounds_for_collection(self.id)
 
         users = User.objects.filter(sounds__in=sound_qs).distinct()
         # Generate text file with license info
@@ -122,13 +128,46 @@ class Collection(models.Model):
         return "%d__%s__%s.zip" % (self.id, username_slug, name_slug)
 
     def get_total_collection_sounds_length(self):
-        result = self.sounds.aggregate(total_duration=Sum("duration"))
+        result = Sound.objects.sounds_for_collection(self.id).aggregate(total_duration=Sum("duration"))
         return result["total_duration"] or 0
+
+    @cached_property
+    def ratings_data(self):
+        # (avg rating, num sounds) of the collection sounds with at least MIN_NUMBER_RATINGS ratings
+        result = (
+            Sound.objects.sounds_for_collection(self.id)
+            .filter(num_ratings__gte=settings.MIN_NUMBER_RATINGS)
+            .aggregate(avg=Avg("avg_rating"), count=Count("id"))
+        )
+        return result["avg"] or 0, result["count"]
+
+    @property
+    def avg_rating(self):
+        return self.ratings_data[0]
+
+    @property
+    def num_ratings(self):
+        return self.ratings_data[1]
+
+    @cached_property
+    def licenses_data(self):
+        licenses_data = list(Sound.objects.sounds_for_collection(self.id).values_list("license__name", "license_id"))
+        license_ids = [lid for _, lid in licenses_data]
+        license_names = [lname for lname, _ in licenses_data]
+        return license_ids, license_names
+
+    def get_collection_tags_bw(self):
+        tags = (
+            Tag.objects.filter(soundtag__sound__in=Sound.objects.sounds_for_collection(self.id))
+            .annotate(count=Count("soundtag"))
+            .order_by("-count")[:10]
+        )
+        return [{"name": tag.name, "count": tag.count, "browse_url": reverse("tags", args=[tag.name])} for tag in tags]
 
     def save(self, *args, **kwargs):
         # Update num_sounds count
         if self.pk:
-            self.num_sounds = CollectionSound.objects.filter(collection=self).count()
+            self.num_sounds = Sound.objects.sounds_for_collection(self.id).count()
 
         super().save(*args, **kwargs)
 
@@ -152,16 +191,10 @@ class CollectionSound(models.Model):
         unique_together = ("sound", "collection")
 
 
-@receiver(post_save, sender=CollectionSound)
+@receiver([post_save, post_delete], sender=CollectionSound)
 def update_collection_num_sounds(sender, instance, **kwargs):
-    if instance:
-        Collection.objects.filter(collectionsound=instance).update(num_sounds=Greatest(F("num_sounds") + 1, 0))
-
-
-@receiver(m2m_changed, sender=CollectionSound)
-def update_collection_num_sounds_bulk_changes(sender, instance, **kwargs):
-    if instance:
-        Collection.objects.filter(collectionsound=instance).update(num_sounds=Greatest(F("num_sounds") - 1, 0))
+    if instance and instance.collection_id:
+        instance.collection.update_num_sounds()
 
 
 @receiver(post_delete, sender=CollectionSound)
@@ -170,9 +203,9 @@ def remove_not_valid_featured_sounds(sender, instance, **kwargs):
     if instance and instance.collection_id:
         collection = instance.collection
         if collection.featured_sound_ids:
-            # Get current sound IDs in the collection
+            # Get current accepted sound IDs in the collection
             valid_sound_ids = set(
-                CollectionSound.objects.filter(collection=collection).values_list("sound_id", flat=True)
+                CollectionSound.objects.filter(collection=collection, status="OK").values_list("sound_id", flat=True)
             )
             # Filter out any featured_sound_ids that are not in the collection
             valid_featured_ids = [sid for sid in collection.featured_sound_ids if sid in valid_sound_ids]

--- a/fscollections/templatetags/display_collections.py
+++ b/fscollections/templatetags/display_collections.py
@@ -29,13 +29,22 @@ register = template.Library()
 
 
 @register.inclusion_tag("collections/display_collection.html", takes_context=True)
-def display_collection(context, collection_id):
-    collection = get_object_or_404(Collection, id=collection_id)
+def display_collection(context, collection):
+    # Accepts a Collection instance or a collection id
+    if not isinstance(collection, Collection):
+        collection = get_object_or_404(Collection, id=collection)
     request = context.get("request")
     if collection.featured_sound_ids:
         header_sounds = Sound.objects.bulk_query_id_public(collection.featured_sound_ids)
     else:
         header_sounds = Sound.objects.bulk_sounds_for_collection(collection.id, limit=1)
 
-    tvars = {"collection": collection, "header_sounds": header_sounds, "request": request}
+    show_visibility = collection.user_is_owner_or_maintainer(request.user if request else None)
+
+    tvars = {
+        "collection": collection,
+        "header_sounds": header_sounds,
+        "request": request,
+        "show_visibility": show_visibility,
+    }
     return tvars

--- a/fscollections/tests.py
+++ b/fscollections/tests.py
@@ -7,6 +7,7 @@ from django.utils.text import slugify
 
 from fscollections.models import Collection, CollectionSound
 from fscollections.views import serialize_collection_sounds
+from sounds.models import Sound
 from utils.test_helpers import create_user_and_sounds
 
 
@@ -25,15 +26,11 @@ class CollectionTest(TestCase):
         self.sound2 = sounds[2]
         self.collection = Collection.objects.create(user=self.user, name="testcollection")
 
-    def test_load_collection_page_and_collection_stats_page(self):
+    def test_load_collection_page(self):
         # Test a collection page is visible to all users if the collection is public
         self.collection.public = True
         self.collection.save()
         resp = self.client.get(reverse("collection", args=[self.collection.id, slugify(self.collection.name)]))
-        self.assertEqual(resp.status_code, 200)
-        resp = self.client.get(
-            reverse("collection-stats-section", args=[self.collection.id, slugify(self.collection.name)]) + "?ajax=1"
-        )
         self.assertEqual(resp.status_code, 200)
 
         # Test a collection page is only visible for owner and maintainers if the collection is private
@@ -44,28 +41,16 @@ class CollectionTest(TestCase):
         self.client.force_login(self.user)
         resp = self.client.get(reverse("collection", args=[self.collection.id, slugify(self.collection.name)]))
         self.assertEqual(resp.status_code, 200)
-        resp = self.client.get(
-            reverse("collection-stats-section", args=[self.collection.id, slugify(self.collection.name)]) + "?ajax=1"
-        )
-        self.assertEqual(resp.status_code, 200)
 
         # Test as maintainer
         self.collection.maintainers.add(self.maintainer)
         self.client.force_login(self.maintainer)
         resp = self.client.get(reverse("collection", args=[self.collection.id, slugify(self.collection.name)]))
         self.assertEqual(resp.status_code, 200)
-        resp = self.client.get(
-            reverse("collection-stats-section", args=[self.collection.id, slugify(self.collection.name)]) + "?ajax=1"
-        )
-        self.assertEqual(resp.status_code, 200)
 
         # Test as external user
         self.client.force_login(self.external_user)
         resp = self.client.get(reverse("collection", args=[self.collection.id, slugify(self.collection.name)]))
-        self.assertEqual(resp.status_code, 404)
-        resp = self.client.get(
-            reverse("collection-stats-section", args=[self.collection.id, slugify(self.collection.name)]) + "?ajax=1"
-        )
         self.assertEqual(resp.status_code, 404)
 
     def test_collections_create_and_delete(self):
@@ -440,7 +425,7 @@ class CollectionTest(TestCase):
 
         self.client.force_login(self.maintainer)
 
-        # Maintainer tries to change featured sounds — should be ignored
+        # Maintainer changes featured sounds — should be applied
         resp = self._post_edit(
             self._base_form_data(
                 featured_sounds=f"{self.sound1.id}",
@@ -448,7 +433,7 @@ class CollectionTest(TestCase):
         )
         self.assertEqual(302, resp.status_code)
         self.collection.refresh_from_db()
-        self.assertEqual([self.sound.id], self.collection.featured_sound_ids)
+        self.assertEqual([self.sound1.id], self.collection.featured_sound_ids)
 
     def test_add_sounds_outside_collection_to_featured(self):
         self.client.force_login(self.user)
@@ -562,3 +547,53 @@ class CollectionTest(TestCase):
         self.assertEqual(0, serialized_by_id[self.sound2.id]["featured_order"])
         self.assertEqual(1, serialized_by_id[self.sound.id]["featured_order"])
         self.assertIsNone(serialized_by_id[self.sound1.id]["featured_order"])
+
+
+class CollectionNumSoundsTest(TestCase):
+    fixtures = ["licenses", "sounds"]
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", email="testuser@freesound.org")
+        _, _, sounds = create_user_and_sounds(
+            num_sounds=3, user=self.user, processing_state="OK", moderation_state="OK"
+        )
+        self.sound, self.sound1, self.sound2 = sounds
+        self.collection = Collection.objects.create(user=self.user, name="testcollection")
+
+    def get_num_sounds(self):
+        self.collection.refresh_from_db()
+        return self.collection.num_sounds
+
+    def test_num_sounds_updated_on_delete(self):
+        CollectionSound.objects.create(user=self.user, sound=self.sound, collection=self.collection, status="OK")
+        cs = CollectionSound.objects.create(user=self.user, sound=self.sound1, collection=self.collection, status="OK")
+        self.assertEqual(2, self.get_num_sounds())
+
+        cs.delete()
+        self.assertEqual(1, self.get_num_sounds())
+
+        # Queryset delete fires post_delete per instance
+        CollectionSound.objects.filter(collection=self.collection).delete()
+        self.assertEqual(0, self.get_num_sounds())
+
+    def test_collection_save_recounts_accepted_sounds(self):
+        # bulk_create does not fire post_save signals, Collection.save() must recount
+        CollectionSound.objects.bulk_create(
+            [
+                CollectionSound(user=self.user, sound=self.sound, collection=self.collection, status="OK"),
+                CollectionSound(user=self.user, sound=self.sound1, collection=self.collection, status="PE"),
+            ]
+        )
+        self.assertEqual(0, self.get_num_sounds())
+        self.collection.save()
+        self.assertEqual(1, self.get_num_sounds())
+
+    def test_bulk_sounds_for_collection_returns_only_accepted_moderated_sounds(self):
+        CollectionSound.objects.create(user=self.user, sound=self.sound, collection=self.collection, status="OK")
+        CollectionSound.objects.create(user=self.user, sound=self.sound1, collection=self.collection, status="PE")
+        # Accepted in the collection but not moderated yet
+        Sound.objects.filter(id=self.sound2.id).update(moderation_state="PE")
+        CollectionSound.objects.create(user=self.user, sound=self.sound2, collection=self.collection, status="OK")
+
+        sound_ids = [s.id for s in Sound.objects.bulk_sounds_for_collection(self.collection.id)]
+        self.assertEqual([self.sound.id], sound_ids)

--- a/fscollections/urls.py
+++ b/fscollections/urls.py
@@ -31,9 +31,4 @@ urlpatterns = [
         views.add_maintainer_modal,
         name="add-maintainers-modal",
     ),
-    path(
-        "<int:collection_id>-<slug:collection_name>/section/stats",
-        views.collection_stats_section,
-        name="collection-stats-section",
-    ),
 ]

--- a/fscollections/views.py
+++ b/fscollections/views.py
@@ -38,6 +38,7 @@ from fscollections.forms import (
     MaintainerForm,
     SelectCollectionOrNewCollectionForm,
 )
+from follow import follow_utils
 from fscollections.models import Collection, CollectionDownload, CollectionDownloadSound, CollectionSound
 from sounds.models import Sound
 from sounds.views import add_sounds_modal_helper
@@ -100,10 +101,13 @@ def collection(request, collection):
     pagination = paginate(request, sounds, settings.BOOKMARKS_PER_PAGE)
     page_sounds = list(pagination["page"])
 
+    is_following = user.is_authenticated and follow_utils.is_user_following_user(user, collection.user)
+
     tvars = {
         "collection": collection,
         "is_owner": is_owner,
         "is_maintainer": is_maintainer,
+        "is_following": is_following,
         "maintainers": collection.maintainers.all(),
         "sort_options": settings.COLLECTION_SORT_OPTIONS,
         "page_sounds": page_sounds,
@@ -124,22 +128,6 @@ def collections_for_user(request):
     # one URL needed to display all collections and one URL to display ONE collection at a time
     # the collections_for_user can be reused to display ONE collection so give it a thought on full collections display
     return render(request, "collections/your_collections.html", tvars)
-
-
-@resolve_collection_from_url
-def collection_stats_section(request, collection):
-    user = request.user
-    is_maintainer = collection.maintainers.filter(username=user.username).exists()
-    is_owner = user == collection.user
-    if not collection.public and not (is_owner or is_maintainer):
-        raise Http404
-
-    # TODO: this tries to imitate the pack_stats_section behaviour despite a lack of comprehension
-    # on cache behaviour, so the stats shown by this are not properly updated
-    if not request.GET.get("ajax"):
-        return HttpResponseRedirect(reverse("your-collections"))
-    tvars = {"collection": collection}
-    return render(request, "collections/collection_stats_section.html", tvars)
 
 
 @login_required
@@ -198,7 +186,10 @@ def create_collection(request):
         form = CreateCollectionForm(request.POST, user=request.user)
         if form.is_valid():
             Collection.objects.create(
-                user=request.user, name=form.cleaned_data["name"], description=form.cleaned_data["description"]
+                user=request.user,
+                name=form.cleaned_data["name"],
+                description=form.cleaned_data["description"],
+                public=form.cleaned_data["public"],
             )
             return JsonResponse({"success": True})
     else:
@@ -264,9 +255,7 @@ def render_collection_cards(request, collection):
       - ``q`` (optional): the active search query, used only to render an
         empty-state message when the supplied id list is empty.
     """
-    is_owner = request.user == collection.user
-    is_maintainer = not is_owner and collection.maintainers.filter(id=request.user.id).exists()
-    if not is_owner and not is_maintainer:
+    if not collection.user_is_owner_or_maintainer(request.user):
         return HttpResponse(status=403)
     raw_ids = request.GET.get("ids", "")
     ids = [int(x) for x in raw_ids.split(",") if x.isdigit()][: settings.MAX_SOUNDS_PER_COLLECTION]
@@ -361,10 +350,7 @@ def edit_collection(request, collection):
 @login_required
 @resolve_collection_from_url
 def download_collection(request, collection):
-    collection_sounds = CollectionSound.objects.filter(collection=collection).values("sound_id")
-    sounds_list = Sound.objects.filter(
-        id__in=collection_sounds, processing_state="OK", moderation_state="OK"
-    ).select_related("user", "license")
+    sounds_list = Sound.objects.bulk_sounds_for_collection(collection.id)
 
     if "range" not in request.headers:
         """

--- a/fscollections/views.py
+++ b/fscollections/views.py
@@ -31,6 +31,7 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonRespons
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
+from follow import follow_utils
 from fscollections.forms import (
     CollectionEditForm,
     CollectionEditFormAsMaintainer,
@@ -38,7 +39,6 @@ from fscollections.forms import (
     MaintainerForm,
     SelectCollectionOrNewCollectionForm,
 )
-from follow import follow_utils
 from fscollections.models import Collection, CollectionDownload, CollectionDownloadSound, CollectionSound
 from sounds.models import Sound
 from sounds.views import add_sounds_modal_helper

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -527,6 +527,16 @@ class SoundManager(models.Manager):
             qs = qs[:limit]
         return qs
 
+    def sounds_for_collection(self, collection_id, base_qs=None):
+        # Accepted public sounds of a collection; lightweight (no display annotations) unless a bulk base_qs is given
+        qs = base_qs if base_qs is not None else self
+        return qs.filter(
+            moderation_state="OK",
+            processing_state="OK",
+            collectionsound__collection_id=collection_id,
+            collectionsound__status="OK",
+        )
+
     def bulk_sounds_for_collection(
         self,
         collection_id,
@@ -540,7 +550,7 @@ class SoundManager(models.Manager):
             include_similarity_vectors=include_similarity_vectors,
             include_remix_subqueries=include_remix_subqueries,
         )
-        qs = qs.filter(moderation_state="OK", processing_state="OK", collections=collection_id).order_by("-created")
+        qs = self.sounds_for_collection(collection_id, base_qs=qs).order_by("-created")
         if limit:
             qs = qs[:limit]
         return qs
@@ -1969,7 +1979,47 @@ class PackManager(models.Manager):
     '''
 
 
-class Pack(models.Model):
+class LicenseSummaryMixin:
+    # Summarizes the licenses of a group of sounds, requires a `licenses_data` property
+    # returning ([license_ids], [license_names])
+
+    VARIOUS_LICENSES_NAME = "Various licenses"
+
+    @cached_property
+    def license_summary(self):
+        # License shared by all sounds, or None if there are various licenses
+        license_ids, _ = self.licenses_data
+        if len(set(license_ids)) == 1:
+            return License.objects.get(id=license_ids[0])
+        return None
+
+    @property
+    def license_summary_name_and_id(self):
+        if self.license_summary is not None:
+            return self.license_summary.name, self.license_summary.id
+        return self.VARIOUS_LICENSES_NAME, None
+
+    @property
+    def license_bw_icon_name(self):
+        license_summary_name, _ = self.license_summary_name_and_id
+        return License.bw_cc_icon_name_from_license_name(license_summary_name)
+
+    @property
+    def license_summary_text(self):
+        if self.license_summary is not None:
+            return self.license_summary.get_short_summary
+        return (
+            f"This {self._meta.model_name} contains sounds released under various licenses. Please check every "
+            "individual sound page (or the <i>readme</i> file upon downloading the "
+            f"{self._meta.model_name}) to know under which license each sound is released."
+        )
+
+    @property
+    def license_summary_deed_url(self):
+        return self.license_summary.deed_url if self.license_summary is not None else ""
+
+
+class Pack(LicenseSummaryMixin, models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
     description = models.TextField(null=True, blank=True, default=None)
@@ -1980,8 +2030,6 @@ class Pack(models.Model):
     num_downloads = models.PositiveIntegerField(default=0)  # Updated via db trigger
     num_sounds = models.PositiveIntegerField(default=0)  # Updated via django Pack.process() method
     is_deleted = models.BooleanField(db_index=True, default=False)
-
-    VARIOUS_LICENSES_NAME = "Various licenses"
 
     objects = PackManager()
 
@@ -2132,44 +2180,6 @@ class Pack(models.Model):
             license_ids = [lid for _, lid in licenses_data]
             license_names = [lname for lname, _ in licenses_data]
             return license_ids, license_names
-
-    @property
-    def license_summary_name_and_id(self):
-        license_ids, license_names = self.licenses_data
-
-        if len(set(license_ids)) == 1:
-            # All sounds have same license
-            license_summary_name = license_names[0]
-            license_id = license_ids[0]
-        else:
-            license_summary_name = self.VARIOUS_LICENSES_NAME
-            license_id = None
-        return license_summary_name, license_id
-
-    @property
-    def license_bw_icon_name(self):
-        license_summary_name, _ = self.license_summary_name_and_id
-        return License.bw_cc_icon_name_from_license_name(license_summary_name)
-
-    @property
-    def license_summary_text(self):
-        license_summary_name, license_summary_id = self.license_summary_name_and_id
-        if license_summary_name != self.VARIOUS_LICENSES_NAME:
-            return License.objects.get(id=license_summary_id).get_short_summary
-        else:
-            return (
-                "This pack contains sounds released under various licenses. Please check every individual sound page "
-                "(or the <i>readme</i> file upon downloading the pack) to know under which "
-                "license each sound is released."
-            )
-
-    @property
-    def license_summary_deed_url(self):
-        license_summary_name, license_summary_id = self.license_summary_name_and_id
-        if license_summary_name != self.VARIOUS_LICENSES_NAME:
-            return License.objects.get(id=license_summary_id).deed_url
-        else:
-            return ""
 
     @property
     def has_geotags(self):

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -1985,19 +1985,19 @@ class LicenseSummaryMixin:
 
     VARIOUS_LICENSES_NAME = "Various licenses"
 
+    @property
+    def license_summary_name_and_id(self):
+        # Name/id of the license shared by all sounds, no DB query needed
+        license_ids, license_names = self.licenses_data
+        if len(set(license_ids)) == 1:
+            return license_names[0], license_ids[0]
+        return self.VARIOUS_LICENSES_NAME, None
+
     @cached_property
     def license_summary(self):
         # License shared by all sounds, or None if there are various licenses
-        license_ids, _ = self.licenses_data
-        if len(set(license_ids)) == 1:
-            return License.objects.get(id=license_ids[0])
-        return None
-
-    @property
-    def license_summary_name_and_id(self):
-        if self.license_summary is not None:
-            return self.license_summary.name, self.license_summary.id
-        return self.VARIOUS_LICENSES_NAME, None
+        _, license_id = self.license_summary_name_and_id
+        return License.objects.get(id=license_id) if license_id is not None else None
 
     @property
     def license_bw_icon_name(self):

--- a/templates/collections/collection.html
+++ b/templates/collections/collection.html
@@ -1,143 +1,179 @@
-{% extends "simple_page.html" %}
-{% load static %}
+{% extends "base.html" %}
+{% load tags %}
 {% load bw_templatetags %}
 {% load display_sound %}
 {% load display_user %}
 {% load util %}
 
-{% block title%}{{collection.name}} - Collection{%endblock title%}
-{% block page-title-custom %}
-<div class="no-paddings col-12 v-spacing-3">
-    <h1><span class="text-light-grey">Collection: </span>{{ collection.name }}</h1>
-</div>
-{% endblock page-title-custom %}
-{% block page-content %}
-<div class="v-spacing-top-5">
-    <div class="row no-gutters">
-        <div class="col-lg-3 offset-lg-1 order-lg-last v-spacing-3">
-            <section class="bw-profile__section_stats v-spacing-top-4 async-section"
-            data-async-section-content-url="{{ collection.stats_section_url }}?ajax=1">
-            <img width="12px" height="12px" src="{% static 'bw-frontend/public/bw_indicator.gif' %}">
-        </section>
-        <div class="v-spacing-top-4">
-            {% if is_owner or is_maintainer%}
-            <a class="no-hover btn-secondary display-inline-block w-100 text-center v-spacing-top-3" href="{{ collection.edit_url }}" title="Edit collection">Edit collection</a>
-            {% endif %}
-            {% if collection.num_sounds > 0%}
-            <a class="no-hover btn-primary display-inline-block w-100 text-center v-spacing-top-3" href="{{ collection.download_url }}" title="Download collection">Download collection</a>
-            {% endif %}
-        </div>
-    </div>    
-    <div class="col-lg-8">
-        
-        <div class="middle bw-sound-page__user v-spacing-top-3">
-            <div class="h-spacing-1 ellipsis">
-                {% bw_user_avatar collection.user.profile.locations.avatar.M.url collection.user.username 40 %}
-            </div>
-            <div class="h-spacing-left-1">
-                <a href="{% url 'account' collection.user.username %}">{{ collection.user.username | truncate_string:15 }}</a>
-                <p class="text-grey">{{ collection.created|date:"F jS, Y" }}</p>
-            </div>
-        </div>
-        
-        {% if maintainers %}
-        <div class="text-grey v-spacing-2 v-spacing-top-4">Collection maintainers:</div>
+{% block title %}{{collection.name}} - Collection{% endblock title %}
+
+{% block content %}
+<div class="container">
+    <div class="navbar-space-filler v-spacing-7 padding-bottom-7 v-spacing-top-5">
         <div class="row no-gutters">
-            {% for user in maintainers %}
-            <div class="col-sm-6 col-md-4 col-lg-3">
-                {% display_user user %}  
-            </div>
-            {% endfor %}
-        </div>
-        {% endif %}
-        
-        {% if collection.description %}
-        <div class="v-spacing-top-4">{{collection.description}}</div>
-        {% endif %}
-        {% if paginator.count %}
-        <form method="get"
-              action="{{ collection.get_absolute_url }}"
-              class="v-spacing-top-5">
-            <div class="v-spacing-3">
-                <div class="row middle">
-                    <div class="col-md-4">
-                        <div class="input-wrapper w-100">
-                            <i class="bw-icon-search input-icon"></i>
-                            <input id="collection-search"
-                                   type="search"
-                                   name="q"
-                                   placeholder="Search in collection..."
-                                   autocomplete="off"
-                                   value="{{ current_search|default:'' }}"
-                                   hx-get="{{ collection.get_absolute_url }}"
-                                   hx-trigger="keyup[keyCode==13], search"
-                                   hx-target="#sounds-section"
-                                   hx-select="#sounds-section"
-                                   hx-swap="outerHTML"
-                                   hx-push-url="true"
-                                   hx-include="#collection-search, #sort-select"
-                                   hx-indicator="#sounds-section"
-                                   hx-on:keydown="if(event.key==='Enter') event.preventDefault()">
+            <div class="col-md-8">
+                <div class="bw-sound-page__information word-wrap-break-word">
+                    <div class="row middle">
+                        <div class="col-10">
+                            <h1><span class="text-light-grey">Collection: </span>{{ collection.name }}</h1>
                         </div>
                     </div>
-                    <div class="col-md-8 text-right v-spacing-top-2 v-spacing-2">
-                        <span class="text-light-grey"><b>Sort by:</b></span>
-                        <select id="sort-select"
-                                name="s"
-                                hx-get="{{ collection.get_absolute_url }}"
-                                hx-trigger="change"
-                                hx-target="#sounds-section"
-                                hx-select="#sounds-section"
-                                hx-swap="outerHTML"
-                                hx-push-url="true"
-                                hx-include="#collection-search, #sort-select"
-                                hx-indicator="#sounds-section">
-                            {% for key, option in sort_options.items %}
-                                <option value="{{ key }}" {% if key == current_sort %}selected{% endif %}>{{ option.0 }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                </div>
-            </div>
-            <div id="sounds-section">
-                <div id="sounds-grid">
-                    {% if page_sounds %}
-                    <div class="row">
-                        {% for sound in page_sounds %}
-                            <div class="col-6 col-sm-4{% if sound.id in featured_sound_ids_set %} featured-highlight{% endif %}">
-                                {% display_sound_small sound %}
+                    <div class="middle v-spacing-top-2">{% bw_generic_stars collection.avg_rating %}<span class="text-grey h-spacing-left-1">{% if collection.num_ratings %}Collection sound's overall rating ({{ collection.num_ratings|formatnumber }}){% else %}Not enough ratings{% endif %}</span></div>
+                    <div class="middle bw-sound-page__user v-spacing-top-5">
+                        <div class="h-spacing-1 ellipsis">
+                            {% bw_user_avatar collection.user.profile.locations.avatar.M.url collection.user.username 40 %}
+                        </div>
+                        <div class="h-spacing-left-1">
+                            <a href="{% url 'account' collection.user.username %}">{{ collection.user.username | truncate_string:15 }}</a>
+                            <p class="text-grey">{{ collection.created|date:"F jS, Y" }}</p>
+                        </div>
+                        {% if collection.user != request.user %}
+                            <div class="h-spacing-left-3">
+                                {% if is_following %}
+                                    <a class="no-hover btn-secondary" href="{% url 'unfollow-user' collection.user.username %}?next={{ next_path }}">Unfollow</a>
+                                {% else %}
+                                    <a class="no-hover btn-inverse" href="{% url 'follow-user' collection.user.username %}?next={{ next_path }}">Follow</a>
+                                {% endif %}
                             </div>
+                        {% endif %}
+                    </div>
+
+                    {% if maintainers %}
+                    <div class="text-grey v-spacing-2 v-spacing-top-4">Collection maintainers:</div>
+                    <div class="row no-gutters">
+                        {% for user in maintainers %}
+                        <div class="col-sm-6 col-md-4 col-lg-3">
+                            {% display_user user %}
+                        </div>
                         {% endfor %}
                     </div>
-                    {% elif current_search %}
-                    <div class="v-spacing-3 text-grey">
-                        No sounds found matching "{{ current_search }}".
-                        <a href="{{ collection.get_absolute_url }}"
-                           hx-get="{{ collection.get_absolute_url }}"
-                           hx-target="#sounds-section"
-                           hx-select="#sounds-section"
-                           hx-swap="outerHTML"
-                           hx-push-url="true"
-                           hx-on:click="document.getElementById('collection-search').value = ''">Clear search</a>
+                    {% endif %}
+
+                    <div class="v-spacing-top-3">
+                        {% if collection.description %}
+                        <div>{{collection.description}}</div>
+                        {% endif %}
+                        <div class="v-spacing-top-3">
+                            {% for tag in collection.get_collection_tags_bw|add_sizes:"count:0.1:1.0" %}
+                                {% bw_tag tag.name 1 '' tag.browse_url tag.size %}
+                            {% endfor %}
+                        </div>
+                    </div>
+                    {% if collection.num_sounds > 0 %}
+                    <form method="get"
+                          action="{{ collection.get_absolute_url }}"
+                          class="v-spacing-top-5">
+                        <div class="v-spacing-3">
+                            <div class="row middle">
+                                <div class="col-md-4">
+                                    <div class="input-wrapper w-100">
+                                        <i class="bw-icon-search input-icon"></i>
+                                        <input id="collection-search"
+                                               type="search"
+                                               name="q"
+                                               placeholder="Search in collection..."
+                                               autocomplete="off"
+                                               value="{{ current_search|default:'' }}"
+                                               hx-get="{{ collection.get_absolute_url }}"
+                                               hx-trigger="keyup[keyCode==13], search"
+                                               hx-target="#sounds-section"
+                                               hx-select="#sounds-section"
+                                               hx-swap="outerHTML"
+                                               hx-push-url="true"
+                                               hx-include="#collection-search, #sort-select"
+                                               hx-indicator="#sounds-section"
+                                               hx-on:keydown="if(event.key==='Enter') event.preventDefault()">
+                                    </div>
+                                </div>
+                                <div class="col-md-8 text-right v-spacing-top-2 v-spacing-2">
+                                    <span class="text-light-grey"><b>Sort by:</b></span>
+                                    <select id="sort-select"
+                                            name="s"
+                                            hx-get="{{ collection.get_absolute_url }}"
+                                            hx-trigger="change"
+                                            hx-target="#sounds-section"
+                                            hx-select="#sounds-section"
+                                            hx-swap="outerHTML"
+                                            hx-push-url="true"
+                                            hx-include="#collection-search, #sort-select"
+                                            hx-indicator="#sounds-section">
+                                        {% for key, option in sort_options.items %}
+                                            <option value="{{ key }}" {% if key == current_sort %}selected{% endif %}>{{ option.0 }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="sounds-section">
+                            <div id="sounds-grid">
+                                {% if page_sounds %}
+                                <div class="row">
+                                    {% for sound in page_sounds %}
+                                        <div class="col-6 col-sm-4">
+                                            {% if sound.id in featured_sound_ids_set %}
+                                            <div class="featured-highlight">
+                                                <span class="featured-badge">Featured</span>
+                                                {% display_sound_small sound %}
+                                            </div>
+                                            {% else %}
+                                            {% display_sound_small sound %}
+                                            {% endif %}
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                                {% elif current_search %}
+                                <div class="v-spacing-7 v-spacing-top-6 w-100">
+                                    <h5>No results... &#128543</h5>
+                                    <p class="text-grey v-spacing-2">Please try another query or
+                                        <a href="{{ collection.get_absolute_url }}"
+                                           hx-get="{{ collection.get_absolute_url }}"
+                                           hx-target="#sounds-section"
+                                           hx-select="#sounds-section"
+                                           hx-swap="outerHTML"
+                                           hx-push-url="true"
+                                           hx-on:click="document.getElementById('collection-search').value = ''">clear the search</a>
+                                    </p>
+                                </div>
+                                {% endif %}
+                            </div>
+                            <div id="sounds-pagination" class="v-spacing-top-3">
+                                {% with hx_target="#sounds-section" %}
+                                    {% bw_paginator paginator page current_page request %}
+                                {% endwith %}
+                            </div>
+                        </div>
+                    </form>
+
+                    {% if collection.public and collection.num_sounds > 0 %}
+                    <div class="v-spacing-top-4 text-center">
+                        <a class="no-hover" href="{{ collection.get_collection_sounds_in_search_url }}"><button class="btn-primary">Browse collections sounds in the search page</button></a>
+                    </div>
+                    {% endif %}
+                    {% else %}
+                    <div class="text-center v-spacing-top-4">
+                        <h5>No sounds... &#128543</h5>
+                        <div class="text-grey v-spacing-top-1">Looks like {{ collection.name }} has no sounds yet</div>
                     </div>
                     {% endif %}
                 </div>
-                <div id="sounds-pagination" class="v-spacing-top-3">
-                    {% with hx_target="#sounds-section" %}
-                        {% bw_paginator paginator page current_page request %}
-                    {% endwith %}
+            </div>
+            <div class="col-md-4 col-extra-left-padding-large-md">
+                <div class="divider-light v-spacing-top-6 v-spacing-5 d-md-none"></div>
+                <div class="bw-sound__sidebar">
+                    <section class="bw-profile__section_stats v-spacing-top-4">
+                        {% include "collections/collection_stats_section.html" %}
+                    </section>
+                    {% if collection.num_sounds > 0 %}
+                    <div class="v-spacing-top-6">
+                        <a class="no-hover btn-primary display-inline-block w-100 text-center" href="{{ collection.download_url }}" title="Download collection">Download collection</a>
+                    </div>
+                    {% endif %}
+                    {% if is_owner or is_maintainer %}
+                        <a class="no-hover btn-secondary display-inline-block w-100 text-center v-spacing-top-3" href="{{ collection.edit_url }}" title="Edit collection">Edit collection</a>
+                    {% endif %}
                 </div>
             </div>
-        </form>
-
-        {% if collection.public and collection.num_sounds > 0 %}
-        <div class="v-spacing-top-4 text-center">
-            <a class="no-hover" href="{{ collection.get_collection_sounds_in_search_url }}"><button class="btn-primary">Browse collections sounds in the search page</button></a>
         </div>
-        {% endif %}
-        {% endif %}
-
     </div>
 </div>
-</div>
-{% endblock page-content %}
+{% endblock %}

--- a/templates/collections/collection.html
+++ b/templates/collections/collection.html
@@ -63,7 +63,7 @@
                     <form method="get"
                           action="{{ collection.get_absolute_url }}"
                           class="v-spacing-top-5">
-                        <div class="v-spacing-3">
+                        <div class="v-spacing-5">
                             <div class="between middle">
                                 <div class="input-wrapper" style="flex: 0 1 240px; min-width: 0;">
                                     <i class="bw-icon-search input-icon"></i>

--- a/templates/collections/collection.html
+++ b/templates/collections/collection.html
@@ -64,28 +64,26 @@
                           action="{{ collection.get_absolute_url }}"
                           class="v-spacing-top-5">
                         <div class="v-spacing-3">
-                            <div class="row middle">
-                                <div class="col-md-4">
-                                    <div class="input-wrapper w-100">
-                                        <i class="bw-icon-search input-icon"></i>
-                                        <input id="collection-search"
-                                               type="search"
-                                               name="q"
-                                               placeholder="Search in collection..."
-                                               autocomplete="off"
-                                               value="{{ current_search|default:'' }}"
-                                               hx-get="{{ collection.get_absolute_url }}"
-                                               hx-trigger="keyup[keyCode==13], search"
-                                               hx-target="#sounds-section"
-                                               hx-select="#sounds-section"
-                                               hx-swap="outerHTML"
-                                               hx-push-url="true"
-                                               hx-include="#collection-search, #sort-select"
-                                               hx-indicator="#sounds-section"
-                                               hx-on:keydown="if(event.key==='Enter') event.preventDefault()">
-                                    </div>
+                            <div class="between middle">
+                                <div class="input-wrapper" style="flex: 0 1 240px; min-width: 0;">
+                                    <i class="bw-icon-search input-icon"></i>
+                                    <input id="collection-search"
+                                           type="search"
+                                           name="q"
+                                           placeholder="Search in collection..."
+                                           autocomplete="off"
+                                           value="{{ current_search|default:'' }}"
+                                           hx-get="{{ collection.get_absolute_url }}"
+                                           hx-trigger="keyup[keyCode==13], search"
+                                           hx-target="#sounds-section"
+                                           hx-select="#sounds-section"
+                                           hx-swap="outerHTML"
+                                           hx-push-url="true"
+                                           hx-include="#collection-search, #sort-select"
+                                           hx-indicator="#sounds-section"
+                                           hx-on:keydown="if(event.key==='Enter') event.preventDefault()">
                                 </div>
-                                <div class="col-md-8 text-right v-spacing-top-2 v-spacing-2">
+                                <div class="no-text-wrap">
                                     <span class="text-light-grey"><b>Sort by:</b></span>
                                     <select id="sort-select"
                                             name="s"
@@ -125,8 +123,9 @@
                                 <div class="v-spacing-7 v-spacing-top-6 w-100">
                                     <h5>No results... &#128543</h5>
                                     <p class="text-grey v-spacing-2">Please try another query or
-                                        <a href="{{ collection.get_absolute_url }}"
+                                        <a href="{{ collection.get_absolute_url }}?s={{ current_sort }}"
                                            hx-get="{{ collection.get_absolute_url }}"
+                                           hx-include="#sort-select"
                                            hx-target="#sounds-section"
                                            hx-select="#sounds-section"
                                            hx-swap="outerHTML"

--- a/templates/collections/collection_stats_section.html
+++ b/templates/collections/collection_stats_section.html
@@ -16,3 +16,11 @@
         </li>
     </ol>
 </div>
+{% if collection.num_sounds > 0 %}
+<div class="v-spacing-top-5 ellipsis middle">
+    {% bw_icon collection.license_bw_icon_name 'text-light-grey text-30' %} <span class="text-20 h-spacing-left-2">{{ collection.license_summary_name_and_id.0 }}</span>
+</div>
+<div class="text-grey v-spacing-top-1">
+    {{ collection.license_summary_text|safe }} {% if collection.license_summary_deed_url %}<a href="{{ collection.license_summary_deed_url }}" target="_blank" class="bw-link--black">More...</a>{% endif %}
+</div>
+{% endif %}

--- a/templates/collections/display_collection.html
+++ b/templates/collections/display_collection.html
@@ -41,8 +41,13 @@
             {% endif %}
         </div>
     </div>
-    <div>
+    <div class="between">
         <span class="text-grey">{{ collection.created|date:"F jS, Y" }}</span>
+        {% if show_visibility %}
+        <div class="text-grey no-text-wrap" title="This collection is {{ collection.public|yesno:'public,private' }}">
+            <span class="bw-icon-eye{% if not collection.public %}-blocked{% endif %}"></span> {{ collection.public|yesno:"Public,Private" }}
+        </div>
+        {% endif %}
     </div>
     <div class="v-spacing-top-1 bw-player__description-height">
         {% if collection.description %}

--- a/templates/collections/modal_create_collection.html
+++ b/templates/collections/modal_create_collection.html
@@ -11,7 +11,24 @@
     <div class="text-center">
         <h4 class="v-spacing-5">Create collection</h4>
         <form method="post" action="{% url 'create-collection' %}?ajax=1" class="bw-form disable-on-submit">{% csrf_token %}
-            {{form}}
+            {{ form.non_field_errors }}
+            <div class="text-left">
+                <div>
+                    {{ form.name.errors }}
+                    {{ form.name.label_tag }}
+                    {{ form.name }}
+                </div>
+                <div>
+                    {{ form.description.errors }}
+                    {{ form.description.label_tag }}
+                    {{ form.description }}
+                </div>
+                <div>
+                    {{ form.public.errors }}
+                    {{ form.public.label_tag }}
+                    {{ form.public }}
+                </div>
+            </div>
             <button class="btn-primary v-spacing-top-3">Create collection</button>
         </form>
     </div>

--- a/templates/collections/your_collections.html
+++ b/templates/collections/your_collections.html
@@ -35,7 +35,7 @@
                 <div class="row">
                     {% for collection in user_collections %}
                     <div class="col-md-6 col-lg-4 v-spacing-top-3">
-                        {% display_collection collection.id %}
+                        {% display_collection collection %}
                     </div>
                     {% endfor %}
                 </div>
@@ -55,7 +55,7 @@
                 <div class="row">
                     {% for collection in maintainer_collections %}
                     <div class="col-md-6 col-lg-4 v-spacing-top-3">
-                        {% display_collection collection.id %}
+                        {% display_collection collection %}
                     </div>
                     {% endfor %}
                 </div>


### PR DESCRIPTION

### Fixed
- `num_sounds` The old increment/decrement signals were replaced with a single recount (`Collection.update_num_sounds()`) fired only at `post_save` and `post_delete`
- At collection page `{% if paginator.count %}` replaced with `{% if collection.num_sounds > 0 %}` which stays consistent across search queries -> fixes search stacking and empty collections.

### Added
- Redesigned collection page on the standard two-column layout to match `Packs`, added:
   - Overall rating stars, 
   - Owner info and follow/unfollow button,
   - License summary on the collection page via a new `LicenseSummaryMixin` shared with `Pack`
   - Tag cloud built from the collection's sounds (`get_collection_tags_bw`)
- Visibility setting (Public/Private radio) in the create-collection modal, and a visibility
  indicator on collection cards shown to owners/maintainers
- "Featured" badge and card styling for featured sounds (new `$orange` color variable)
- Maintainers can now edit featured sounds
- `SoundManager.sounds_for_collection()`: lightweight accepted-sounds queryset, reused by
  `bulk_sounds_for_collection`
- `Collection.user_is_owner_or_maintainer()` centralizing the permission check used by views,
  forms and templatetags

### Performance fixes
- License summary resolves the `License` object once and caches it (benefits packs too)
- `display_collection` templatetag accepts a `Collection` instance, avoiding a re-fetch per card

### Screenshots about the visual changes:

<img width="1231" height="587" alt="Screenshot 2026-06-12 at 12 34 38" src="https://github.com/user-attachments/assets/5987ebd3-96bc-4bab-bc53-7396145c1bef" />


