### PR TITLE
enforce a daily download limit

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
       continue-on-error: true
 
     - name: Pull docker images
-      run: docker compose -f docker-compose.test.yml pull db
+      run: docker compose -f docker-compose.test.yml pull db redis
 
     - name: Build test_runner image
       uses: docker/build-push-action@v5

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -30,6 +30,13 @@ from django.urls import reverse
 from bookmarks.forms import BookmarkCategoryForm, BookmarkForm
 from bookmarks.models import Bookmark, BookmarkCategory
 from sounds.models import Sound
+from utils.download_limit import (
+    DownloadType,
+    count_download_and_set_sentinel,
+    download_limit_reached_response,
+    new_download_blocked,
+    user_download_limit_reached,
+)
 from utils.downloads import download_sounds
 from utils.pagination import paginate
 from utils.username import get_parameter_user_or_404, raise_404_if_user_is_deleted, redirect_if_old_username
@@ -59,6 +66,7 @@ def bookmarks(request, category_id=None):
     page_sounds = Sound.objects.ordered_ids([bookmark.sound_id for bookmark in paginator["page"].object_list])
     tvars.update(paginator)
     tvars["page_bookmarks_and_sound_objects"] = zip(paginator["page"].object_list, page_sounds)
+    tvars["download_limit_reached"] = user_download_limit_reached(request)
     return render(request, "bookmarks/bookmarks.html", tvars)
 
 
@@ -108,9 +116,11 @@ def download_bookmark_category(request, category_id):
     sounds_list = Sound.objects.filter(
         id__in=bookmarked_sounds, processing_state="OK", moderation_state="OK"
     ).select_related("user", "license")
+    if new_download_blocked(request, DownloadType.BOOKMARK_CATEGORY, category.id):
+        return download_limit_reached_response(request)
+    count_download_and_set_sentinel(request, DownloadType.BOOKMARK_CATEGORY, category.id)
     licenses_url = reverse("category-licenses", args=[category_id])
     licenses_content = category.get_attribution(sound_qs=sounds_list)
-    # NOTE: unlike pack downloads, here we are not doing any cache check to avoid consecutive downloads
     return download_sounds(licenses_url, licenses_content, sounds_list, category.download_filename)
 
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,6 +3,9 @@ volumes:
     solr9data:
 
 services:
+    redis:
+        image: redis:8.4.2
+
     db:
         image: postgres:18.3
         env_file:
@@ -38,6 +41,7 @@ services:
             - FS_USER_ID
         depends_on:
             - db
+            - redis
 
     test_runner_search:
         image: freesound-test:ci

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -120,6 +120,7 @@ API_MONITORING_REDIS_STORE_ID = 0
 CLUSTERING_CACHE_REDIS_STORE_ID = 1
 AUDIO_FEATURES_REDIS_STORE_ID = 2
 CELERY_BROKER_REDIS_STORE_ID = 3
+ABUSE_REDIS_STORE_ID = 4
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
@@ -137,6 +138,10 @@ CACHES = {
     "clustering": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{CLUSTERING_CACHE_REDIS_STORE_ID}",
+    },
+    "abuse": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{ABUSE_REDIS_STORE_ID}",
     },
 }
 
@@ -333,6 +338,10 @@ USER_STATS_CACHE_KEY = "user_stats_{}"
 # User flagging notification thresholds
 USERFLAG_THRESHOLD_FOR_NOTIFICATION = 3
 USERFLAG_THRESHOLD_FOR_AUTOMATIC_BLOCKING = 6
+
+# Daily download limit
+MAX_DOWNLOADS_PER_DAY = 200
+DOWNLOAD_LIMIT_MESSAGE = "You have reached the download limit. Come back tomorrow to download more sounds."
 
 # Supported audio formats
 # When adding support for a new audio format you have to change the variables below and check:

--- a/freesound/test_settings.py
+++ b/freesound/test_settings.py
@@ -27,6 +27,10 @@ CACHES = {
     "clustering": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     },
+    "abuse": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/15",
+    },
 }
 
 # django_ratelimit off in tests.

--- a/freesound/urls.py
+++ b/freesound/urls.py
@@ -118,6 +118,7 @@ urlpatterns = [
     path("embed/geotags_box/iframe/", geotags.views.embed_iframe, name="embed-geotags"),
     path("oembed/", sounds.views.oembed, name="oembed-sound"),
     path("after-download-modal/", sounds.views.after_download_modal, name="after-download-modal"),
+    path("download-limit-modal/", sounds.views.download_limit_modal, name="download-limit-modal"),
     path("browse/", sounds.views.sounds, name="sounds"),
     path("browse/tags/", tags.views.tags, name="tags"),
     path("browse/tags/<multitags:multiple_tags>/", tags.views.multiple_tags_lookup, name="tags"),

--- a/fscollections/views.py
+++ b/fscollections/views.py
@@ -26,6 +26,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.paginator import Paginator
+from django.db import transaction
 from django.db.models import Case, IntegerField, Q, Value, When
 from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
@@ -42,6 +43,13 @@ from fscollections.forms import (
 from fscollections.models import Collection, CollectionDownload, CollectionDownloadSound, CollectionSound
 from sounds.models import Sound
 from sounds.views import add_sounds_modal_helper
+from utils.download_limit import (
+    DownloadType,
+    count_download_and_set_sentinel,
+    download_limit_reached_response,
+    new_download_blocked,
+    user_download_limit_reached,
+)
 from utils.downloads import download_sounds
 from utils.pagination import build_paginator_template_context, paginate, read_page
 
@@ -121,6 +129,7 @@ def collection(request, collection):
         "current_search": search,
     }
     tvars.update(pagination)
+    tvars["download_limit_reached"] = user_download_limit_reached(request)
     return render(request, "collections/collection.html", tvars)
 
 
@@ -129,7 +138,10 @@ def collections_for_user(request):
     user = request.user
     user_collections = Collection.objects.filter(user=user).order_by("-modified")
     maintainer_collections = Collection.objects.filter(maintainers__id=user.id).order_by("-modified")
-    tvars = {"user_collections": user_collections, "maintainer_collections": maintainer_collections}
+    tvars = {
+        "user_collections": user_collections,
+        "maintainer_collections": maintainer_collections,
+    }
     # one URL needed to display all collections and one URL to display ONE collection at a time
     # the collections_for_user can be reused to display ONE collection so give it a thought on full collections display
     return render(request, "collections/your_collections.html", tvars)
@@ -368,17 +380,14 @@ def edit_collection(request, collection):
 
 
 @login_required
+@transaction.atomic()
 @resolve_collection_from_url
 def download_collection(request, collection):
     sounds_list = Sound.objects.bulk_sounds_for_collection(collection.id)
 
-    if "range" not in request.headers:
-        """
-        Download managers and some browsers use the range header to download files in multiple parts. We have observed 
-        that all clients first make a GET with no range header (to get the file length) and then make multiple other 
-        requests. We ignore all requests that have range header because we assume that a first query has already been 
-        made. Unlike in pack downloads, here we do not guard against multiple consecutive downloads.
-        """
+    if new_download_blocked(request, DownloadType.COLLECTION, collection.id):
+        return download_limit_reached_response(request)
+    if count_download_and_set_sentinel(request, DownloadType.COLLECTION, collection.id):
         cd = CollectionDownload.objects.create(user=request.user, collection=collection)
         cds = []
         for sound in sounds_list:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ markers = [
     "search_engine: solr tests",
     "forum: search engine forum tests",
     "sounds: search engine search tests",
+    "redis: tests that require a real Redis server",
 ]
 
 [tool.ty.src]

--- a/sounds/tests/test_download_limit_views.py
+++ b/sounds/tests/test_download_limit_views.py
@@ -1,0 +1,260 @@
+from unittest import mock
+
+import pytest
+from django.contrib.auth.models import Group, User
+from django.core.cache import cache, caches
+from django.core.management import call_command
+from django.http import Http404, HttpResponse
+from django.urls import reverse
+from django.utils.text import slugify
+from pytest_django.asserts import assertContains, assertNotContains
+
+from bookmarks.models import Bookmark, BookmarkCategory
+from fscollections.models import Collection, CollectionDownload, CollectionSound
+from sounds.models import Download, PackDownload
+from utils.download_limit import get_daily_download_count, increment_daily_download_count
+from utils.test_helpers import create_user_and_sounds
+
+pytestmark = pytest.mark.redis
+
+
+@pytest.fixture
+def limit_test_data(db):
+    """Load users and clear abuse db on each call"""
+    caches["abuse"]._cache.get_client(write=True).flushdb()
+    cache.clear()
+    call_command("loaddata", "licenses", "users")
+
+
+@pytest.fixture
+def uploader(limit_test_data):
+    return User.objects.get(username="User2")
+
+
+@pytest.fixture
+def downloader(limit_test_data, client):
+    user = User.objects.get(username="User1")
+    client.force_login(user)
+    return user
+
+
+@pytest.fixture
+def moderators_group(db):
+    Group.objects.get_or_create(name="moderators")
+
+
+@pytest.fixture
+def download_sound(uploader):
+    _, _, sounds = create_user_and_sounds(num_sounds=1, processing_state="OK", moderation_state="OK", user=uploader)
+    return sounds[0]
+
+
+@pytest.fixture
+def download_pack(uploader):
+    _, packs, _ = create_user_and_sounds(
+        num_sounds=1, num_packs=1, processing_state="OK", moderation_state="OK", user=uploader
+    )
+    pack = packs[0]
+    pack.process()
+    return pack
+
+
+@pytest.fixture
+def sound_download_url(download_sound):
+    return reverse("sound-download", args=[download_sound.user.username, download_sound.id])
+
+
+@pytest.fixture
+def download_collection(downloader, download_sound):
+    collection = Collection.objects.create(user=downloader, name="limit collection")
+    CollectionSound.objects.create(user=downloader, sound=download_sound, collection=collection, status="OK")
+    return collection
+
+
+@pytest.fixture
+def bookmark_category(downloader, download_sound):
+    category = BookmarkCategory.objects.create(user=downloader, name="limit bookmarks")
+    Bookmark.objects.create(user=downloader, category=category, sound=download_sound)
+    return category
+
+
+@pytest.fixture
+def public_collection(downloader, download_sound):
+    collection = Collection.objects.create(user=downloader, name="render test collection", public=True)
+    CollectionSound.objects.create(user=downloader, sound=download_sound, collection=collection, status="OK")
+    return collection
+
+
+def test_sound_download_under_limit_records_and_increments(
+    client, settings, download_sound, downloader, sound_download_url, django_capture_on_commit_callbacks
+):
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    with mock.patch("sounds.views.sendfile", return_value=HttpResponse()):
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.get(sound_download_url)
+    assert response.status_code == 200
+    assert Download.objects.filter(user=downloader).count() == 1
+    assert get_daily_download_count(downloader.id) == 1
+
+
+def test_sound_download_over_limit_returns_429_and_no_row(
+    client, settings, download_sound, downloader, sound_download_url
+):
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    increment_daily_download_count(downloader.id)
+    response = client.get(sound_download_url)
+    assert response.status_code == 429
+    assert Download.objects.filter(user=downloader).count() == 0
+    assert get_daily_download_count(downloader.id) == 1
+
+
+def test_sound_download_error_does_not_increment(
+    client, settings, download_sound, downloader, sound_download_url, django_capture_on_commit_callbacks
+):
+    # Simulate a download error - no daily download count and now Download row.
+    settings.MAX_DOWNLOADS_PER_DAY = 200
+    with mock.patch("sounds.views.sendfile", side_effect=Http404):
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.get(sound_download_url)
+    assert response.status_code == 404
+    assert Download.objects.filter(user=downloader).count() == 0
+    assert get_daily_download_count(downloader.id) == 0
+    assert cache.get("sdwn_%s_%d" % (download_sound.id, downloader.id), None) is None
+
+
+def test_sound_download_over_limit_range_continuation_is_served(
+    client, settings, download_sound, downloader, sound_download_url
+):
+    # User is over the limit but downloading a sound that has already been started.
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    increment_daily_download_count(downloader.id)
+    cache.set("sdwn_%s_%d" % (download_sound.id, downloader.id), True, 60 * 5)
+    with mock.patch("sounds.views.sendfile", return_value=HttpResponse()):
+        response = client.get(sound_download_url, HTTP_RANGE="bytes=0-")
+    assert response.status_code == 200
+
+
+def test_sound_download_continuation_refreshes_sentinel_without_recounting(
+    client, settings, download_sound, downloader, sound_download_url, django_capture_on_commit_callbacks
+):
+    # An in-progress download (sentinel present) refreshes its marker on every request and
+    # does not re-count.
+    settings.MAX_DOWNLOADS_PER_DAY = 200
+    cache.set("sdwn_%s_%d" % (download_sound.id, downloader.id), True, 60 * 5)
+    with mock.patch("sounds.views.sendfile", return_value=HttpResponse()):
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            client.get(sound_download_url, HTTP_RANGE="bytes=100-")
+    assert len(callbacks) == 1
+    assert Download.objects.filter(user=downloader).count() == 0
+    assert get_daily_download_count(downloader.id) == 0
+
+
+def test_pack_download_over_limit_returns_429_and_no_row(client, settings, download_pack, downloader):
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    increment_daily_download_count(downloader.id)
+    response = client.get(reverse("pack-download", args=[download_pack.user.username, download_pack.id]))
+    assert response.status_code == 429
+    assert PackDownload.objects.filter(user=downloader).count() == 0
+
+
+def test_collection_download_over_limit_returns_429_and_no_row(client, settings, download_collection, downloader):
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    increment_daily_download_count(downloader.id)
+    url = reverse("download-collection", args=[download_collection.id, slugify(download_collection.name)])
+    response = client.get(url)
+    assert response.status_code == 429
+    assert CollectionDownload.objects.filter(user=downloader).count() == 0
+
+
+def test_repeated_collection_download_records_one_row(
+    client, settings, download_collection, downloader, django_capture_on_commit_callbacks
+):
+    # Repeated downloads within the sentinel window record a single CollectionDownload row
+    settings.MAX_DOWNLOADS_PER_DAY = 200
+    url = reverse("download-collection", args=[download_collection.id, slugify(download_collection.name)])
+    with mock.patch("fscollections.views.download_sounds", return_value=HttpResponse()):
+        for _ in range(3):
+            with django_capture_on_commit_callbacks(execute=True):
+                client.get(url)
+    assert CollectionDownload.objects.filter(user=downloader).count() == 1
+
+
+def test_bookmark_category_download_over_limit_returns_429_and_does_not_increment(
+    client, settings, bookmark_category, downloader
+):
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    increment_daily_download_count(downloader.id)
+    response = client.get(reverse("download-bookmark-category", args=[bookmark_category.id]))
+    assert response.status_code == 429
+    # Bookmark-category downloads do not have a download-row model, so assert the
+    # failed over-limit request did not advance the counter.
+    assert get_daily_download_count(downloader.id) == 1
+
+
+def test_sound_page_hides_download_href_when_over_limit(
+    client, settings, download_sound, downloader, sound_download_url, moderators_group
+):
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    url = reverse("sound", args=[download_sound.user.username, download_sound.id])
+
+    response = client.get(url)
+    assert not response.context["download_limit_reached"]
+    assertContains(response, 'href="%s' % sound_download_url)
+
+    increment_daily_download_count(downloader.id)
+    response = client.get(url)
+    assert response.context["download_limit_reached"]
+    assertNotContains(response, 'href="%s' % sound_download_url)
+    assertContains(response, "download-limit-modal")
+
+
+def test_pack_page_hides_download_href_when_over_limit(client, settings, download_pack, downloader, moderators_group):
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    url = reverse("pack", args=[download_pack.user.username, download_pack.id])
+    download_path = reverse("pack-download", args=[download_pack.user.username, download_pack.id])
+
+    response = client.get(url)
+    assert not response.context["download_limit_reached"]
+    assertContains(response, 'href="%s' % download_path)
+
+    increment_daily_download_count(downloader.id)
+    response = client.get(url)
+    assert response.context["download_limit_reached"]
+    assertNotContains(response, 'href="%s' % download_path)
+    assertContains(response, "download-limit-modal")
+
+
+def test_collection_page_hides_download_href_when_over_limit(client, settings, public_collection, downloader):
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    url = reverse("collection", args=[public_collection.id, slugify(public_collection.name)])
+
+    response = client.get(url)
+    assert not response.context["download_limit_reached"]
+    assertContains(response, 'href="%s' % public_collection.download_url)
+
+    increment_daily_download_count(downloader.id)
+    response = client.get(url)
+    assert response.context["download_limit_reached"]
+    assertNotContains(response, 'href="%s' % public_collection.download_url)
+    assertContains(response, "download-limit-modal")
+
+
+def test_bookmarks_page_hides_download_href_when_over_limit(client, settings, bookmark_category, downloader):
+    settings.MAX_DOWNLOADS_PER_DAY = 1
+    download_path = reverse("download-bookmark-category", args=[bookmark_category.id])
+
+    response = client.get(reverse("bookmarks"))
+    assert not response.context["download_limit_reached"]
+    assertContains(response, 'href="%s' % download_path)
+
+    increment_daily_download_count(downloader.id)
+    response = client.get(reverse("bookmarks"))
+    assert response.context["download_limit_reached"]
+    assertNotContains(response, 'href="%s' % download_path)
+    assertContains(response, "download-limit-modal")
+
+
+def test_modal_view_returns_limit_content(client, downloader):
+    response = client.get(reverse("download-limit-modal") + "?ajax=1")
+    assert response.status_code == 200
+    assert b"download limit" in response.content.lower()

--- a/sounds/tests/test_sound.py
+++ b/sounds/tests/test_sound.py
@@ -385,14 +385,16 @@ class SoundPackDownloadTestCase(TestCase):
 
             # Check download works successfully if user logged in
             self.client.force_login(self.user)
-            resp = self.client.get(reverse("sound-download", args=[self.sound.user.username, self.sound.id]))
+            with self.captureOnCommitCallbacks(execute=True):
+                resp = self.client.get(reverse("sound-download", args=[self.sound.user.username, self.sound.id]))
             self.assertEqual(resp.status_code, 200)
 
             # Check n download objects is 1
             self.assertEqual(Download.objects.filter(user=self.user, sound=self.sound).count(), 1)
 
             # Download again and check n download objects is still 1
-            self.client.get(reverse("sound-download", args=[self.sound.user.username, self.sound.id]))
+            with self.captureOnCommitCallbacks(execute=True):
+                self.client.get(reverse("sound-download", args=[self.sound.user.username, self.sound.id]))
             self.assertEqual(Download.objects.filter(user=self.user, sound=self.sound).count(), 1)
 
             # Check num_download attribute of Sound is 1
@@ -475,7 +477,8 @@ class SoundPackDownloadTestCase(TestCase):
 
             # Check download works successfully if user logged in
             self.client.force_login(self.user)
-            resp = self.client.get(reverse("pack-download", args=[self.sound.user.username, self.pack.id]))
+            with self.captureOnCommitCallbacks(execute=True):
+                resp = self.client.get(reverse("pack-download", args=[self.sound.user.username, self.pack.id]))
             self.assertEqual(resp.status_code, 200)
 
             # Check n download objects is 1
@@ -487,8 +490,10 @@ class SoundPackDownloadTestCase(TestCase):
                 1,
             )
 
-            # Download again and check n download objects is still 1
-            self.client.get(reverse("pack-download", args=[self.sound.user.username, self.pack.id]))
+            # Download again and check n download objects is still 1 (deduplicated via the
+            # in-progress sentinel, which is written on transaction commit)
+            with self.captureOnCommitCallbacks(execute=True):
+                self.client.get(reverse("pack-download", args=[self.sound.user.username, self.pack.id]))
             self.assertEqual(PackDownload.objects.filter(user=self.user, pack=self.pack).count(), 1)
 
             # Check num_download attribute of Sound is 1

--- a/sounds/views.py
+++ b/sounds/views.py
@@ -63,6 +63,13 @@ from tickets import TICKET_STATUS_CLOSED
 from tickets.models import Ticket, TicketComment
 from utils.cache import invalidate_user_template_caches
 from utils.cdn import generate_cdn_download_url
+from utils.download_limit import (
+    DownloadType,
+    count_download_and_set_sentinel,
+    download_limit_reached_response,
+    new_download_blocked,
+    user_download_limit_reached,
+)
 from utils.downloads import download_sounds, should_suggest_donation
 from utils.mail import send_mail_template, send_mail_template_to_support
 from utils.nginxsendfile import prepare_sendfile_arguments_for_sound_download, sendfile
@@ -294,6 +301,7 @@ def sound(request, username, sound_id):
         "is_explicit": is_explicit,  # if the sound should be shown blurred, already checks for adult profile
         "sizes": settings.IFRAME_PLAYER_SIZE,
         "min_num_ratings": settings.MIN_NUMBER_RATINGS,
+        "download_limit_reached": user_download_limit_reached(request),
     }
     tvars.update(paginate(request, qs, settings.SOUND_COMMENTS_PER_PAGE))
     return render(request, "sounds/sound.html", tvars)
@@ -338,6 +346,12 @@ def after_download_modal(request):
         return HttpResponse()
 
 
+@login_required
+def download_limit_modal(request):
+    """modal shown when a user reaches the daily download limit."""
+    return render(request, "molecules/modal_download_limit.html", {"message": settings.DOWNLOAD_LIMIT_MESSAGE})
+
+
 @redirect_if_old_username
 @transaction.atomic()
 def sound_download(request, username, sound_id):
@@ -347,19 +361,14 @@ def sound_download(request, username, sound_id):
     if sound.user.username.lower() != username.lower():
         raise Http404
 
-    if "range" not in request.headers:
-        """
-        Download managers and some browsers use the range header to download files in multiple parts. We have observed
-        that all clients first make a GET with no range header (to get the file length) and then make multiple other
-        requests. We ignore all requests that have range header because we assume that a first query has already been
-        made. We additionally guard against users clicking on download multiple times by storing a sentinel in the
-        cache for 5 minutes.
-        """
-        cache_key = "sdwn_%s_%d" % (sound_id, request.user.id)
-        if cache.get(cache_key, None) is None:
-            Download.objects.create(user=request.user, sound=sound, license_id=sound.license_id)
-            sound.invalidate_template_caches()
-            cache.set(cache_key, True, 60 * 5)  # Don't save downloads for the same user/sound in 5 minutes
+    if new_download_blocked(request, DownloadType.SOUND, sound_id):
+        return download_limit_reached_response(request)
+    if count_download_and_set_sentinel(request, DownloadType.SOUND, sound_id):
+        # True only for a new download, not a continuation of one already started
+        # (e.g. a multi-part Range request, or a repeated click within the window),
+        # so we record only one Download row per download.
+        Download.objects.create(user=request.user, sound=sound, license_id=sound.license_id)
+        sound.invalidate_template_caches()
 
     if settings.USE_CDN_FOR_DOWNLOADS:
         cdn_url = generate_cdn_download_url(sound)
@@ -378,22 +387,16 @@ def pack_download(request, username, pack_id):
     if pack.user.username.lower() != username.lower():
         raise Http404
 
-    if "range" not in request.headers:
-        """
-        Download managers and some browsers use the range header to download files in multiple parts. We have observed
-        that all clients first make a GET with no range header (to get the file length) and then make multiple other
-        requests. We ignore all requests that have range header because we assume that a first query has already been
-        made. We additionally guard against users clicking on download multiple times by storing a sentinel in the
-        cache for 5 minutes.
-        """
-        cache_key = "pdwn_%s_%d" % (pack_id, request.user.id)
-        if cache.get(cache_key, None) is None:
-            pd = PackDownload.objects.create(user=request.user, pack=pack)
-            pds = []
-            for sound in pack.sounds.all():
-                pds.append(PackDownloadSound(sound=sound, license_id=sound.license_id, pack_download=pd))
-            PackDownloadSound.objects.bulk_create(pds)
-            cache.set(cache_key, True, 60 * 5)  # Don't save downloads for the same user/pack in the next 5 minutes
+    if new_download_blocked(request, DownloadType.PACK, pack_id):
+        return download_limit_reached_response(request)
+    if count_download_and_set_sentinel(request, DownloadType.PACK, pack_id):
+        # Create a PackDownload only if it's a new download, not if it's a continuation
+        # of an existing download (Range request, or double-click)
+        pd = PackDownload.objects.create(user=request.user, pack=pack)
+        pds = []
+        for sound in pack.sounds.all():
+            pds.append(PackDownloadSound(sound=sound, license_id=sound.license_id, pack_download=pd))
+        PackDownloadSound.objects.bulk_create(pds)
 
     sounds_list = pack.sounds.filter(processing_state="OK", moderation_state="OK").select_related("user", "license")
     licenses_url = reverse("pack-licenses", args=[username, pack_id])
@@ -1001,6 +1004,7 @@ def pack(request, username, pack_id):
         "pack_sounds": pack_sounds,
         "is_following": is_following,
         "geotags_in_pack_serialized": geotags_in_pack_serialized,
+        "download_limit_reached": user_download_limit_reached(request),
     }
     return render(request, "sounds/pack.html", tvars)
 

--- a/templates/bookmarks/bookmarks.html
+++ b/templates/bookmarks/bookmarks.html
@@ -21,7 +21,11 @@
                             {% if is_owner %}
                             <a class="cursor-pointer h-spacing-left-1" data-toggle="confirmation-modal" data-modal-confirmation-title="Are you sure you want to remove this bookmark category?" data-modal-confirmation-help-text="Note that all the bookmarks inside this category will also be removed" data-modal-confirmation-url="{% url "delete-bookmark-category" cat.id %}{% if cat.id != category.id %}?next={{request.path}}&page={{current_page}}{% endif %}" title="Remove bookmark category" aria-label="Remove bookmark category">{% bw_icon 'trash' %}</a>
                             <a class="cursor-pointer" data-toggle="modal-default-with-form" data-modal-content-url="{% url 'edit-bookmark-category' cat.id %}?ajax=1" data-reload-on-success= "true" title="Edit bookmark category" aria-label="Edit bookmark category">{% bw_icon 'edit' %}</a>
+                            {% if download_limit_reached %}
+                            <a class="opacity-050" href="javascript:void(0);" data-toggle="modal-default" data-modal-content-url="{% url 'download-limit-modal' %}?ajax=1" title="Daily download limit reached" aria-label="Download bookmark category">{% bw_icon 'download' %}</a>
+                            {% else %}
                             <a class="cursor-pointer" href="{% url 'download-bookmark-category' cat.id %}" title="Download bookmark category" aria-label="Download bookmark category">{% bw_icon 'download' %}</a>
+                            {% endif %}
                             {% endif %}</li>
                         {% endfor %}
                     </ul>

--- a/templates/collections/collection.html
+++ b/templates/collections/collection.html
@@ -164,7 +164,11 @@
                     </section>
                     {% if collection.num_sounds > 0 %}
                     <div class="v-spacing-top-6">
+                        {% if download_limit_reached %}
+                        <a class="no-hover btn-primary display-inline-block w-100 text-center opacity-050" href="javascript:void(0);" data-toggle="modal-default" data-modal-content-url="{% url 'download-limit-modal' %}?ajax=1" title="Daily download limit reached">Download collection</a>
+                        {% else %}
                         <a class="no-hover btn-primary display-inline-block w-100 text-center" href="{{ collection.download_url }}" title="Download collection">Download collection</a>
+                        {% endif %}
                     </div>
                     {% endif %}
                     {% if is_owner or is_maintainer %}

--- a/templates/collections/display_collection.html
+++ b/templates/collections/display_collection.html
@@ -34,7 +34,7 @@
             </div>
             {% if collection.num_downloads %}
             <div class="h-spacing-left-1" title="{{ collection.num_downloads|bw_intcomma }} download{{ collection.num_downloads|pluralize }}">
-                <a href="{{ collection.download_url }}" class="bw-link--grey-light">
+                <a href="javascript:void(0)" data-toggle="modal-default" data-modal-content-url="{% url 'collection-downloaders' collection.id collection.url_kwargs.collection_name %}?ajax=1" class="bw-link--grey-light">
                     <span class="bw-icon-download" style="font-size:90%;"></span> {{ collection.num_downloads|formatnumber }}
                 </a>
             </div>

--- a/templates/molecules/modal_download_limit.html
+++ b/templates/molecules/modal_download_limit.html
@@ -1,0 +1,14 @@
+{% extends "molecules/modal_base.html" %}
+
+{% block id %}downloadLimitModal{% endblock %}
+{% block extra-class %}modal-width-60{% endblock %}
+{% block aria-label %}Download limit reached{% endblock %}
+
+{% block body %}
+<div class="col-10 offset-1">
+    <div class="text-center"><h4 class="v-spacing-5">Download limit reached</h4></div>
+    <div class="v-spacing-5">
+        {{ message }}
+    </div>
+</div>
+{% endblock %}

--- a/templates/sounds/download_limit_reached.html
+++ b/templates/sounds/download_limit_reached.html
@@ -1,0 +1,8 @@
+{% extends "simple_page.html" %}
+
+{% block title %}Download limit reached{% endblock %}
+{% block page-title %}Download limit reached{% endblock %}
+
+{% block page-content %}
+    <p>{{ message }}</p>
+{% endblock %}

--- a/templates/sounds/pack.html
+++ b/templates/sounds/pack.html
@@ -90,7 +90,11 @@
                         {% if pack.num_sounds %}
                         <div class="v-spacing-top-6">
                             {% if request.user.is_authenticated %}
+                                {% if download_limit_reached %}
+                                <a class="no-hover btn-primary display-inline-block w-100 text-center opacity-050" href="javascript:void(0);" data-toggle="modal-default" data-modal-content-url="{% url 'download-limit-modal' %}?ajax=1" title="Daily download limit reached">Download pack</a>
+                                {% else %}
                                 <a class="no-hover btn-primary display-inline-block w-100 text-center" href="{% url 'pack-download' pack.user.username pack.id %}" title="Download pack">Download pack</a>
+                                {% endif %}
                             {% else %}
                                 <a class="no-hover btn-primary display-inline-block w-100 text-center" href="{% url 'pack-download' pack.user.username pack.id %}" title="Login to download">Login to download</a>
                             {% endif %}

--- a/templates/sounds/sound.html
+++ b/templates/sounds/sound.html
@@ -287,7 +287,11 @@
                         <div class="v-spacing-top-5 v-padding-bottom-5 {% if sound.user == request.user %}v-spacing-top-5{% endif %}">
                             {% if sound.moderation_state == 'OK' and sound.processing_state == 'OK' %}
                                 {% if request.user.is_authenticated %}
+                                    {% if download_limit_reached %}
+                                    <a class="no-hover btn-primary display-inline-block w-100 text-center opacity-050" href="javascript:void(0);" data-toggle="modal-default" data-modal-content-url="{% url 'download-limit-modal' %}?ajax=1">Download sound</a>
+                                    {% else %}
                                     <a class="no-hover btn-primary display-inline-block w-100 text-center sound-download-button" href="{% url 'sound-download' sound.user.username sound.id %}{{ sound.friendly_filename }}" data-show-after-download-modal-url="{% url "after-download-modal" %}">Download sound</a>
+                                    {% endif %}
                                 {% else %}
                                     <a class="no-hover btn-primary display-inline-block w-100 text-center" href="{% url 'sound-download' sound.user.username sound.id %}{{ sound.friendly_filename }}">Login to download</a>
                                 {% endif %}

--- a/utils/download_limit.py
+++ b/utils/download_limit.py
@@ -1,0 +1,123 @@
+import datetime
+import enum
+import logging
+
+from django.conf import settings
+from django.core.cache import cache, caches
+from django.db import transaction
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+
+logger = logging.getLogger("web")
+
+DOWNLOAD_LIMIT_CACHE_ALIAS = "abuse"
+DOWNLOAD_LIMIT_KEY_PREFIX = "downloadlimit"
+DOWNLOAD_LIMIT_KEY_TTL = 60 * 60 * 48  # 48 hours
+
+# TTL of the per-download "in progress" sentinel (see count_download_and_set_sentinel). Long enough to
+# span a single (possibly multi-part / slow) download; short enough that it doesn't persist
+# between genuinely separate downloads of the same object.
+DOWNLOAD_LIMIT_SENTINEL_TTL = 60 * 5  # 5 minutes
+
+
+def _get_redis_client():
+    # Native redis-py client from the cache backend. We use the raw client so a single
+    # pipelined INCR+EXPIRE creates-and-bumps in one round-trip (the backend's incr()
+    # would raise on a missing key).
+    return caches[DOWNLOAD_LIMIT_CACHE_ALIAS]._cache.get_client(write=True)
+
+
+def _daily_key(user_id):
+    today = datetime.datetime.now(datetime.timezone.utc).date()
+    return f"{DOWNLOAD_LIMIT_KEY_PREFIX}:{user_id}:{today:%Y%m%d}"
+
+
+def get_daily_download_count(user_id):
+    try:
+        value = _get_redis_client().get(_daily_key(user_id))
+        return int(value) if value is not None else 0
+    except Exception:  # noqa
+        # Intentionally fail open on redis error
+        logger.warning("Could not read daily download count for user %s", user_id, exc_info=True)
+        return 0
+
+
+def increment_daily_download_count(user_id):
+    """Increment the number of downloads for a user. Use the underlying redis client in order
+    to increment in 1 request (creates and sets to 1 if it doesn't yet exist) and set a 2 day
+    expiry."""
+    try:
+        client = _get_redis_client()
+        key = _daily_key(user_id)
+        pipe = client.pipeline()
+        pipe.incr(key)
+        pipe.expire(key, DOWNLOAD_LIMIT_KEY_TTL)
+        count, _ = pipe.execute()
+        return int(count)
+    except Exception:  # noqa
+        # Intentionally fail open on redis error
+        logger.warning("Could not increment daily download count for user %s", user_id, exc_info=True)
+        return 0
+
+
+def download_limit_reached(user_id):
+    return get_daily_download_count(user_id) >= settings.MAX_DOWNLOADS_PER_DAY
+
+
+def user_download_limit_reached(request):
+    """Whether the request's user is over the daily download limit."""
+    return request.user.is_authenticated and download_limit_reached(request.user.id)
+
+
+class DownloadType(enum.Enum):
+    """Something that can be downloaded; values are used in the redis download sentinel check."""
+
+    SOUND = "sdwn"
+    PACK = "pdwn"
+    BOOKMARK_CATEGORY = "bdwn"
+    COLLECTION = "cdwn"
+
+
+def _sentinel_key(download_type: DownloadType, object_id: int, user_id: int) -> str:
+    return f"{download_type.value}_{object_id}_{user_id}"
+
+
+def download_limit_reached_response(request: HttpRequest) -> HttpResponse:
+    """The 429 page returned when ``new_download_blocked`` says a download must not start."""
+    return render(
+        request, "sounds/download_limit_reached.html", {"message": settings.DOWNLOAD_LIMIT_MESSAGE}, status=429
+    )
+
+
+def new_download_blocked(request: HttpRequest, download_type: DownloadType, object_id: int) -> bool:
+    """Check if the user is allowed to download this item.
+
+    The download is blocked if it's a new download and if the user is over their daily limit.
+    see ``count_download_and_set_sentinel`` for a description of what new download means.
+    """
+    is_new_download = cache.get(_sentinel_key(download_type, object_id, request.user.id), None) is None
+    return is_new_download and download_limit_reached(request.user.id)
+
+
+def count_download_and_set_sentinel(request: HttpRequest, download_type: DownloadType, object_id: int) -> bool:
+    """Count this download towards the user's daily limit and mark it as in progress.
+
+    We mark a 5 minute sentinel when a user downloads something for the first time. This guards
+    us from double-counting downloads if the user's browser or download manager makes multiple
+    requests to download a single file.
+    We've seen that sometimes a client makes a request to get the content-length and then makes
+    another request with a Range header. In this case we don't want to save multiple
+    Download rows to the database or count this download multiple times in our abuse counter.
+
+    Increments the daily download count if this is a new download and increments the
+    "existing download" sentinel key every time this is called, new or not.
+
+    Returns True if this is a new download, False otherwise.
+    """
+    user_id = request.user.id
+    sentinel_key = _sentinel_key(download_type, object_id, user_id)
+    is_new_download = cache.get(sentinel_key, None) is None
+    if is_new_download:
+        transaction.on_commit(lambda: increment_daily_download_count(user_id))
+    transaction.on_commit(lambda: cache.set(sentinel_key, True, DOWNLOAD_LIMIT_SENTINEL_TTL))
+    return is_new_download

--- a/utils/tests/test_download_limit.py
+++ b/utils/tests/test_download_limit.py
@@ -1,0 +1,61 @@
+import pytest
+from django.core.cache import caches
+
+from utils.download_limit import (
+    download_limit_reached,
+    get_daily_download_count,
+    increment_daily_download_count,
+)
+
+pytestmark = pytest.mark.redis
+
+
+@pytest.fixture
+def abuse_redis():
+    """The abuse cache's raw redis client, flushed so counters start from a clean slate."""
+    client = caches["abuse"]._cache.get_client(write=True)
+    client.flushdb()
+    return client
+
+
+def test_count_starts_at_zero(abuse_redis):
+    assert get_daily_download_count(123) == 0
+
+
+def test_increment_counts_up_and_is_readable(abuse_redis):
+    assert increment_daily_download_count(123) == 1
+    assert increment_daily_download_count(123) == 2
+    assert get_daily_download_count(123) == 2
+
+
+def test_counts_are_per_user(abuse_redis):
+    increment_daily_download_count(123)
+    assert get_daily_download_count(456) == 0
+
+
+def test_increment_sets_ttl(abuse_redis):
+    increment_daily_download_count(123)
+    key = next(iter(abuse_redis.scan_iter("downloadlimit:123:*")))
+    assert abuse_redis.ttl(key) > 0
+
+
+def test_limit_reached_at_threshold(abuse_redis, settings):
+    settings.MAX_DOWNLOADS_PER_DAY = 2
+    increment_daily_download_count(123)
+    assert not download_limit_reached(123)
+    increment_daily_download_count(123)
+    assert download_limit_reached(123)
+
+
+def test_fails_open_when_redis_unavailable(settings):
+    settings.CACHES = {
+        **settings.CACHES,
+        "abuse": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            # Invalid location, will cause a ConnectionError
+            "LOCATION": "redis://localhost:1/0",
+        },
+    }
+    assert get_daily_download_count(123) == 0
+    assert increment_daily_download_count(123) == 0
+    assert not download_limit_reached(123)


### PR DESCRIPTION
**Description**
Very infrequently we see people try to download all of Freesound via the download buttons on each sound. Stop this from happening.

Count the number of downloads that a user makes over a day. Align all users to UTC for simplicity. Use Redis to store the count. Count Sounds, Packs, Collections, and Bookmark Category downloads as 1 download each time.
Once a user goes over the limit, don't show a download link, and prevent the direct download link from providing the file (HTTP 429).

Set an "in progress" download key when the user starts a download, and don't count again if they access the URL when the download sentinel is active - this prevents download managers that request different ranges from counting multiple times.

Add the same guard to Collection downloads (it was missing)

The In progress download key in redis was previously set, but we also checked the http Range header to see if this was a "new" or "continued" download. Remove the Range header entirely, because the redis check performs pretty much the same check and we were using it anyway.

There was one bug where a user could maliciously request `Range: 0-` in order to circumvent the check, although we expect that this probably never happened.
The new check does mean that if there is a large file (takes longer than 5 minutes to download) and the client makes multiple requests to download it, that we'll count this twice. We'll check this in a few weeks but don't expect that it'll cause an issue either.

**Deployment steps**:
Requires the "abuse" cache to be added in prod. We'll add it to volatile.
