### PR TITLE
Fix Pagination + filtering in search page can return unexpected results

### DIFF
--- a/utils/search/search_query_processor.py
+++ b/utils/search/search_query_processor.py
@@ -796,8 +796,13 @@ class SearchQueryProcessor:
             base_url = reverse("sounds-search")
 
         # Add query parameters from search options
+        # Skipping the page option while iterating
+
+
         parameters_to_add = {}
-        for option in self.options.values():
+        for option_name, option in self.options.items():
+            if option_name == "page":
+                continue
             if option.set_in_request and not option.is_default_value:
                 params_for_url = option.as_URL_params()
                 if params_for_url is not None:

--- a/utils/tests/test_search_query_processor.py
+++ b/utils/tests/test_search_query_processor.py
@@ -103,10 +103,11 @@ class SearchQueryProcessorTests(TestCase):
         )
         self.assertGetUrlAsExpected(sqp, url)
 
-        # With page number specified
+        # With page number specified.
+        # It should now reset the page number if having a filter (see get_url)
         sqp, url = self.run_fake_search_query_processor(params={"page": "3"})
         self.assertExpectedParams(sqp.as_query_params(), {"current_page": 3})
-        self.assertGetUrlAsExpected(sqp, url)
+        self.assertGetUrlAsExpected(sqp, url.replace("page=3", ""))
 
         # With "search in" options specified
         sqp, url = self.run_fake_search_query_processor(
@@ -244,7 +245,7 @@ class SearchQueryProcessorTests(TestCase):
                 "field_list": ["id", "score", "geotag"],
             },
         )
-        self.assertGetUrlAsExpected(sqp, url)
+        self.assertGetUrlAsExpected(sqp, url.replace("page=3", ""))
 
         # With tags mode
         sqp, url = self.run_fake_search_query_processor(base_url=reverse("tags"))
@@ -372,6 +373,12 @@ class SearchQueryProcessorTests(TestCase):
         # Test remove_filters removes them from the URL
         sqp, _ = self.run_fake_search_query_processor(params={"f": 'filter1:"aaa" filter2:123'})
         self.assertEqual(sqp.get_url(remove_filters=['filter1:"aaa"', "filter2:123"]), "/search/")
+
+        # Test that when browsing a page other than the first one, the generated URLs remove the page parameter
+        sqp, _ = self.run_fake_search_query_processor(params={"q": "test", "page": "2"})
+        self.assertEqual(sqp.get_url(add_filters=['tag:"tag1"']), "/search/?q=test&f=tag%3A%22tag1%22")
+        sqp, _ = self.run_fake_search_query_processor(params={"f": 'filter1:"aaa"', "page": "2"})
+        self.assertEqual(sqp.get_url(remove_filters=['filter1:"aaa"']), "/search/")
 
     def test_search_query_processor_contains_active_advanced_search_options(self):
         # Query with no params


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/2137

**Description**
Fixes #2137 

Before: 

https://github.com/user-attachments/assets/058882d1-465d-410b-9191-4215a473da3c

After:

https://github.com/user-attachments/assets/57db522a-8d68-454a-8ff3-2c52beddae3a

Details:

## Fix: pagination + filtering in search page can return unexpected (empty) results

### Problem

If a user is browsing page 2 of a search result set and then adds a facet filter (or removes an existing one, or changes the selected cluster), the new query loads while still on page 2. The filtered result set often has fewer pages, so the user can land on an out-of-range page that shows no results, even though matching sounds exist.

### Root cause

Facet and filter links are generated by `SearchQueryProcessor.get_url()`. That method rebuilds the URL from all currently active search options, and `page` is one of those options. When you are on page 2, `page=2` is a non-default, in-request value, so it gets copied into every generated URL; this includes the "add filter" and "remove filter" links. Following such a link re-runs the modified query but keeps the stale page number.

Pagination links themselves are built by a separate mechanism (`bw_paginator`, using the request's GET params), and normal form submissions like sort, query, and advanced options already reset the page because the search form has no hidden `page` field. So the bug was isolated to `get_url()`.

### Fix

`get_url()` now skips the `page` option when rebuilding the URL. Every caller of it (facet add-filter links, active-filter remove links, and cluster-change links) produces a different result set where the old page number is no longer meaningful, so the generated URL always points to page 1. The current query itselrams()` still applies `current_page`, and paginationis untouched.

### Changes
- `utils/search/search_query_processor.py`: skip the `page` option in the `get_url()` option loop.
- `utils/tests/test_search_query_processor.py`: update two assertions that expected `page` to be echoed back into `get_url()`, and add coverage that adding or removing a filter from page

### Testing

`utils/tests/test_search_query_processor.py` passes (8/8). Example of the added assertion:

```python
sqp, _ = self.run_fake_search_query_processor(params={"q": "test", "page": "2"})
self.assertEqual(sqp.get_url(add_filters=['tag:"tag1"']), "/search/?q=test&f=tag%3A%22tag1%22")
```

Note that `page=2` is gone from the output while `q=test` is preserved.


**Deployment steps**:
None
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
