### PR TITLE
Emit standard prometheus event on all 429 errors

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -354,6 +354,15 @@ Running this command will also mark sounds as index dirty so search index is upd
 The command has a number of options that can be set to skip some of the steps if needed, or run it only for a specific set of sound IDs.
 
 
+### Prometheus metrics
+
+From freesound you can count metrics by defining a `prometheus_client.Counter` and then calling `.inc()` on it.
+We prefer to define metrics close to the location where they are defined, especially if they are only emitted
+in that one place. A metric incremented from several modules should be defined in a generic "domain" module
+
+Metrics are periodically pulled from freesound by Prometheus. Freesound automatically serves an internal /metrics
+endpoint when running in production. 
+
 ### Considerations when updating Django version
 
 #### Preparation

--- a/accounts/tests/test_ratelimited_error.py
+++ b/accounts/tests/test_ratelimited_error.py
@@ -1,0 +1,42 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+from accounts.views import ratelimited_error
+from utils.ratelimit import request_limit_events_total
+from utils.test_helpers import counter_samples
+
+
+def _samples():
+    return counter_samples(request_limit_events_total, "reason", "enforced", "user_type")
+
+
+def test_ratelimited_error_returns_429_and_counts_event():
+    # ratelimited_error helper increments a prometheus counter
+    request = RequestFactory().get("/search/")
+    request.user = AnonymousUser()
+    before = _samples().get(("django_ratelimit", "true", "anonymous"), 0)
+
+    response = ratelimited_error(request, Exception())
+
+    assert response.status_code == 429
+    assert _samples()[("django_ratelimit", "true", "anonymous")] == before + 1

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -112,7 +112,7 @@ from utils.mirror_files import (
     remove_uploaded_file_from_mirror_locations,
 )
 from utils.pagination import paginate
-from utils.ratelimit import key_for_ratelimiting, rate_per_ip
+from utils.ratelimit import RequestLimitReason, count_request_limit_event, key_for_ratelimiting, rate_per_ip
 from utils.username import (
     get_parameter_user_or_404,
     get_user_by_username,
@@ -140,6 +140,7 @@ def ratelimited_error(request, exception):
     if not path.endswith("/"):
         path += "/"
     volatile_logger.info(f"Rate limited IP ({json.dumps({'ip': get_client_ip(request), 'path': path})})")
+    count_request_limit_event(request, RequestLimitReason.DJANGO_RATELIMIT, enforced=True)
     return render(request, "429.html", status=429)
 
 

--- a/apiv2/exceptions.py
+++ b/apiv2/exceptions.py
@@ -26,6 +26,7 @@ from rest_framework import status
 from rest_framework.exceptions import APIException
 
 import apiv2.apiv2_utils  # absolute import because of mutual imports of this module and apiv2_utils
+from utils.ratelimit import RequestLimitReason, count_request_limit_event
 
 errors_logger = logging.getLogger("api_errors")
 
@@ -174,3 +175,5 @@ class Throttled(APIException):
             )
         )
         self.detail = msg
+        if request is not None:
+            count_request_limit_event(request, RequestLimitReason.API_THROTTLE, enforced=True)

--- a/apiv2/tests.py
+++ b/apiv2/tests.py
@@ -18,7 +18,7 @@
 #     See AUTHORS file.
 #
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.test import RequestFactory, SimpleTestCase, TestCase
@@ -28,9 +28,10 @@ from apiv2.models import ApiV2Client
 from apiv2.serializers import DEFAULT_FIELDS_IN_SOUND_LIST, SoundListSerializer, SoundSerializer
 from bookmarks.models import Bookmark, BookmarkCategory
 from sounds.models import Sound
-from utils.test_helpers import create_user_and_sounds
+from utils.ratelimit import request_limit_events_total
+from utils.test_helpers import counter_samples, create_user_and_sounds
 
-from .exceptions import BadRequestException
+from .exceptions import BadRequestException, Throttled
 from .forms import SoundTextSearchFormAPI
 
 
@@ -711,3 +712,31 @@ class APIAuthenticationTestCase(TestCase):
         )
         resp = self.client.get(f"/apiv2/?token={c.key}", secure=True)
         self.assertEqual(resp.status_code, 401)
+
+
+class TestThrottledException(SimpleTestCase):
+    @staticmethod
+    def _samples():
+        return counter_samples(request_limit_events_total, "reason", "enforced", "user_type")
+
+    def _make_request(self, user):
+        request = RequestFactory().get("/apiv2/search/text/")
+        request.user = user
+        request.successful_authenticator = None
+        return request
+
+    def test_throttled_counts_event_for_anonymous_request(self):
+        request = self._make_request(AnonymousUser())
+        before = self._samples().get(("api_throttle", "true", "anonymous"), 0)
+
+        Throttled(request=request)
+
+        assert self._samples()[("api_throttle", "true", "anonymous")] == before + 1
+
+    def test_throttled_counts_event_for_authenticated_request(self):
+        request = self._make_request(User(username="throttled_user"))
+        before = self._samples().get(("api_throttle", "true", "authenticated"), 0)
+
+        Throttled(request=request)
+
+        assert self._samples()[("api_throttle", "true", "authenticated")] == before + 1

--- a/search/tests/test_views.py
+++ b/search/tests/test_views.py
@@ -29,8 +29,13 @@ from django.urls import reverse
 
 from sounds.models import Sound
 from utils.pagination import PreSlicedCountProvidedPaginator
+from utils.ratelimit import request_limit_events_total
 from utils.search import SearchResults
-from utils.test_helpers import create_user_and_sounds
+from utils.test_helpers import counter_samples, create_user_and_sounds
+
+
+def _samples():
+    return counter_samples(request_limit_events_total, "reason", "enforced", "user_type")
 
 
 def create_fake_search_engine_results():
@@ -334,10 +339,12 @@ class TestSearchDeepPagination:
         call_command("loaddata", "users")
         search_url = reverse("sounds-search") + "?q=wind&page=300"
         tag_url = reverse("tags") + '?f=tag:"field-recording"&page=300'
+        before = _samples().get(("search_page_limit", "true", "anonymous"), 0)
 
         with mock.patch("search.views.perform_search_engine_query") as perform:
             assert client.get(search_url, **self.IP).status_code == 429
             assert client.get(tag_url, **self.IP).status_code == 429
+            assert _samples()[("search_page_limit", "true", "anonymous")] == before + 2
 
             client.force_login(User.objects.get(username="User1"))
             assert client.get(search_url, **self.IP).status_code == 429

--- a/search/views.py
+++ b/search/views.py
@@ -29,7 +29,6 @@ from django.core.cache import cache
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render, reverse
 from django_ratelimit.decorators import ratelimit
-from prometheus_client import Counter
 
 import forum
 import sounds
@@ -44,7 +43,7 @@ from utils.clustering_utilities import (
 from utils.encryption import create_hash
 from utils.logging_filters import get_client_ip
 from utils.pagination import PreSlicedCountProvidedPaginator, read_page
-from utils.ratelimit import key_for_ratelimiting, rate_per_ip
+from utils.ratelimit import RequestLimitReason, count_request_limit_event, key_for_ratelimiting, rate_per_ip
 from utils.search import (
     SearchEngineException,
     SearchEngineTimeoutException,
@@ -58,13 +57,6 @@ from utils.search.search_sounds import (
 )
 
 search_logger = logging.getLogger("search")
-
-# number of times we identified a suspicious ?page parameter in a search
-search_pagination_blocks_total = Counter(
-    "freesound_search_pagination_blocks_total",
-    "Search requests blocked by ?page query parameter anti-abuse",
-    ["reason", "enforced"],
-)
 
 
 def is_empty_query(request):
@@ -130,12 +122,12 @@ def search_view_helper(request):
                     "ip": get_client_ip(request),
                     "page": page,
                     "query": sqp.get_option_value_to_apply("query"),
-                    "reason": "hard_cap",
+                    "reason": RequestLimitReason.SEARCH_PAGE_LIMIT.value,
                     "enforced": True,
                 }
             )
         )
-        search_pagination_blocks_total.labels(reason="hard_cap", enforced="true").inc()
+        count_request_limit_event(request, RequestLimitReason.SEARCH_PAGE_LIMIT, enforced=True)
         raise PaginationAbuseBlocked()
 
     # Run the query and post-process the results

--- a/sounds/tests/test_download_limit_views.py
+++ b/sounds/tests/test_download_limit_views.py
@@ -13,9 +13,15 @@ from bookmarks.models import Bookmark, BookmarkCategory
 from fscollections.models import Collection, CollectionDownload, CollectionSound
 from sounds.models import Download, PackDownload
 from utils.download_limit import get_daily_download_count, increment_daily_download_count
-from utils.test_helpers import create_user_and_sounds
+from utils.ratelimit import request_limit_events_total
+from utils.test_helpers import counter_samples, create_user_and_sounds
 
 pytestmark = pytest.mark.redis
+
+
+def _daily_download_limit_events():
+    samples = counter_samples(request_limit_events_total, "reason", "enforced", "user_type")
+    return samples.get(("daily_download_limit", "true", "authenticated"), 0)
 
 
 @pytest.fixture
@@ -129,9 +135,11 @@ def test_sound_download_over_limit_range_continuation_is_served(
     settings.MAX_DOWNLOADS_PER_DAY = 1
     increment_daily_download_count(downloader.id)
     cache.set("sdwn_%s_%d" % (download_sound.id, downloader.id), True, 60 * 5)
+    before = _daily_download_limit_events()
     with mock.patch("sounds.views.sendfile", return_value=HttpResponse()):
         response = client.get(sound_download_url, HTTP_RANGE="bytes=0-")
     assert response.status_code == 200
+    assert _daily_download_limit_events() == before
 
 
 def test_sound_download_continuation_refreshes_sentinel_without_recounting(
@@ -179,7 +187,7 @@ def test_repeated_collection_download_records_one_row(
     assert CollectionDownload.objects.filter(user=downloader).count() == 1
 
 
-def test_bookmark_category_download_over_limit_returns_429_and_does_not_increment(
+def test_bookmark_category_download_over_limit_returns_429_and_does_not_increment_download_count(
     client, settings, bookmark_category, downloader
 ):
     settings.MAX_DOWNLOADS_PER_DAY = 1
@@ -187,7 +195,7 @@ def test_bookmark_category_download_over_limit_returns_429_and_does_not_incremen
     response = client.get(reverse("download-bookmark-category", args=[bookmark_category.id]))
     assert response.status_code == 429
     # Bookmark-category downloads do not have a download-row model, so assert the
-    # failed over-limit request did not advance the counter.
+    # failed over-limit request did not advance the count.
     assert get_daily_download_count(downloader.id) == 1
 
 

--- a/utils/download_limit.py
+++ b/utils/download_limit.py
@@ -8,6 +8,8 @@ from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 
+from utils.ratelimit import RequestLimitReason, count_request_limit_event
+
 logger = logging.getLogger("web")
 
 DOWNLOAD_LIMIT_CACHE_ALIAS = "abuse"
@@ -84,6 +86,7 @@ def _sentinel_key(download_type: DownloadType, object_id: int, user_id: int) -> 
 
 def download_limit_reached_response(request: HttpRequest) -> HttpResponse:
     """The 429 page returned when ``new_download_blocked`` says a download must not start."""
+    count_request_limit_event(request, RequestLimitReason.DAILY_DOWNLOAD_LIMIT, enforced=True)
     return render(
         request, "sounds/download_limit_reached.html", {"message": settings.DOWNLOAD_LIMIT_MESSAGE}, status=429
     )

--- a/utils/ratelimit.py
+++ b/utils/ratelimit.py
@@ -18,6 +18,7 @@
 #     See AUTHORS file.
 #
 
+import enum
 import ipaddress
 import logging
 import random
@@ -25,6 +26,7 @@ import time
 
 from django.conf import settings
 from django.core.cache import cache
+from prometheus_client import Counter
 
 from utils.logging_filters import get_client_ip
 
@@ -122,3 +124,38 @@ def rate_per_ip(group, request):
     if ip_is_blocked(ip):
         return "0/s"
     return settings.RATELIMITS.get(group, settings.RATELIMIT_DEFAULT_GROUP_RATELIMIT)
+
+
+class RequestLimitReason(enum.Enum):
+    """Cause of a request-limit event, used as the `reason` label on request_limit_events_total."""
+
+    # An APIv2 request exceeded its throttling rate (apiv2/exceptions.py)
+    API_THROTTLE = "api_throttle"
+    # An authenticated user exceeded the daily download limit (utils/download_limit.py)
+    DAILY_DOWNLOAD_LIMIT = "daily_download_limit"
+    # A view protected by the django-ratelimit decorator exceeded its rate (accounts/views.py ratelimited handler)
+    DJANGO_RATELIMIT = "django_ratelimit"
+    # A search requested a results page beyond the absolute maximum page number (search/views.py)
+    SEARCH_PAGE_LIMIT = "search_page_limit"
+
+
+# Emitted any time we return a 429 response to a user
+request_limit_events_total = Counter(
+    "freesound_request_limit_events_total",
+    "A user was limited for the given reason. enforced=true if we took action and returned 429. "
+    "enforced=false if we're only reporting (request is served normally). user_type=authenticated or anonymous.",
+    ["reason", "enforced", "user_type"],
+)
+
+
+def count_request_limit_event(request, reason: RequestLimitReason, *, enforced: bool):
+    """Increment the freesound_request_limit_events_total counter for the given labels.
+    Labels:
+      reason: type of rate limit event
+      enforced: true If we blocked the request or false if we're just reporting
+      user_type: authenticated or anonymous
+    """
+    user_type = "authenticated" if request.user.is_authenticated else "anonymous"
+    request_limit_events_total.labels(
+        reason=reason.value, enforced="true" if enforced else "false", user_type=user_type
+    ).inc()

--- a/utils/test_helpers.py
+++ b/utils/test_helpers.py
@@ -210,6 +210,20 @@ override_processing_before_description_path_with_temp_directory = partial(
 )
 
 
+def counter_samples(counter, *label_names):
+    """Given a prometheus Counter, get the values from it
+
+    Returns:
+        dict of {label-and-values: value}
+    """
+    return {
+        tuple(s.labels[name] for name in label_names): s.value
+        for m in counter.collect()
+        for s in m.samples
+        if s.name.endswith("_total")
+    }
+
+
 def create_fake_perform_search_engine_query_results_tags_mode():
     # This returns utils.search.SearchResults which was pickled from a real query in a local freesound instance
     return pickle.loads(  # noqa: S301

--- a/utils/tests/test_download_limit.py
+++ b/utils/tests/test_download_limit.py
@@ -1,11 +1,15 @@
 import pytest
 from django.core.cache import caches
+from django.test import RequestFactory
 
 from utils.download_limit import (
     download_limit_reached,
+    download_limit_reached_response,
     get_daily_download_count,
     increment_daily_download_count,
 )
+from utils.ratelimit import request_limit_events_total
+from utils.test_helpers import counter_samples
 
 pytestmark = pytest.mark.redis
 
@@ -45,6 +49,25 @@ def test_limit_reached_at_threshold(abuse_redis, settings):
     assert not download_limit_reached(123)
     increment_daily_download_count(123)
     assert download_limit_reached(123)
+
+
+def _daily_download_limit_events():
+    samples = counter_samples(request_limit_events_total, "reason", "enforced", "user_type")
+    return samples.get(("daily_download_limit", "true", "authenticated"), 0)
+
+
+@pytest.mark.django_db
+def test_reached_response_returns_429_and_counts_event(django_user_model):
+    # download_limit_reached_response is the shared 429 helper that every over-limit download
+    # type funnels through; assert it emits the request-limit event once with the right labels.
+    request = RequestFactory().get("/people/user/sounds/1/download/")
+    request.user = django_user_model.objects.create_user("u")
+    before = _daily_download_limit_events()
+
+    response = download_limit_reached_response(request)
+
+    assert response.status_code == 429
+    assert _daily_download_limit_events() == before + 1
 
 
 def test_fails_open_when_redis_unavailable(settings):

--- a/utils/tests/test_ratelimit.py
+++ b/utils/tests/test_ratelimit.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.models import AnonymousUser, User
+from django.test import RequestFactory
+
+from utils.ratelimit import RequestLimitReason, count_request_limit_event, request_limit_events_total
+from utils.test_helpers import counter_samples
+
+
+def _samples():
+    return counter_samples(request_limit_events_total, "reason", "enforced", "user_type")
+
+
+def test_count_request_limit_event_labels_anonymous():
+    req = RequestFactory().get("/search/")
+    req.user = AnonymousUser()
+    before = _samples().get(("search_page_limit", "true", "anonymous"), 0)
+    count_request_limit_event(req, RequestLimitReason.SEARCH_PAGE_LIMIT, enforced=True)
+    assert _samples()[("search_page_limit", "true", "anonymous")] == before + 1
+
+
+def test_count_request_limit_event_labels_authenticated():
+    req = RequestFactory().get("/search/")
+    req.user = User(username="u")
+    before = _samples().get(("django_ratelimit", "false", "authenticated"), 0)
+    count_request_limit_event(req, RequestLimitReason.DJANGO_RATELIMIT, enforced=False)
+    assert _samples()[("django_ratelimit", "false", "authenticated")] == before + 1


### PR DESCRIPTION
**Description**
I previously added a counter which allowed us to track search requests that were throttled due to bad requests. However we have other flows which send a 429 status too, so it'd be nice to be able to track all of them