### PR TITLE
use a real Paginator Page object in all paginators, make pagination consistent

### DIFF
--- a/accounts/tests/test_views.py
+++ b/accounts/tests/test_views.py
@@ -30,7 +30,7 @@ from django.utils.html import escape
 from accounts.models import OldUsername
 from geotags.models import GeoTag
 from sounds.models import Download, PackDownload, SoundOfTheDay
-from utils.search import SearchResultsPaginator
+from utils.pagination import PreSlicedCountProvidedPaginator
 from utils.test_helpers import create_fake_perform_search_engine_query_results_tags_mode, create_user_and_sounds
 
 
@@ -309,7 +309,7 @@ class SimpleUserTest(TestCase):
     @mock.patch("search.views.perform_search_engine_query")
     def test_tags_response(self, perform_search_engine_query):
         results = create_fake_perform_search_engine_query_results_tags_mode()
-        paginator = SearchResultsPaginator(results, 15)
+        paginator = PreSlicedCountProvidedPaginator(results.docs, 15, results.num_found)
         perform_search_engine_query.return_value = (results, paginator)
 
         # 200 response on tags page access

--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -20,7 +20,6 @@
 
 import json
 import logging
-import math
 import urllib.parse
 from urllib.parse import unquote
 
@@ -489,29 +488,6 @@ def get_authentication_details_form_request(request):
 
 def request_parameters_info_for_log_message(get_parameters):
     return ",".join([f"{key}={value}" for key, value in get_parameters.items()])
-
-
-class ApiSearchPaginator:
-    def __init__(self, results, count, num_per_page):
-        self.num_per_page = num_per_page
-        self.count = count
-        self.num_pages = math.ceil(count / num_per_page)
-        self.page_range = list(range(1, self.num_pages + 1))
-        self.results = results
-
-    def page(self, page_num):
-        has_next = page_num < self.num_pages
-        has_previous = 1 < page_num <= self.num_pages
-
-        return {
-            "object_list": self.results,
-            "has_next": has_next,
-            "has_previous": has_previous,
-            "has_other_pages": has_next or has_previous,
-            "next_page_number": page_num + 1,
-            "previous_page_number": page_num - 1,
-            "page_num": page_num,
-        }
 
 
 # Docs examples utils

--- a/apiv2/tests.py
+++ b/apiv2/tests.py
@@ -24,7 +24,6 @@ from django.contrib.sites.models import Site
 from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
 
-from apiv2.apiv2_utils import ApiSearchPaginator
 from apiv2.models import ApiV2Client
 from apiv2.serializers import DEFAULT_FIELDS_IN_SOUND_LIST, SoundListSerializer, SoundSerializer
 from bookmarks.models import Bookmark, BookmarkCategory
@@ -145,25 +144,6 @@ class TestAPI(TestCase):
             "/apiv2/search/text/?query=ambient&filter=tag:(rain%20OR%CAfe)", secure=True, **headers
         )
         self.assertEqual(resp.status_code, 200)
-
-
-class ApiSearchPaginatorTest(TestCase):
-    def test_page(self):
-        paginator = ApiSearchPaginator([1, 2, 3, 4, 5], 5, 2)
-        page = paginator.page(2)
-
-        self.assertEqual(
-            page,
-            {
-                "object_list": [1, 2, 3, 4, 5],
-                "has_next": True,
-                "has_previous": True,
-                "has_other_pages": True,
-                "next_page_number": 3,
-                "previous_page_number": 1,
-                "page_num": 2,
-            },
-        )
 
 
 class TestSoundCombinedSearchFormAPI(SimpleTestCase):

--- a/apiv2/views.py
+++ b/apiv2/views.py
@@ -83,10 +83,10 @@ from sounds.models import License, Pack, Sound
 from utils.downloads import download_sounds
 from utils.filesystem import generate_tree
 from utils.nginxsendfile import prepare_sendfile_arguments_for_sound_download, sendfile
+from utils.pagination import PreSlicedCountProvidedPaginator
 from utils.tags import clean_and_split_tags
 
 from .apiv2_utils import (
-    ApiSearchPaginator,
     DownloadAPIView,
     GenericAPIView,
     ListAPIView,
@@ -199,7 +199,7 @@ class TextSearch(GenericAPIView):
             raise ServerErrorException(msg="Unexpected error", resource=self)
 
         # Paginate results
-        paginator = ApiSearchPaginator(results, count, search_form.cleaned_data["page_size"])
+        paginator = PreSlicedCountProvidedPaginator(results, search_form.cleaned_data["page_size"], count)
         if search_form.cleaned_data["page"] > paginator.num_pages and count != 0:
             raise NotFoundException(resource=self)
         page = paginator.page(search_form.cleaned_data["page"])
@@ -207,18 +207,18 @@ class TextSearch(GenericAPIView):
         response_data["count"] = paginator.count
         response_data["previous"] = None
         response_data["next"] = None
-        if page["has_other_pages"]:
-            if page["has_previous"]:
+        if page.has_other_pages():
+            if page.has_previous():
                 response_data["previous"] = search_form.construct_link(
-                    reverse("apiv2-sound-search"), page=page["previous_page_number"]
+                    reverse("apiv2-sound-search"), page=page.previous_page_number()
                 )
-            if page["has_next"]:
+            if page.has_next():
                 response_data["next"] = search_form.construct_link(
-                    reverse("apiv2-sound-search"), page=page["next_page_number"]
+                    reverse("apiv2-sound-search"), page=page.next_page_number()
                 )
 
         # Get analysis data and serialize sound results
-        object_list = [ob for ob in page["object_list"]]
+        object_list = [ob for ob in page.object_list]
         id_score_map = dict(object_list)
         sound_ids = [ob[0] for ob in object_list]
         # In search queries, only include audio analyzer's output if requested through the fields parameter
@@ -381,7 +381,7 @@ class SimilarSounds(GenericAPIView):
         results = [sound_id for sound_id, _ in results]
 
         # Paginate results
-        paginator = ApiSearchPaginator(results, count, similarity_sound_form.cleaned_data["page_size"])
+        paginator = PreSlicedCountProvidedPaginator(results, similarity_sound_form.cleaned_data["page_size"], count)
         if similarity_sound_form.cleaned_data["page"] > paginator.num_pages and count != 0:
             raise NotFoundException(resource=self)
         page = paginator.page(similarity_sound_form.cleaned_data["page"])
@@ -389,19 +389,19 @@ class SimilarSounds(GenericAPIView):
         response_data["count"] = paginator.count
         response_data["previous"] = None
         response_data["next"] = None
-        if page["has_other_pages"]:
-            if page["has_previous"]:
+        if page.has_other_pages():
+            if page.has_previous():
                 response_data["previous"] = similarity_sound_form.construct_link(
-                    reverse("apiv2-similarity-sound", args=[sound_id]), page=page["previous_page_number"]
+                    reverse("apiv2-similarity-sound", args=[sound_id]), page=page.previous_page_number()
                 )
-            if page["has_next"]:
+            if page.has_next():
                 response_data["next"] = similarity_sound_form.construct_link(
-                    reverse("apiv2-similarity-sound", args=[sound_id]), page=page["next_page_number"]
+                    reverse("apiv2-similarity-sound", args=[sound_id]), page=page.next_page_number()
                 )
 
         # Serialize sound results
         # In search queries, only include audio analyzer's output if requested through the fields parameter
-        ids = [id for id in page["object_list"]]
+        ids = [id for id in page.object_list]
         needs_analyzers_output = get_needed_audio_descriptors(similarity_sound_form.cleaned_data.get("fields", ""))
         needs_similarity_vectors = get_needed_similarity_vectors(similarity_sound_form.cleaned_data.get("fields", ""))
         include_remix_subqueries = get_include_remix_subqueries(similarity_sound_form.cleaned_data.get("fields", ""))

--- a/fscollections/tests.py
+++ b/fscollections/tests.py
@@ -514,6 +514,30 @@ class CollectionTest(TestCase):
             html.index(f'data-object-id="{self.sound.id}"'),
         )
 
+    def test_render_collection_cards_renders_pager_when_multiple_pages(self):
+        """verify that the paginator shows 2 pages"""
+        self.client.force_login(self.user)
+        cards_url = reverse("collection-render-cards", args=[self.collection.id, slugify(self.collection.name)])
+        resp = self.client.get(
+            cards_url,
+            {"ids": f"{self.sound2.id},{self.sound.id}", "page": "1", "total": "2"},
+            HTTP_HX_CURRENT_URL="/collections/test/edit/",
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertContains(resp, "page=2")
+
+    def test_render_collection_cards_clamps_overflow_page(self):
+        """verify that asking for a large page number if there are only 2 doesn't raise"""
+        self.client.force_login(self.user)
+        cards_url = reverse("collection-render-cards", args=[self.collection.id, slugify(self.collection.name)])
+        resp = self.client.get(
+            cards_url,
+            {"ids": f"{self.sound2.id},{self.sound.id}", "page": "99", "total": "2"},
+            HTTP_HX_CURRENT_URL="/collections/test/edit/",
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(resp.context["current_page"], 2)
+
     def test_render_collection_cards_forbidden_for_non_member(self):
         self.client.force_login(self.external_user)
         cards_url = reverse("collection-render-cards", args=[self.collection.id, slugify(self.collection.name)])

--- a/fscollections/views.py
+++ b/fscollections/views.py
@@ -43,7 +43,7 @@ from fscollections.models import Collection, CollectionDownload, CollectionDownl
 from sounds.models import Sound
 from sounds.views import add_sounds_modal_helper
 from utils.downloads import download_sounds
-from utils.pagination import build_paginator_template_context, paginate
+from utils.pagination import build_paginator_template_context, paginate, read_page
 
 
 def resolve_collection_from_url(view_func):
@@ -274,7 +274,7 @@ def render_collection_cards(request, collection):
     if raw_page and raw_total:
         try:
             total_pages = int(raw_total)
-            page_num = max(1, min(int(raw_page), max(1, total_pages)))
+            page_num = min(read_page(request), max(1, total_pages))
             paginator_ns = SimpleNamespace(num_pages=total_pages)
             page_dict = {
                 "has_previous": page_num > 1,

--- a/fscollections/views.py
+++ b/fscollections/views.py
@@ -20,12 +20,12 @@
 
 from functools import wraps
 from operator import itemgetter
-from types import SimpleNamespace
 
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.core.paginator import Paginator
 from django.db.models import Case, IntegerField, Q, Value, When
 from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
@@ -275,16 +275,13 @@ def render_collection_cards(request, collection):
         try:
             total_pages = int(raw_total)
             page_num = min(read_page(request), max(1, total_pages))
-            paginator_ns = SimpleNamespace(num_pages=total_pages)
-            page_dict = {
-                "has_previous": page_num > 1,
-                "has_next": page_num < total_pages,
-                "previous_page_number": page_num - 1,
-                "next_page_number": page_num + 1,
-            }
+            # Make a fake Paginator with `total_pages` pages so that the template can
+            # render the paginator
+            paginator = Paginator(range(total_pages), 1)
+            page = paginator.page(page_num)
             tvars.update(
                 build_paginator_template_context(
-                    paginator_ns, page_dict, page_num, base_path=request.path, base_query=request.GET
+                    paginator, page, page_num, base_path=request.path, base_query=request.GET
                 )
             )
             tvars["has_paginator"] = True

--- a/fscollections/views.py
+++ b/fscollections/views.py
@@ -279,11 +279,7 @@ def render_collection_cards(request, collection):
             # render the paginator
             paginator = Paginator(range(total_pages), 1)
             page = paginator.page(page_num)
-            tvars.update(
-                build_paginator_template_context(
-                    paginator, page, page_num, base_path=request.path, base_query=request.GET
-                )
-            )
+            tvars.update(build_paginator_template_context(page, base_path=request.path, base_query=request.GET))
             tvars["has_paginator"] = True
         except (ValueError, TypeError):
             pass

--- a/general/templatetags/bw_templatetags.py
+++ b/general/templatetags/bw_templatetags.py
@@ -179,16 +179,14 @@ def bw_generic_stars(context, rating_0_10):
 
 
 @register.inclusion_tag("molecules/paginator.html", takes_context=True)
-def bw_paginator(context, paginator, page, current_page, request, anchor="", non_grouped_number_of_results=-1):
+def bw_paginator(context, page, request, anchor="", non_grouped_number_of_results=-1):
     """
     Adds pagination context variables for use in displaying first, adjacent and
     last page links in addition to those created by the object_list generic
     view.
     """
     return build_paginator_template_context(
-        paginator,
         page,
-        current_page,
         base_path=request.path,
         base_query=request.GET,
         anchor=anchor,

--- a/search/tests.py
+++ b/search/tests.py
@@ -172,6 +172,87 @@ class SearchPageLowerClampTests(TestCase):
         self.assertEqual(engine.search_forum_posts.call_args.kwargs["current_page"], 1)
 
 
+class SearchOutOfRangeTests(TestCase):
+    """If we ask for a page number past the number of available results then
+    show a message instead of an empty page (rendering 0 items).
+    Show a paginator with the last real page of results highlighted, but
+    don't re-run the search on that page."""
+
+    fixtures = ["licenses", "users", "sounds_with_tags"]
+
+    @mock.patch("search.views.perform_search_engine_query")
+    def test_sound_search_past_last_page_shows_message(self, perform_search_engine_query):
+        # num_found > 0 but the requested (overflow) page returned no docs.
+        results = SearchResults(docs=[], num_found=548)
+        # this paginator has 37 pages
+        paginator = PreSlicedCountProvidedPaginator(results.docs, 15, results.num_found)
+        perform_search_engine_query.return_value = (results, paginator)
+
+        resp = self.client.get(reverse("sounds-search") + "?q=test&page=999")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.context["beyond_last"])
+        # actual last page, not what was requested
+        self.assertEqual(resp.context["current_page"], 37)
+        self.assertContains(resp, "No more results")
+        self.assertNotContains(resp, "No results...")
+        content = resp.content.decode()
+        # in the paginator the last real page is the current page - no <a>
+        self.assertInHTML('<li class="bw-pagination_circle bw-pagination_selected">37</li>', content)
+        # page 1 link exists
+        self.assertInHTML('<a href="/search/?q=test&amp;page=1#sound" data-page="1" title="First Page">1</a>', content)
+
+    @mock.patch("search.views.perform_search_engine_query")
+    def test_sound_search_zero_results_shows_no_results(self, perform_search_engine_query):
+        results = SearchResults(docs=[], num_found=0)
+        paginator = PreSlicedCountProvidedPaginator(results.docs, 15, results.num_found)
+        perform_search_engine_query.return_value = (results, paginator)
+
+        resp = self.client.get(reverse("sounds-search") + "?q=nonsense")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.context["beyond_last"])
+        self.assertContains(resp, "No results...")
+        self.assertNotContains(resp, "No more results")
+        # 0 results shows no paginator
+        self.assertNotContains(resp, "bw-pagination_container")
+
+    @mock.patch("search.views.get_search_engine")
+    def test_forum_search_past_last_page_shows_no_more_results(self, get_search_engine):
+        engine = get_search_engine.return_value
+        engine.search_forum_posts.return_value = SearchResults(docs=[], num_found=100)
+
+        resp = self.client.get(reverse("forums-search") + "?q=test&page=999")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.context["beyond_last"])
+        self.assertContains(resp, "No more results")
+        self.assertNotContains(resp, "No results...")
+        # actual last page (100 posts / 20 per page), not what was requested
+        self.assertEqual(resp.context["current_page"], 5)
+        content = resp.content.decode()
+        # in the paginator the last real page is the current page - no <a>
+        self.assertInHTML('<li class="bw-pagination_circle bw-pagination_selected">5</li>', content)
+        # page 1 link exists
+        self.assertInHTML(
+            '<a href="/forum/forums-search/?q=test&amp;page=1" data-page="1" title="Page 1">1</a>', content
+        )
+
+    @mock.patch("search.views.get_search_engine")
+    def test_forum_search_zero_results_shows_no_results(self, get_search_engine):
+        engine = get_search_engine.return_value
+        engine.search_forum_posts.return_value = SearchResults(docs=[], num_found=0)
+
+        resp = self.client.get(reverse("forums-search") + "?q=nonsense")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.context["beyond_last"])
+        self.assertContains(resp, "No results...")
+        self.assertNotContains(resp, "No more results")
+        # 0 results shows no paginator
+        self.assertNotContains(resp, "bw-pagination_container")
+
+
 class SearchResultClustering(TestCase):
     fixtures = ["licenses"]
 

--- a/search/tests.py
+++ b/search/tests.py
@@ -25,7 +25,8 @@ from django.test import TestCase
 from django.urls import reverse
 
 from sounds.models import Sound
-from utils.search import SearchResults, SearchResultsPaginator
+from utils.pagination import PreSlicedCountProvidedPaginator
+from utils.search import SearchResults
 from utils.test_helpers import create_user_and_sounds
 
 
@@ -93,7 +94,7 @@ def create_fake_perform_search_engine_query_response(num_results=15):
         }
         for sound_id, pack_id in sound_ids
     ]
-    paginator = SearchResultsPaginator(results, num_results)
+    paginator = PreSlicedCountProvidedPaginator(results.docs, num_results, results.num_found)
     return (results, paginator)
 
 

--- a/search/tests.py
+++ b/search/tests.py
@@ -142,6 +142,35 @@ class SearchPageTests(TestCase):
             self.client.get(reverse("sounds-search") + "?dp=1&cm=1")
 
 
+class SearchPageLowerClampTests(TestCase):
+    """If ?page= value is < 1 then clamp it to 1 before sending to solr in order to prevent failures"""
+
+    fixtures = ["licenses", "users", "sounds_with_tags"]
+
+    def setUp(self):
+        self.perform_search_engine_query_response = create_fake_perform_search_engine_query_response(15)
+
+    @mock.patch("search.views.perform_search_engine_query")
+    def test_sound_search_page_zero_clamped_before_query(self, perform_search_engine_query):
+        perform_search_engine_query.return_value = self.perform_search_engine_query_response
+
+        resp = self.client.get(reverse("sounds-search") + "?q=test&page=0")
+
+        self.assertEqual(resp.status_code, 200)
+        query_params = perform_search_engine_query.call_args[0][0]
+        self.assertEqual(query_params["current_page"], 1)
+
+    @mock.patch("search.views.get_search_engine")
+    def test_forum_search_page_zero_clamped_before_query(self, get_search_engine):
+        engine = get_search_engine.return_value
+        engine.search_forum_posts.return_value = SearchResults(docs=[], num_found=0)
+
+        resp = self.client.get(reverse("forums-search") + "?q=test&page=0")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(engine.search_forum_posts.call_args.kwargs["current_page"], 1)
+
+
 class SearchResultClustering(TestCase):
     fixtures = ["licenses"]
 

--- a/search/views.py
+++ b/search/views.py
@@ -207,11 +207,19 @@ def search_view_helper(request):
             )
         )
 
+        # If the requested page is beyond the last page of a non-empty result set, the search
+        # engine returns no docs for it; show an explicit "no more results" state and clamp the
+        # pager to the real last page (Solr can't return last-page content without a 2nd query).
+        requested_page = query_params["current_page"]
+        page = paginator.page(requested_page)
+        beyond_last = paginator.count > 0 and requested_page > paginator.num_pages
+
         # Compile template variables
         return {
             "sqp": sqp,
             "error_text": None,
-            "current_page": query_params["current_page"],
+            "current_page": page.number,
+            "beyond_last": beyond_last,
             "has_advanced_search_settings_set": sqp.contains_active_advanced_search_options(),
             "advanced_search_closed_on_load": settings.ADVANCED_SEARCH_MENU_ALWAYS_CLOSED_ON_PAGE_LOAD,
             "map_bytearray_url": map_bytearray_url,
@@ -220,7 +228,7 @@ def search_view_helper(request):
             "get_clusters_url": get_clusters_url,
             "clusters_data": clusters_data,
             "paginator": paginator,
-            "page": paginator.page(query_params["current_page"]),
+            "page": page,
             "docs": docs,
             "facets": results.facets,
             "non_grouped_number_of_results": results.non_grouped_number_of_results,
@@ -355,6 +363,7 @@ def search_forum(request):
     paginator = None
     num_results = None
     page = None
+    beyond_last = False
     results = []
     if search_query.strip() != "" or filter_query:
         # add current forum
@@ -377,7 +386,9 @@ def search_forum(request):
 
             paginator = PreSlicedCountProvidedPaginator(results.docs, settings.FORUM_POSTS_PER_PAGE, results.num_found)
             num_results = paginator.count
+            beyond_last = paginator.count > 0 and current_page > paginator.num_pages
             page = paginator.page(current_page)
+            current_page = page.number  # clamp the pager to the real last page on overflow
             error = False
         except SearchEngineTimeoutException as e:
             search_logger.info(
@@ -410,6 +421,7 @@ def search_forum(request):
         "advanced_search": advanced_search,
         "current_forum": current_forum,
         "current_page": current_page,
+        "beyond_last": beyond_last,
         "date_from": date_from,
         "date_from_display": date_from_display,
         "date_to": date_to,

--- a/search/views.py
+++ b/search/views.py
@@ -41,6 +41,7 @@ from utils.clustering_utilities import (
 )
 from utils.encryption import create_hash
 from utils.logging_filters import get_client_ip
+from utils.pagination import read_page
 from utils.ratelimit import key_for_ratelimiting, rate_per_ip
 from utils.search import (
     SearchEngineException,
@@ -310,10 +311,7 @@ def clustered_graph(request):
 def search_forum(request):
     search_query = request.GET.get("q", "")
     filter_query = request.GET.get("f", "")
-    try:
-        current_page = int(request.GET.get("page", 1))
-    except ValueError:
-        current_page = 1
+    current_page = read_page(request)
     current_forum_name_slug = request.GET.get("forum", "").strip()  # for context sensitive search
     if current_forum_name_slug:
         current_forum = get_object_or_404(forum.models.Forum.objects, name_slug=current_forum_name_slug)

--- a/search/views.py
+++ b/search/views.py
@@ -41,12 +41,11 @@ from utils.clustering_utilities import (
 )
 from utils.encryption import create_hash
 from utils.logging_filters import get_client_ip
-from utils.pagination import read_page
+from utils.pagination import PreSlicedCountProvidedPaginator, read_page
 from utils.ratelimit import key_for_ratelimiting, rate_per_ip
 from utils.search import (
     SearchEngineException,
     SearchEngineTimeoutException,
-    SearchResultsPaginator,
     get_search_engine,
     search_query_processor,
 )
@@ -376,7 +375,7 @@ def search_forum(request):
                 group_by_thread=False,
             )
 
-            paginator = SearchResultsPaginator(results, settings.FORUM_POSTS_PER_PAGE)
+            paginator = PreSlicedCountProvidedPaginator(results.docs, settings.FORUM_POSTS_PER_PAGE, results.num_found)
             num_results = paginator.count
             page = paginator.page(current_page)
             error = False

--- a/tags/tests.py
+++ b/tags/tests.py
@@ -23,7 +23,8 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from tags.models import FS1Tag, Tag
-from utils.search import SearchResults, SearchResultsPaginator
+from utils.pagination import PreSlicedCountProvidedPaginator
+from utils.search import SearchResults
 
 
 def create_fake_search_engine_results():
@@ -52,7 +53,7 @@ def create_fake_perform_search_engine_query_response(num_results):
         }
         for sound_id, pack_id in zip(range(num_results, 2), range(num_results))
     ]
-    paginator = SearchResultsPaginator(results, num_results)
+    paginator = PreSlicedCountProvidedPaginator(results.docs, num_results, results.num_found)
     return results, paginator
 
 

--- a/templates/accounts/attribution.html
+++ b/templates/accounts/attribution.html
@@ -78,6 +78,6 @@
 
 </div>
 
-{% bw_paginator paginator page current_page request "download" %}
+{% bw_paginator page request "download" %}
 
 {% endblock %}

--- a/templates/accounts/manage_sounds.html
+++ b/templates/accounts/manage_sounds.html
@@ -58,7 +58,7 @@
             {% if tab == "packs" %}
                 {%  if packs_to_select %}
                     {% packs_selector_with_select_buttons packs_to_select %}
-                    {% bw_paginator paginator page current_page request "pack" %}
+                    {% bw_paginator page request "pack" %}
                 {% else %}
                     <div class="v-spacing-7 v-spacing-top-6 text-center">
                         <h5>No packs...</h5>
@@ -70,7 +70,7 @@
             {% else %}
                 {% if sounds_to_select %}
                     {% sounds_selector_with_select_buttons sounds_to_select %}
-                    {% bw_paginator paginator page current_page request "sound" %}
+                    {% bw_paginator page request "sound" %}
                 {% else %}
                     <div class="v-spacing-7 v-spacing-top-6 text-center">
                         <h5>No sounds...</h5>

--- a/templates/accounts/modal_comments.html
+++ b/templates/accounts/modal_comments.html
@@ -67,7 +67,7 @@
                 {% endfor %}
             {% endif %}
             <div class="v-spacing-top-5">
-                {% bw_paginator paginator page current_page request "comments" %}
+                {% bw_paginator page request "comments" %}
             </div>   
         {% else %}
             <div class="text-center">

--- a/templates/accounts/modal_downloads.html
+++ b/templates/accounts/modal_downloads.html
@@ -32,9 +32,9 @@
                 {% endfor %}
                 <div class="v-spacing-top-5">
                     {% if type_sounds %}
-                    {% bw_paginator paginator page current_page request "sounds" %}
+                    {% bw_paginator page request "sounds" %}
                     {% else %}
-                    {% bw_paginator paginator page current_page request "packs" %}    
+                    {% bw_paginator page request "packs" %}    
                     {% endif %}
                 </div>   
         {% else %}

--- a/templates/accounts/modal_follow.html
+++ b/templates/accounts/modal_follow.html
@@ -26,7 +26,7 @@
             </div>
         {% endfor %}
         <div class="v-spacing-top-5">
-            {% bw_paginator paginator page current_page request "" -1 %}
+            {% bw_paginator page request "" -1 %}
         </div>
 
     {% elif follow_page == 'following' %}
@@ -44,7 +44,7 @@
             </div>
         {% endfor %}
         <div class="v-spacing-top-5">
-            {% bw_paginator paginator page current_page request "" -1 %}
+            {% bw_paginator page request "" -1 %}
         </div>
 
     {% elif follow_page == 'tags' %}
@@ -79,7 +79,7 @@
             </div>
         {% endfor %}
         <div class="v-spacing-top-5">
-            {% bw_paginator paginator page current_page request "" -1 %}
+            {% bw_paginator page request "" -1 %}
         </div>
     {% endif %}
 </div>

--- a/templates/bookmarks/bookmarks.html
+++ b/templates/bookmarks/bookmarks.html
@@ -49,7 +49,7 @@
                 {% else %}
                     <div class="text-grey">There are no {% if not category %}uncategorized{% endif %} bookmarks {% if category %}in this category{% endif %} &#128543</div>
                 {% endif %}
-                {% bw_paginator paginator page current_page request "bookmark" %}
+                {% bw_paginator page request "bookmark" %}
                 </div>
             </div>
         </div>

--- a/templates/collections/collection.html
+++ b/templates/collections/collection.html
@@ -137,7 +137,7 @@
                             </div>
                             <div id="sounds-pagination" class="v-spacing-top-3">
                                 {% with hx_target="#sounds-section" %}
-                                    {% bw_paginator paginator page current_page request %}
+                                    {% bw_paginator page request %}
                                 {% endwith %}
                             </div>
                         </div>

--- a/templates/donations/donation_list.html
+++ b/templates/donations/donation_list.html
@@ -52,7 +52,7 @@
             </div>
         {% endfor %}
         <div class="v-spacing-top-5 v-spacing-5">
-            {% bw_paginator page_obj.paginator page_obj page_obj.number request "donations" %}
+            {% bw_paginator page_obj request "donations" %}
         </div>
     </div>
 {% endblock %}

--- a/templates/forum/hot_threads.html
+++ b/templates/forum/hot_threads.html
@@ -16,6 +16,6 @@
         {% endfor %}
     </div>
     <div class="v-spacing-top-7">
-        {% bw_paginator paginator page current_page request "" %}
+        {% bw_paginator page request "" %}
     </div>
 {% endblock %}

--- a/templates/forum/thread.html
+++ b/templates/forum/thread.html
@@ -54,6 +54,6 @@
         <a class="btn-primary no-hover" href="{% url "forums-reply" forum.name_slug thread.id %}"><i class="text-16 padding-right-1 bw-icon-reply" ></i>Post reply</a>
     </div>
     <div class="v-spacing-top-4">
-        {% bw_paginator paginator page current_page request "thread" %}
+        {% bw_paginator page request "thread" %}
     </div>
 {% endblock %}

--- a/templates/forum/threads.html
+++ b/templates/forum/threads.html
@@ -49,6 +49,6 @@
         {% endfor %}
     </div>
     <div class="v-spacing-top-7">
-        {% bw_paginator paginator page current_page request "thread" %}
+        {% bw_paginator page request "thread" %}
     </div>
 {% endblock %}

--- a/templates/messages/messages_list.html
+++ b/templates/messages/messages_list.html
@@ -18,7 +18,7 @@
             </div>
         </div>
         <div class="v-spacing-top-1">
-            {% bw_paginator paginator page current_page request "message" %}
+            {% bw_paginator page request "message" %}
         </div>
     </div>
 {% endblock %}

--- a/templates/moderation/assigned.html
+++ b/templates/moderation/assigned.html
@@ -52,7 +52,7 @@
                     </table>
                 </div>
                 {% if show_pagination %}
-                    {% bw_paginator paginator page current_page request "ticket" %}
+                    {% bw_paginator page request "ticket" %}
                 {% endif %}
                 <div class="v-spacing-4">
                     <div>

--- a/templates/moderation/modal_pending.html
+++ b/templates/moderation/modal_pending.html
@@ -22,7 +22,7 @@
             {% endfor %}
         </div>
         <div class="v-spacing-top-5">
-            {% bw_paginator paginator page current_page request "tickets" %}
+            {% bw_paginator page request "tickets" %}
         </div>
         <div class="v-spacing-top-5 center">
             <a class="btn-primary no-hover" href="{% url 'tickets-moderation-assign-user-pending' user.id %}">{% bw_icon "plus" %}Assign all sounds to me</a>

--- a/templates/moderation/modal_tardy.html
+++ b/templates/moderation/modal_tardy.html
@@ -22,7 +22,7 @@
             {% endfor %}
         </div>
         <div class="v-spacing-top-5">
-            {% bw_paginator paginator page current_page request "tickets" %}
+            {% bw_paginator page request "tickets" %}
         </div>
         {% else %}
         <div class="text-center">

--- a/templates/search/_no_results.html
+++ b/templates/search/_no_results.html
@@ -1,0 +1,8 @@
+<div class="v-spacing-7 v-spacing-top-6 w-100 text-center">
+    {% if beyond_last %}
+        <h5>No more results</h5>
+    {% else %}
+        <h5>No results...</h5>
+    {% endif %}
+    <p class="text-grey v-spacing-2">Please try another search</p>
+</div>

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -266,7 +266,7 @@
                     {% else %}
                         {% comment %}list/grid of sounds{% endcomment %}
                         <div class="v-spacing-6 v-spacing-top-2">
-                            {% if paginator.count > 0 %}
+                            {% if paginator.count > 0 and not beyond_last %}
                                 {% if sqp.grid_mode_active %}
                                     <div class="row">
                                         {% for result in docs %}
@@ -310,10 +310,7 @@
                                     {% endfor %}
                                 {% endif %}
                             {% else %}
-                                <div class="v-spacing-7 v-spacing-top-6 w-100">
-                                    <h5>No results... &#128543</h5>
-                                    <p class="text-grey v-spacing-2">Please try another query or change the filters</p>
-                                </div>
+                                {% include "search/_no_results.html" %}
                             {% endif %}
                         </div>
                         <div class="v-spacing-6">

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -314,7 +314,7 @@
                             {% endif %}
                         </div>
                         <div class="v-spacing-6">
-                            {% bw_paginator paginator page current_page request "sound" non_grouped_number_of_results %}
+                            {% bw_paginator page request "sound" non_grouped_number_of_results %}
                         </div>
                     {% endif %}
                 </main>

--- a/templates/search/search_forum.html
+++ b/templates/search/search_forum.html
@@ -65,7 +65,7 @@
             {% endif %}
         </div>
         <div class="v-spacing-top-5">
-            {% bw_paginator paginator page current_page request "" -1 %}
+            {% bw_paginator page request "" -1 %}
         </div>
     {% endif %}
 

--- a/templates/search/search_forum.html
+++ b/templates/search/search_forum.html
@@ -53,17 +53,16 @@
         </div>
     {% else %}
         <div class="v-spacing-top-4">
-            {% for post in posts  %}
-                {% display_post post show_post_location=True show_action_icons=False show_report_actions=False results_highlighted=results.highlighting %}
-                {% if not forloop.last %}
-                    <div class="divider-light v-spacing-top-3 v-spacing-3"></div>
-                {% endif %}
-            {% empty %}
-                <div class="v-spacing-7 v-spacing-top-6 w-100 text-center">
-                    <h5>No results... &#128543</h5>
-                    <p class="text-grey v-spacing-2">Please try another query</p>
-                </div>
-            {% endfor %}
+            {% if posts %}
+                {% for post in posts  %}
+                    {% display_post post show_post_location=True show_action_icons=False show_report_actions=False results_highlighted=results.highlighting %}
+                    {% if not forloop.last %}
+                        <div class="divider-light v-spacing-top-3 v-spacing-3"></div>
+                    {% endif %}
+                {% endfor %}
+            {% else %}
+                {% include "search/_no_results.html" %}
+            {% endif %}
         </div>
         <div class="v-spacing-top-5">
             {% bw_paginator paginator page current_page request "" -1 %}

--- a/templates/sounds/modal_downloaders.html
+++ b/templates/sounds/modal_downloaders.html
@@ -28,7 +28,7 @@
                 </div>
             {% endfor %}
             <div class="v-spacing-top-5">
-                {% bw_paginator paginator page current_page request "" -1 %}
+                {% bw_paginator page request "" -1 %}
             </div>
         {% else %}
             <div class="text-center">

--- a/templates/sounds/modal_similar_sounds.html
+++ b/templates/sounds/modal_similar_sounds.html
@@ -32,7 +32,7 @@
                         {% endif %}
                     </div>
                     <div>
-                        {% bw_paginator paginator page current_page request "" -1 %}
+                        {% bw_paginator page request "" -1 %}
                     </div>
                     <div>
                         <a href="{% url 'sounds-search' %}?st={{ sound.id }}&ss={{ similarity_space }}" class="btn-primary">See more results...</a>

--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -234,7 +234,7 @@
                                     {% endfor %}
 
                                     <div>
-                                        {% bw_paginator paginator page current_page request "comments" %}
+                                        {% bw_paginator page request "comments" %}
                                     </div>
 
                                 {% else %}

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -111,24 +111,26 @@ def paginate(
 
 
 def build_paginator_template_context(
-    paginator,
-    page,
-    current_page,
-    base_path,
+    page: Page | None,
+    base_path: str,
     base_query,
-    anchor="",
-    non_grouped_number_of_results=-1,
-    hx_target="",
-):
+    anchor: str = "",
+    non_grouped_number_of_results: int = -1,
+    hx_target: str = "",
+) -> dict:
     """Build context for ``templates/molecules/paginator.html``.
 
+    ``page``'s ``paginator`` and ``number`` are derived here.
     ``base_path`` is the URL path that paginator links should point to (typically
     ``request.path``). ``base_query`` is a dict-like (e.g. ``QueryDict``) of
     query parameters to preserve across pages; ``page`` is always stripped and
     replaced with the target page number.
     """
-    if paginator is None:
+    if page is None:
         return {}
+
+    paginator = page.paginator
+    current_page = page.number
 
     adjacent_pages = 3
     total_wanted = adjacent_pages * 2 + 1

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -20,7 +20,7 @@
 
 import urllib.parse
 
-from django.core.paginator import Paginator
+from django.core.paginator import Page, Paginator
 from django.http import HttpRequest
 from django.utils.functional import cached_property
 
@@ -30,17 +30,55 @@ class CountProvidedPaginator(Paginator):
     which is the length of object_list. This means that count() or
     len() doesn't have to be called"""
 
-    def __init__(self, object_list, per_page, orphans=0, allow_empty_first_page=True, object_count=None):
+    def __init__(
+        self,
+        object_list,
+        per_page: int,
+        orphans: int = 0,
+        allow_empty_first_page: bool = True,
+        object_count: int | None = None,
+    ) -> None:
         Paginator.__init__(self, object_list, per_page, orphans, allow_empty_first_page)
 
         self._count = object_count
 
     @cached_property
-    def count(self):
+    def count(self) -> int:
         # If the count was provided return it, otherwise use the
         if self._count:
             return self._count
         return super().count
+
+
+class PreSlicedCountProvidedPaginator(CountProvidedPaginator):
+    """A CountProvidedPaginator whose ``object_list`` is already sliced to the specific page
+    (e.g. by solr)."""
+
+    def __init__(self, object_list: list, per_page: int, object_count: int) -> None:
+        """
+        Args:
+            object_list: the results for a single, already-sliced page.
+            per_page: number of results per page.
+            object_count: total number of results across all pages.
+        """
+        if len(object_list) > per_page:
+            # Because object_list is pre-sliced it must contain as many items
+            # as are claimed in per_page (or fewer if it's the last page)
+            raise ValueError(f"object_list size must be less than or equal to {per_page=} ")
+        super().__init__(object_list, per_page, object_count=object_count)
+
+    def page(self, number: int | str) -> Page:
+        """Return the ``Page`` for ``number``.
+
+        Because the object list is already sliced, the `number` argument is only used for
+        validation (it must be within `object_count/per_page` and >=1)
+        and is used verbatim in the returned Page object.
+        """
+        number = int(number)
+        if number < 1:
+            raise ValueError(f"page number must be >= 1, got {number}")
+        number = min(number, self.num_pages)
+        return self._get_page(self.object_list, number, self)
 
 
 def read_page(request: HttpRequest, param: str = "page") -> int:
@@ -116,12 +154,8 @@ def build_paginator_template_context(
     else:
         url = base_path + "?" + params + "&page="
 
-    if isinstance(page, dict):
-        prev_page_num = page["previous_page_number"] if page.get("has_previous") else None
-        next_page_num = page["next_page_number"] if page.get("has_next") else None
-    else:
-        prev_page_num = page.previous_page_number() if page.has_previous() else None
-        next_page_num = page.next_page_number() if page.has_next() else None
+    prev_page_num = page.previous_page_number() if page.has_previous() else None
+    next_page_num = page.next_page_number() if page.has_next() else None
 
     url_prev_page = url + str(prev_page_num) if prev_page_num is not None else None
     url_next_page = url + str(next_page_num) if next_page_num is not None else None

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -20,7 +20,8 @@
 
 import urllib.parse
 
-from django.core.paginator import InvalidPage, Paginator
+from django.core.paginator import Paginator
+from django.http import HttpRequest
 from django.utils.functional import cached_property
 
 
@@ -42,19 +43,32 @@ class CountProvidedPaginator(Paginator):
         return super().count
 
 
-def paginate(request, qs, items_per_page=20, page_get_name="page", object_count=None):
-    paginator = CountProvidedPaginator(qs, items_per_page, object_count=object_count)
+def read_page(request: HttpRequest, param: str = "page") -> int:
+    """Read the requested page number from the request.
+
+    If the page number is not set or not a number, return 1
+    Return page 1 for any number < 1
+    """
     try:
-        current_page = int(request.GET.get(page_get_name, 1))
+        page = int(request.GET.get(param, 1))
     except ValueError:
-        current_page = 1
+        return 1
+    return max(page, 1)
 
-    try:
-        page = paginator.page(current_page)
-    except InvalidPage:
-        current_page = paginator.num_pages
-        page = paginator.page(current_page)
 
+def paginate(
+    request: HttpRequest,
+    qs,
+    items_per_page: int = 20,
+    page_get_name: str = "page",
+    object_count: int | None = None,
+) -> dict:
+    paginator = CountProvidedPaginator(qs, items_per_page, object_count=object_count)
+    page_param = read_page(request, page_get_name)
+    # If the requested page is greater than the number of pages in the queryset,
+    # clamp it to the max valid value
+    current_page = min(page_param, paginator.num_pages)
+    page = paginator.page(current_page)
     return dict(paginator=paginator, current_page=current_page, page=page)
 
 

--- a/utils/search/__init__.py
+++ b/utils/search/__init__.py
@@ -18,7 +18,6 @@
 #     See AUTHORS file.
 #
 import importlib
-import math
 
 from django.conf import settings
 
@@ -151,36 +150,6 @@ class SearchResults:
 
     def __str__(self):
         return f"<SearchResults with {self.num_found} results found>"
-
-
-class SearchResultsPaginator:
-    def __init__(self, search_results, num_per_page):
-        """Paginator object for search results which has a similar API to django.core.paginator.Paginator
-
-        Note that the results of a query are already paginated. This paginator is a simple wrapper to provide a
-        pagination API for search results similar to that of the official django.core.paginator.Paginator
-
-        Args:
-            search_results (SearchResults): results of a query
-            num_per_page: number of results per page
-        """
-        self.num_per_page = num_per_page
-        self.results = search_results.docs
-        self.count = search_results.num_found
-        self.num_pages = math.ceil(search_results.num_found / num_per_page)
-        self.page_range = list(range(1, self.num_pages + 1))
-
-    def page(self, page_num):
-        has_next = page_num < self.num_pages
-        has_previous = 1 < page_num <= self.num_pages
-        return {
-            "object_list": self.results,
-            "has_next": has_next,
-            "has_previous": has_previous,
-            "has_other_pages": has_next or has_previous,
-            "next_page_number": page_num + 1,
-            "previous_page_number": page_num - 1,
-        }
 
 
 class SearchEngineException(Exception):

--- a/utils/search/search_query_processor.py
+++ b/utils/search/search_query_processor.py
@@ -106,7 +106,7 @@ class SearchQueryProcessor:
                 query_param_name="page",
                 value_default=1,
                 get_value_to_apply=lambda option: (
-                    1 if option.sqp.get_option_value_to_apply("map_mode") else option.value
+                    1 if option.sqp.get_option_value_to_apply("map_mode") else max(1, option.value)
                 ),
             ),
         ),

--- a/utils/search/search_sounds.py
+++ b/utils/search/search_sounds.py
@@ -25,7 +25,8 @@ from django.db.models.query import RawQuerySet
 
 import sounds.models
 import utils.search
-from utils.search import SearchEngineException, SearchResultsPaginator, get_search_engine
+from utils.pagination import PreSlicedCountProvidedPaginator
+from utils.search import SearchEngineException, SearchResults, get_search_engine
 
 search_logger = logging.getLogger("search")
 console_logger = logging.getLogger("console")
@@ -56,22 +57,21 @@ def parse_weights_parameter(weights_param):
         return None
 
 
-def perform_search_engine_query(query_params):
+def perform_search_engine_query(query_params: dict) -> tuple[SearchResults, PreSlicedCountProvidedPaginator]:
     """Perform a query in the search engine given some query parameters and get the paginated results
 
     This util function performs the query to the search engine and returns needed parameters to continue with the view.
     The main reason to have this util function is to facilitate mocking in unit tests for this view.
 
     Args:
-        query_params (dict): query parameters dictionary with parameters following the specification of search_sounds
+        query_params: query parameters dictionary with parameters following the specification of search_sounds
             function from utils.search.SearchEngine.
 
     Returns:
-        utils.search.SearchResults: search results object with query results from the search engine
-        utils.search.SearchResultsPaginator: paginator object for the selected page according to query_params
+        the search results and a paginator for the selected page according to query_params.
     """
     results = get_search_engine().search_sounds(**query_params)
-    paginator = SearchResultsPaginator(results, query_params["num_sounds"])
+    paginator = PreSlicedCountProvidedPaginator(results.docs, query_params["num_sounds"], results.num_found)
 
     return results, paginator
 

--- a/utils/tests/test_pagination.py
+++ b/utils/tests/test_pagination.py
@@ -17,12 +17,77 @@
 # Authors:
 #     See AUTHORS file.
 #
+import pytest
+from django.core.management import call_command
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
 from general.templatetags.bw_templatetags import bw_paginator
 from sounds.models import Sound
-from utils.pagination import CountProvidedPaginator, paginate
+from utils.pagination import CountProvidedPaginator, paginate, read_page
+
+
+@pytest.fixture
+def page_request():
+    """Return a factory that builds a GET request with a given ``page`` param.
+
+    Pass ``page=`` to set the page value, ``param=`` to change the query-param name,
+    or any other keyword as an extra query param.
+    """
+
+    def _make(page=None, param="page", **extra):
+        params = dict(extra)
+        if page is not None:
+            params[param] = page
+        return RequestFactory().get("/", params)
+
+    return _make
+
+
+@pytest.fixture
+def sounds(db):
+    """Load the sound fixtures (14 sounds) and return them as a queryset."""
+    call_command("loaddata", "licenses.json", "sounds.json")
+    return Sound.objects.all()
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, 1),  # no param
+        ("abc", 1),  # non-numeric
+        ("0", 1),  # zero, set to 1
+        ("-5", 1),  # negative -> set to 1
+        ("7", 7),  # normal value
+    ],
+    ids=["missing", "non-numeric", "zero", "negative", "in-range"],
+)
+def test_read_page_clamps_and_defaults(page_request, value, expected):
+    assert read_page(page_request(page=value)) == expected
+
+
+def test_read_page_custom_param_name(page_request):
+    assert read_page(page_request(p="3"), param="p") == 3
+
+
+def test_paginate_underflow_goes_to_first_page(page_request, sounds):
+    """?page=0 must clamp to page 1, not snap to the last page."""
+    result = paginate(page_request(page="0"), sounds, 10)
+    assert result["page"].number == 1
+    assert result["current_page"] == 1
+
+
+def test_paginate_overflow_goes_to_last_page(page_request, sounds):
+    """?page beyond the end clamps to the last page (14 sounds / 10 per page == 2 pages)."""
+    result = paginate(page_request(page="999"), sounds, 10)
+    assert result["page"].number == 2
+    assert result["current_page"] == 2
+
+
+def test_paginate_in_range_unchanged(page_request, sounds):
+    result = paginate(page_request(page="2"), sounds, 10)
+    assert result["page"].number == 2
+    assert result["current_page"] == 2
 
 
 class PaginationTest(TestCase):

--- a/utils/tests/test_pagination.py
+++ b/utils/tests/test_pagination.py
@@ -19,12 +19,13 @@
 #
 import pytest
 from django.core.management import call_command
+from django.core.paginator import Page
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
 from general.templatetags.bw_templatetags import bw_paginator
 from sounds.models import Sound
-from utils.pagination import CountProvidedPaginator, paginate, read_page
+from utils.pagination import CountProvidedPaginator, PreSlicedCountProvidedPaginator, paginate, read_page
 
 
 @pytest.fixture
@@ -49,6 +50,61 @@ def sounds(db):
     """Load the sound fixtures (14 sounds) and return them as a queryset."""
     call_command("loaddata", "licenses.json", "sounds.json")
     return Sound.objects.all()
+
+
+class PreSlicedCountProvidedPaginatorTest(TestCase):
+    """object_list is a pre-sliced page: page() must not re-slice. Overflow page numbers
+    clamp to the last page; a page number < 1 raises ValueError."""
+
+    def _paginator(self, num_docs=15, num_found=100, num_per_page=15):
+        docs = [{"id": i} for i in range(num_docs)]
+        return PreSlicedCountProvidedPaginator(docs, num_per_page, num_found)
+
+    def test_page_does_not_reslice(self):
+        paginator = self._paginator(num_docs=15, num_found=100, num_per_page=15)
+        # a normal paginator would return no items here (page 3 of 15 items per page
+        # would be items [30:45] which don't exist).
+        self.assertEqual(len(paginator.page(3).object_list), 15)
+
+    def test_page_overflow_last_page(self):
+        paginator = self._paginator(num_found=100, num_per_page=15)
+        # getting page 50 clamps to page 7 ceil(100/15)
+        self.assertEqual(paginator.num_pages, 7)
+        self.assertEqual(paginator.page(50).number, 7)
+
+        # getting the last page returns the last page
+        self.assertEqual(paginator.page(7).number, 7)
+
+    def test_page_underflow_raises(self):
+        # Unlike overflow, page < 1 is a caller bug (callers clamp to >= 1 first), so we
+        # raise rather than silently clamping.
+        paginator = self._paginator()
+        with self.assertRaises(ValueError):
+            paginator.page(0)
+        with self.assertRaises(ValueError):
+            paginator.page(-3)
+
+    def test_empty_results_have_one_page(self):
+        paginator = PreSlicedCountProvidedPaginator([], 15, 0)
+        self.assertEqual(paginator.num_pages, 1)
+        self.assertEqual(list(paginator.page(1).object_list), [])
+
+    def test_paginator_page(self):
+        # a paginator with 5 objects and 2 per page is 3 pages
+        paginator = PreSlicedCountProvidedPaginator([1, 2], 2, 5)
+        page = paginator.page(2)
+        self.assertIsInstance(page, Page)
+        self.assertEqual(list(page.object_list), [1, 2])
+        self.assertTrue(page.has_next())
+        self.assertTrue(page.has_previous())
+        self.assertTrue(page.has_other_pages())
+        self.assertEqual(page.next_page_number(), 3)
+        self.assertEqual(page.previous_page_number(), 1)
+
+    def test_object_list_longer_than_per_page_raises(self):
+        # it's an error to pass in 3 items with 2 declared per page.
+        with self.assertRaises(ValueError):
+            PreSlicedCountProvidedPaginator([1, 2, 3], 2, 5)
 
 
 @pytest.mark.parametrize(

--- a/utils/tests/test_pagination.py
+++ b/utils/tests/test_pagination.py
@@ -19,13 +19,19 @@
 #
 import pytest
 from django.core.management import call_command
-from django.core.paginator import Page
+from django.core.paginator import Page, Paginator
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
 from general.templatetags.bw_templatetags import bw_paginator
 from sounds.models import Sound
-from utils.pagination import CountProvidedPaginator, PreSlicedCountProvidedPaginator, paginate, read_page
+from utils.pagination import (
+    CountProvidedPaginator,
+    PreSlicedCountProvidedPaginator,
+    build_paginator_template_context,
+    paginate,
+    read_page,
+)
 
 
 @pytest.fixture
@@ -50,6 +56,24 @@ def sounds(db):
     """Load the sound fixtures (14 sounds) and return them as a queryset."""
     call_command("loaddata", "licenses.json", "sounds.json")
     return Sound.objects.all()
+
+
+def _paginator_context(page):
+    return build_paginator_template_context(page, base_path="/search/", base_query={"q": "wind"})
+
+
+class PaginatorTemplateContextTest(TestCase):
+    def test_pagination_link_targets(self):
+        page = Paginator(range(700 * 15), 15).page(5)
+        ctx = _paginator_context(page)
+        self.assertEqual(ctx["url_prev_page"], "/search/?q=wind&page=4")
+        self.assertEqual(ctx["url_next_page"], "/search/?q=wind&page=6")
+        self.assertEqual(ctx["url_last_page"], "/search/?q=wind&page=700")
+        self.assertEqual(ctx["current_page"], 5)
+        self.assertIs(ctx["paginator"], page.paginator)
+
+    def test_none_page_returns_empty(self):
+        self.assertEqual(build_paginator_template_context(None, base_path="/x/", base_query={}), {})
 
 
 class PreSlicedCountProvidedPaginatorTest(TestCase):
@@ -197,4 +221,4 @@ class PaginationTest(TestCase):
             },
         )
         paginator = paginate(dummy_request, Sound.objects.all(), 10)
-        bw_paginator({}, paginator["paginator"], paginator["page"], paginator["current_page"], dummy_request)
+        bw_paginator({}, paginator["page"], dummy_request)

--- a/utils/tests/test_search_query_processor_options.py
+++ b/utils/tests/test_search_query_processor_options.py
@@ -24,6 +24,26 @@ class SearchQueryProcessorOptionsTest(TestCase):
         assert option.get_value_from_request() is None
 
 
+class PageOptionTest(TestCase):
+    def _value_to_apply(self, query):
+        request = RequestFactory().get(query)
+        request.user = AnonymousUser()
+        sqp = search_query_processor.SearchQueryProcessor(request)
+        return sqp.get_option_value_to_apply("page")
+
+    def test_page_zero_clamps_to_1(self):
+        assert self._value_to_apply("/?page=0") == 1
+
+    def test_page_negative_clamps_to_1(self):
+        assert self._value_to_apply("/?page=-3") == 1
+
+    def test_page_normal_value_passes_through(self):
+        assert self._value_to_apply("/?page=4") == 4
+
+    def test_page_non_numeric_defaults_to_1(self):
+        assert self._value_to_apply("/?page=abc") == 1
+
+
 class DisplayMapModeTest(TestCase):
     def test_display_map_mode(self):
         request = RequestFactory().get("/?mm=1")


### PR DESCRIPTION
**Description**
We had a bunch of almost but not quite the same pagination logic in our search interfaces (API, Sounds, Forum)

Update pagination to always use a `Paginator` subclass which returns a `Page` object. This removes the need to sometimes use a dict and then switch based on the type of the value that's passed in. This also lets us remove some now duplicated parameters from the templatetag to simplify it.

Validate the `&page=` parameter consistently every it's used.

Make the behaviour of search results consistent if the requested page number is greater than the number of pages in the results, or if there are no results.

Add more explicit typing to pagination-related methods
