### PR TITLE
 Fix 'Last post' property of threads not correctly re-set after spammers get deleted

### DIFF
--- a/forum/management/commands/update_last_thread_forum_posts.py
+++ b/forum/management/commands/update_last_thread_forum_posts.py
@@ -20,15 +20,15 @@
 
 import logging
 
-from forum.models import Forum, Thread
+from forum.models import Forum, Post, Thread
 from utils.management_commands import LoggingBaseCommand
 
 console_logger = logging.getLogger("console")
 
 
 class Command(LoggingBaseCommand):
-    help = """Updates last_post property of all Thread and Forum objects to make sure these
-    do not get out of sync."""
+    help = """Updates last_post and num_posts properties of all Thread and Forum objects to make
+    sure these do not get out of sync."""
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -45,17 +45,25 @@ class Command(LoggingBaseCommand):
         self.log_start()
 
         num_threads_updated = 0
-        for thread in Thread.objects.filter(last_post=None):
-            if not dry:
-                thread.set_last_post(commit=True)
-            num_threads_updated += 1
+        for thread in Thread.objects.all():
+            correct_num_posts = thread.post_set.filter(moderation_state="OK").count()
+            if thread.last_post_id is None or thread.num_posts != correct_num_posts:
+                if not dry:
+                    thread.set_last_post(commit=True)
+                    thread.set_num_posts(commit=True)
+                num_threads_updated += 1
 
         num_forums_updated = 0
-        for forum in Forum.objects.filter(last_post=None):
-            if not dry:
-                forum.set_last_post(commit=True)
-            num_forums_updated += 1
+        for forum in Forum.objects.all():
+            correct_num_posts = Post.objects.filter(thread__forum=forum, moderation_state="OK").count()
+            if forum.last_post_id is None or forum.num_posts != correct_num_posts:
+                if not dry:
+                    forum.set_last_post(commit=True)
+                    forum.set_num_posts(commit=True)
+                num_forums_updated += 1
 
-        console_logger.info(f"Updated last_post for {num_threads_updated} threads and {num_forums_updated} forums.")
+        console_logger.info(
+            f"Updated last_post/num_posts for {num_threads_updated} threads and {num_forums_updated} forums."
+        )
 
         self.log_end({"num_threads_updated": num_threads_updated, "num_forums_updated": num_forums_updated})

--- a/forum/models.py
+++ b/forum/models.py
@@ -311,15 +311,17 @@ def update_thread_on_post_delete(sender, instance, **kwargs):
     elif post.moderation_state == "OK":
         try:
             with transaction.atomic():
-                post.author.profile.num_posts = F("num_posts") - 1
-                post.author.profile.save()
+                # Update the author's profile count with a queryset update so that it is a no-op when the profile has already been deleted.
+                accounts.models.Profile.objects.filter(user_id=post.author_id).update(
+                    num_posts=Greatest(F("num_posts") - 1, 0)
+                )
                 post.thread.forum.refresh_from_db()
-                post.thread.forum.num_posts = F("num_posts") - 1
+                post.thread.forum.num_posts = Greatest(F("num_posts") - 1, 0)
                 post.thread.forum.set_last_post()
                 post.thread.forum.save()
                 thread_has_posts = post.thread.set_last_post()
                 if thread_has_posts:
-                    post.thread.num_posts = F("num_posts") - 1
+                    post.thread.num_posts = Greatest(F("num_posts") - 1, 0)
                     post.thread.save()
 
                     # If this post was the first post in the thread then we should set it to the next one
@@ -335,11 +337,6 @@ def update_thread_on_post_delete(sender, instance, **kwargs):
             # to update the thread, but it would be nice to get to the forum object
             # somehow and update that one....
             web_logger.info("Tried setting last posts for thread and forum, but the thread has already been deleted?")
-        except accounts.models.Profile.DoesNotExist:
-            # When a user is deleted using the admin, is possible that his posts are deleted after the profile has been
-            # deleted. In that case we shouldn't update the value of num_posts because the profile doesn't exists
-            # anymore, here it's safe to ignore the exception since we are deleting all the objects.
-            web_logger.info("Tried setting last posts for thread and forum, but the profile has already been deleted?")
     invalidate_template_cache("latest_posts")
 
 

--- a/forum/models.py
+++ b/forum/models.py
@@ -70,6 +70,11 @@ class Forum(SortableMixin):
         if commit:
             self.save()
 
+    def set_num_posts(self, commit=False):
+        self.num_posts = Post.objects.filter(thread__forum=self, moderation_state="OK").count()
+        if commit:
+            self.save(update_fields=["num_posts"])
+
     def __str__(self):
         return self.name
 
@@ -121,6 +126,11 @@ class Thread(models.Model):
         invalidate_template_cache("bw_thread_common_commenters", self.id)
 
         return has_posts
+
+    def set_num_posts(self, commit=False):
+        self.num_posts = self.post_set.filter(moderation_state="OK").count()
+        if commit:
+            self.save(update_fields=["num_posts"])
 
     def set_first_post(self, commit=False):
         self.first_post = self.post_set.first()

--- a/forum/tests.py
+++ b/forum/tests.py
@@ -23,7 +23,7 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
-from accounts.models import EmailPreferenceType, UserEmailSetting
+from accounts.models import DeletedUser, EmailPreferenceType, UserEmailSetting
 from forum.models import Forum, Post, Subscription, Thread
 
 
@@ -239,6 +239,39 @@ class ForumPostSignalTestCase(TestCase):
         # After deleting t1post2, the last post of thread1 has changed, but not the last post of the forum
         self.assertEqual(self.thread.last_post, t1post1)
         self.assertEqual(self.forum.last_post, t2post)
+
+
+class ForumPostCascadeDeleteTestCase(TestCase):
+    """Tests that thread and forum last_post/num_posts are correctly updated when posts are
+    deleted in cascade together with their author, e.g. when a spammer user is deleted (#1575)"""
+
+    def setUp(self):
+        self.user = User.objects.create_user("testuser", password="testpass", email="email@freesound.org")
+        self.spammer = User.objects.create_user("spammer", password="testpass", email="spammer@freesound.org")
+        self.forum = Forum.objects.create(name="testForum", name_slug="test_forum", description="test")
+        self.thread = Thread.objects.create(forum=self.forum, title="testThread", author=self.user)
+        self.first_post = Post.objects.create(thread=self.thread, author=self.user, body="", moderation_state="OK")
+        self.spam_post = Post.objects.create(thread=self.thread, author=self.spammer, body="", moderation_state="OK")
+
+    def assert_counts_updated_after_spammer_deletion(self):
+        self.thread.refresh_from_db()
+        self.forum.refresh_from_db()
+        self.assertEqual(self.thread.num_posts, 1)
+        self.assertEqual(self.thread.last_post, self.first_post)
+        self.assertEqual(self.forum.num_posts, 1)
+        self.assertEqual(self.forum.last_post, self.first_post)
+
+    def test_delete_user_object_cascade(self):
+
+        self.spammer.delete()
+        self.assert_counts_updated_after_spammer_deletion()
+
+    def test_delete_spammer_user_from_db(self):
+
+        self.spammer.profile.delete_user(
+            delete_user_object_from_db=True, deletion_reason=DeletedUser.DELETION_REASON_SPAMMER
+        )
+        self.assert_counts_updated_after_spammer_deletion()
 
 
 class ForumThreadSignalTestCase(TestCase):


### PR DESCRIPTION
**Issue(s)**
#1575 

**Description**
## Fix "Last post" not re-set after spammers get deleted (#1575)

### Problem
When a spammer is deleted from the DB, their posts are cascade-deleted along
with their account. This left threads and forums with a blank "last post" and
an inflated reply count on the forum listing pages.

**Root cause:** the `post_delete` signal handler that repairs these cached
fields tried to update the spammer's own profile first. Since the profile was
already deleted in the cascade, that line raised `Profile.DoesNotExist`, which
was silently caught, so the code never reached the part that re-points
`last_post` and fixes `num_posts`.

### Changes

**1. Fix the signal handler (`forum/models.py`)**
- Update the author's profile count with a queryset `update()` so it's a no-op
  (instead of an exception) when the profile is already gone. The thread/forum
  repairs now always run.
- Clamp all `num_posts` decrements with `Greatest(..., 0)` so deletions can't
  crash on counts that are already out of sync.
- Remove the now-unreachable `except Profile.DoesNotExist` branch.
- Add regression tests covering both deletion paths (`user.delete()` and
  `Profile.delete_user(delete_user_object_from_db=True)`).

**2. Repair already-broken data (`update_last_thread_forum_posts` command)**
The fix above only prevents *new* corruption; rows already broken on production
stay broken. This extends the existing repair command to also recompute
`num_posts` (previously it only fixed `last_post`), and to scan all threads and
forums rather than only those with a null `last_post`. Run it once after
deploying to heal the historical data.

### Testing
- New tests fail on the old code and pass with the fix.
- Full `forum/` and `accounts/tests/test_user.py` suites pass.
- Verified the repair command end-to-end: manually corrupted a thread/forum,
  ran the command, confirmed `last_post` and `num_posts` were restored.

**Deployment steps**:
After deploying, run the forum repair command once to fix threads/forums whose
`last_post`/`num_posts` were already corrupted by this bug before the fix:

    python manage.py update_last_thread_forum_posts

(Run with `--dry` first to see how many rows would change without writing.)
