### PR TITLE
Add prometheus /metrics endpoint and pushgateway for commands

### DIFF
--- a/freesound/local_settings.example.py
+++ b/freesound/local_settings.example.py
@@ -19,3 +19,8 @@ BULK_UPLOAD_MIN_SOUNDS = 0
 
 # Sentry DSN configuration
 SENTRY_DSN = None
+
+# Prometheus metrics configuration
+# PROMETHEUS_PUSHGATEWAY_URL = "http://pushgateway:9091"
+# PROMETHEUS_METRICS_TOKEN = "if-set-then-/metrics-is-active"
+# PROMETHEUS_PUSHGATEWAY_TIMEOUT_SECONDS = 5

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -181,6 +181,12 @@ SILENCED_SYSTEM_CHECKS = ["urls.W002"]
 
 INTERNAL_IPS = ["127.0.0.1"]
 
+# Bearer token to pull data from /metrics. If empty, the endpoint returns 404
+PROMETHEUS_METRICS_TOKEN = ""
+# Management commands push stats to a pushgateway if this value is set
+PROMETHEUS_PUSHGATEWAY_URL = ""
+PROMETHEUS_PUSHGATEWAY_TIMEOUT_SECONDS = 5
+
 MESSAGE_STORAGE = "django.contrib.messages.storage.cookie.CookieStorage"
 
 PASSWORD_HASHERS = [

--- a/freesound/urls.py
+++ b/freesound/urls.py
@@ -41,6 +41,7 @@ import tags.views
 import utils.tagrecommendation_utilities as tagrec
 from apiv2.apiv2_utils import apiv1_end_of_life_message
 from utils.converters import MultipleTagsConverter
+from utils.prometheus_metrics import prometheus_metrics_view
 
 admin.autodiscover()
 
@@ -48,6 +49,7 @@ register_converter(MultipleTagsConverter, "multitags")
 
 urlpatterns = [
     path("", sounds.views.front_page, name="front-page"),
+    path("metrics", prometheus_metrics_view, name="prometheus-metrics"),
     path("people/", accounts.views.accounts, name="accounts"),
     path("people/<username>/", accounts.views.account, name="account"),
     path("people/<username>/section/stats/", accounts.views.account_stats_section, name="account-stats-section"),

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -31,12 +31,18 @@ from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils import timezone
+from prometheus_client import Counter as PrometheusCounter
 
 import tickets
 from freesound.celery import get_queues_task_counts
 from sounds.models import Sound, SoundAnalysis, SoundSimilarityVector
 from tickets import TICKET_STATUS_CLOSED
 from utils.search import SearchEngineException, get_search_engine
+
+MONITOR_HOME_VIEWS = PrometheusCounter(
+    "freesound_monitor_home_views_total",
+    "Number of times the staff monitor home page has been viewed (test metric)",
+)
 
 
 @login_required
@@ -52,6 +58,8 @@ def get_queues_status(request):
 @login_required
 @user_passes_test(lambda u: u.is_staff, login_url="/")
 def monitor_home(request):
+    # Test instrumentation: bump a counter so we can confirm it appears on /metrics.
+    MONITOR_HOME_VIEWS.inc()
     return HttpResponseRedirect(reverse("monitor-stats"))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "pyparsing==2.4.7",
     "pysndfile~=1.5.3",
     "pysolr==3.10.0",
+    "prometheus-client==0.25.0",
     "pytest~=8.0.2",
     "pytest-django~=4.8.0", # community detection in clustering
     "python-louvain==0.16", # community detection in clustering

--- a/utils/management_commands.py
+++ b/utils/management_commands.py
@@ -25,6 +25,8 @@ import time
 
 from django.core.management.base import BaseCommand
 
+from utils.prometheus_metrics import make_command_registry, push_to_gateway_safe
+
 commands_logger = logging.getLogger("commands")
 
 
@@ -42,6 +44,8 @@ class LoggingBaseCommand(BaseCommand):
     and end of the self.handle() function respectively. Optionally, a `data` dictionary can be passed to both
     self.log_start() and self.log_end() so that the data will be also sent (and parsed) in the logging server. This
     data dictionary must be JSON serializable.
+
+    This command also sends the execution time and final status for each command to prometheus pushgateway.
     """
 
     start_time = None
@@ -52,6 +56,22 @@ class LoggingBaseCommand(BaseCommand):
             if "manage.py" in arg:
                 return sys.argv[count + 1]
         return None
+
+    def execute(self, *args, **options):
+        start = time.monotonic()
+        name = self.find_command_name() or self.__class__.__module__.split(".")[-1]
+        ok = False
+        try:
+            result = super().execute(*args, **options)
+            ok = True
+            return result
+        except SystemExit as e:
+            ok = e.code in (0, None)
+            raise
+        finally:
+            duration_seconds = time.monotonic() - start
+            registry = make_command_registry(duration_seconds=duration_seconds, success=ok)
+            push_to_gateway_safe(job=name, registry=registry)
 
     def log_start(self, data=None):
         self.start_time = time.monotonic()

--- a/utils/prometheus_metrics.py
+++ b/utils/prometheus_metrics.py
@@ -1,0 +1,89 @@
+import hmac
+import logging
+import os
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.views.decorators.http import require_GET
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    generate_latest,
+    push_to_gateway,
+)
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.multiprocess import MultiProcessCollector
+
+logger = logging.getLogger("commands")
+
+
+def _authorized(request):
+    expected = getattr(settings, "PROMETHEUS_METRICS_TOKEN", None)
+    header = request.META.get("HTTP_AUTHORIZATION", "")
+    prefix = "Bearer "
+    if not header.startswith(prefix):
+        return False
+    return hmac.compare_digest(header[len(prefix) :], expected)
+
+
+@require_GET
+def prometheus_metrics_view(request):
+    """GET view that returns prometheus metrics for this webserver.
+    Because gunicorn runs multiple subprocesses, we use the built-in
+    PROMETHEUS_MULTIPROC_DIR functionality in prometheus_client: If it's set
+    to a directory then different processes automatically write metrics there and
+    whatever process gets the request will aggregate and return them.
+    When running as a single process (dev server) then just return in-memory metrics."""
+    if not getattr(settings, "PROMETHEUS_METRICS_TOKEN", None):
+        return HttpResponse(status=404)
+    if not _authorized(request):
+        return HttpResponse("Unauthorized", status=401)
+    if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+        registry = CollectorRegistry()
+        MultiProcessCollector(registry)
+        output = generate_latest(registry)
+    else:
+        output = generate_latest()
+    return HttpResponse(output, content_type=CONTENT_TYPE_LATEST)
+
+
+def push_to_gateway_safe(job, registry):
+    url: str | None = getattr(settings, "PROMETHEUS_PUSHGATEWAY_URL", None)
+    if not url:
+        return
+    timeout = getattr(settings, "PROMETHEUS_PUSHGATEWAY_TIMEOUT_SECONDS", 5)
+    try:
+        push_to_gateway(url, job=job, registry=registry, timeout=timeout)
+    except Exception:
+        logger.warning("Failed to push metrics to Pushgateway", exc_info=True)
+
+
+class ManagementCommandCollector:
+    """Stats to store for a management command. We store one metric per command marking
+    how long the last run took and what its status was. Details of the command are sent
+    to the pushgateway."""
+
+    def __init__(self, duration_seconds, success):
+        self.duration_seconds = duration_seconds
+        self.success = success
+
+    def collect(self):
+        duration = GaugeMetricFamily(
+            "freesound_management_command_last_duration_seconds",
+            "Duration of last command run",
+        )
+        duration.add_metric([], self.duration_seconds)
+        yield duration
+
+        success = GaugeMetricFamily(
+            "freesound_management_command_last_success",
+            "Whether last command run succeeded (1=ok, 0=error)",
+        )
+        success.add_metric([], 1 if self.success else 0)
+        yield success
+
+
+def make_command_registry(duration_seconds, success):
+    registry = CollectorRegistry()
+    registry.register(ManagementCommandCollector(duration_seconds, success))
+    return registry

--- a/utils/test_prometheus_metrics.py
+++ b/utils/test_prometheus_metrics.py
@@ -1,0 +1,139 @@
+import re
+from unittest.mock import Mock
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from prometheus_client import CollectorRegistry, generate_latest
+
+import utils.management_commands as management_commands
+import utils.prometheus_metrics as prometheus_metrics
+from utils.management_commands import LoggingBaseCommand
+from utils.prometheus_metrics import make_command_registry, push_to_gateway_safe
+
+
+class MetricsEndpointTest:
+    def test_metrics_endpoint_uses_current_token_setting(self, client, settings):
+        # none token is 404
+        settings.PROMETHEUS_METRICS_TOKEN = None
+        assert client.get("/metrics").status_code == 404
+
+        # empty token is 404
+        settings.PROMETHEUS_METRICS_TOKEN = ""
+        assert client.get("/metrics").status_code == 404
+
+        # wrong token/correct token
+        settings.PROMETHEUS_METRICS_TOKEN = "test-token"  # noqa: S105
+        assert client.get("/metrics").status_code == 401
+        assert client.get("/metrics", HTTP_AUTHORIZATION="Bearer wrong").status_code == 401
+
+        response = client.get("/metrics", HTTP_AUTHORIZATION="Bearer test-token")
+
+        assert response.status_code == 200
+        assert b"python_info" in response.content
+
+    def test_metrics_endpoint_requires_get(self, client, settings):
+        # only supports GET
+        settings.PROMETHEUS_METRICS_TOKEN = "test-token"  # noqa: S105
+
+        response = client.post("/metrics")
+
+        assert response.status_code == 405
+
+
+class PushgatewayHelperTest:
+    def test_push_to_gateway_safe_noops_without_url(self, monkeypatch, settings):
+        settings.PROMETHEUS_PUSHGATEWAY_URL = None
+        mocked_push_to_gateway = Mock()
+        monkeypatch.setattr(prometheus_metrics, "push_to_gateway", mocked_push_to_gateway)
+        registry = CollectorRegistry()
+
+        push_to_gateway_safe("test-job", registry)
+
+        mocked_push_to_gateway.assert_not_called()
+
+    def test_push_to_gateway_safe_pushes_with_timeout(self, monkeypatch, settings):
+        settings.PROMETHEUS_PUSHGATEWAY_URL = "http://pushgateway:9091"
+        settings.PROMETHEUS_PUSHGATEWAY_TIMEOUT_SECONDS = 5
+        mocked_push_to_gateway = Mock()
+        monkeypatch.setattr(prometheus_metrics, "push_to_gateway", mocked_push_to_gateway)
+        registry = CollectorRegistry()
+
+        push_to_gateway_safe("test-job", registry)
+
+        mocked_push_to_gateway.assert_called_once_with(
+            "http://pushgateway:9091",
+            job="test-job",
+            registry=registry,
+            timeout=5,
+        )
+
+    def test_push_to_gateway_safe_swallows_push_errors(self, monkeypatch, settings):
+        settings.PROMETHEUS_PUSHGATEWAY_URL = "http://pushgateway:9091"
+        mocked_push_to_gateway = Mock(side_effect=OSError("unreachable"))
+        monkeypatch.setattr(prometheus_metrics, "push_to_gateway", mocked_push_to_gateway)
+        registry = CollectorRegistry()
+
+        push_to_gateway_safe("test-job", registry)
+
+        mocked_push_to_gateway.assert_called_once()
+
+
+class SuccessfulCommand(LoggingBaseCommand):
+    def handle(self, *args, **options):
+        return "done"
+
+
+class FailingCommand(LoggingBaseCommand):
+    def handle(self, *args, **options):
+        raise CommandError("nope")
+
+
+class SystemExitCommand(LoggingBaseCommand):
+    def handle(self, *args, **options):
+        raise SystemExit(0)
+
+
+class LoggingBaseCommandMetricsTest:
+    def test_successful_command_pushes_success_and_duration(self, monkeypatch):
+        mocked_push_to_gateway_safe = Mock()
+        monkeypatch.setattr(management_commands, "push_to_gateway_safe", mocked_push_to_gateway_safe)
+
+        output = call_command(SuccessfulCommand())
+
+        assert output == "done"
+        mocked_push_to_gateway_safe.assert_called_once()
+        assert mocked_push_to_gateway_safe.call_args.kwargs["job"] == "test_prometheus_metrics"
+        metrics = generate_latest(mocked_push_to_gateway_safe.call_args.kwargs["registry"])
+        assert b"freesound_management_command_last_success 1.0" in metrics
+        assert re.search(rb"freesound_management_command_last_duration_seconds [0-9.]+", metrics)
+
+    def test_failing_command_pushes_failure_and_reraises(self, monkeypatch):
+        mocked_push_to_gateway_safe = Mock()
+        monkeypatch.setattr(management_commands, "push_to_gateway_safe", mocked_push_to_gateway_safe)
+
+        with pytest.raises(CommandError):
+            call_command(FailingCommand())
+
+        mocked_push_to_gateway_safe.assert_called_once()
+        metrics = generate_latest(mocked_push_to_gateway_safe.call_args.kwargs["registry"])
+        assert b"freesound_management_command_last_success 0.0" in metrics
+
+    def test_clean_system_exit_counts_as_success(self, monkeypatch):
+        mocked_push_to_gateway_safe = Mock()
+        monkeypatch.setattr(management_commands, "push_to_gateway_safe", mocked_push_to_gateway_safe)
+
+        with pytest.raises(SystemExit):
+            call_command(SystemExitCommand())
+
+        metrics = generate_latest(mocked_push_to_gateway_safe.call_args.kwargs["registry"])
+        assert b"freesound_management_command_last_success 1.0" in metrics
+
+    def test_make_command_registry_contains_only_command_metrics(self):
+        registry = make_command_registry(duration_seconds=1.2, success=True)
+
+        metrics = generate_latest(registry)
+
+        assert b"freesound_management_command_last_duration_seconds 1.2" in metrics
+        assert b"freesound_management_command_last_success 1.0" in metrics
+        assert b"python_info" not in metrics

--- a/uv.lock
+++ b/uv.lock
@@ -726,6 +726,7 @@ dependencies = [
     { name = "oauthlib" },
     { name = "openpyxl" },
     { name = "pillow" },
+    { name = "prometheus-client" },
     { name = "psutil" },
     { name = "psycopg" },
     { name = "pyjwt" },
@@ -796,6 +797,7 @@ requires-dist = [
     { name = "oauthlib", specifier = ">=3.3.1" },
     { name = "openpyxl", specifier = "==3.1.0" },
     { name = "pillow", specifier = "==9.5.0" },
+    { name = "prometheus-client", specifier = "==0.25.0" },
     { name = "psutil", specifier = "~=7.0.0" },
     { name = "psycopg", specifier = "~=3.2.4" },
     { name = "pyjwt", specifier = "==2.6.0" },
@@ -1248,6 +1250,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description**
First part of the work to migrate graylog metrics to grafana, this just sets up the endpoints and a test command

**Deployment steps**:
needs to be deployed in parallel with the deploy repo which includes the pushgateway configuration