### PR TITLE
Move API exception logging to DRF handler

### DIFF
--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -59,7 +59,6 @@ from utils.search.search_sounds import parse_weights_parameter
 
 from .examples import examples
 
-error_logger = logging.getLogger("api_errors")
 search_logger = logging.getLogger("search")
 cache_api_monitoring = caches["api_monitoring"]
 

--- a/apiv2/exceptions.py
+++ b/apiv2/exceptions.py
@@ -19,161 +19,66 @@
 #
 
 
-import logging
-
-import sentry_sdk
 from rest_framework import status
 from rest_framework.exceptions import APIException
 
-import apiv2.apiv2_utils  # absolute import because of mutual imports of this module and apiv2_utils
-from utils.ratelimit import RequestLimitReason, count_request_limit_event
 
-errors_logger = logging.getLogger("api_errors")
+class LoggedAPIException(APIException):
+    # An APIException, which when handled by our exception handler will also emit a log message
+    # to the specified logger.
+    summary_label = None
+    report_to_sentry = False
+
+    def __init__(self, msg=None, *, resource=None, request=None):
+        self.detail = msg if msg is not None else self.default_detail
+        self.log_resource = resource
+        self.log_request = request
 
 
-class NotFoundException(APIException):
-    detail = None
+class NotFoundException(LoggedAPIException):
     status_code = status.HTTP_404_NOT_FOUND
-
-    def __init__(self, msg="Not found", resource=None):
-        summary_message = "%i Not found" % self.status_code
-        errors_logger.info(
-            apiv2.apiv2_utils.log_message_helper(
-                summary_message,
-                data_dict={"summary_message": summary_message, "long_message": msg, "status": self.status_code},
-                resource=resource,
-            )
-        )
-        self.detail = msg
+    summary_label = "Not found"
+    default_detail = "Not found"
 
 
-class InvalidUrlException(APIException):
-    detail = None
+class InvalidUrlException(LoggedAPIException):
     status_code = status.HTTP_400_BAD_REQUEST
-
-    def __init__(self, msg="Invalid url", request=None):
-        summary_message = "%i Invalid url" % self.status_code
-        errors_logger.info(
-            apiv2.apiv2_utils.log_message_helper(
-                summary_message,
-                data_dict={"summary_message": summary_message, "long_message": msg, "status": self.status_code},
-                request=request,
-            )
-        )
-        self.detail = msg
+    summary_label = "Invalid url"
+    default_detail = "Invalid url"
 
 
-class BadRequestException(APIException):
-    detail = None
+class BadRequestException(LoggedAPIException):
     status_code = status.HTTP_400_BAD_REQUEST
-
-    def __init__(self, msg="Bad request", resource=None):
-        summary_message = "%i Bad request" % self.status_code
-        errors_logger.info(
-            apiv2.apiv2_utils.log_message_helper(
-                summary_message,
-                data_dict={"summary_message": summary_message, "long_message": msg, "status": self.status_code},
-                resource=resource,
-            )
-        )
-        self.detail = msg
+    summary_label = "Bad request"
+    default_detail = "Bad request"
 
 
-class ConflictException(APIException):
-    detail = None
+class ConflictException(LoggedAPIException):
     status_code = status.HTTP_409_CONFLICT
-
-    def __init__(self, msg="Conflict", resource=None):
-        summary_message = "%i Conflict" % self.status_code
-        errors_logger.info(
-            apiv2.apiv2_utils.log_message_helper(
-                summary_message,
-                data_dict={"summary_message": summary_message, "long_message": msg, "status": self.status_code},
-                resource=resource,
-            )
-        )
-        self.detail = msg
+    summary_label = "Conflict"
+    default_detail = "Conflict"
 
 
-class UnauthorizedException(APIException):
-    detail = None
+class UnauthorizedException(LoggedAPIException):
     status_code = status.HTTP_401_UNAUTHORIZED
-
-    def __init__(self, msg="Not authorized", resource=None):
-        summary_message = "%i Not authorized" % self.status_code
-        errors_logger.info(
-            apiv2.apiv2_utils.log_message_helper(
-                summary_message,
-                data_dict={"summary_message": summary_message, "long_message": msg, "status": self.status_code},
-                resource=resource,
-            )
-        )
-        self.detail = msg
+    summary_label = "Not authorized"
+    default_detail = "Not authorized"
 
 
-class RequiresHttpsException(APIException):
-    detail = None
+class RequiresHttpsException(LoggedAPIException):
     status_code = status.HTTP_403_FORBIDDEN
-
-    def __init__(self, msg="This resource requires a secure connection (https)", request=None):
-        summary_message = "%i Requires Https" % self.status_code
-        errors_logger.info(
-            apiv2.apiv2_utils.log_message_helper(
-                summary_message,
-                data_dict={"summary_message": summary_message, "long_message": msg, "status": self.status_code},
-                request=request,
-            )
-        )
-        self.detail = msg
+    summary_label = "Requires Https"
+    default_detail = "This resource requires a secure connection (https)"
 
 
-class ServerErrorException(APIException):
-    detail = None
+class ServerErrorException(LoggedAPIException):
     status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-
-    def __init__(self, msg="Server error", resource=None):
-        summary_message = "%i Server error" % self.status_code
-        errors_logger.info(
-            apiv2.apiv2_utils.log_message_helper(
-                summary_message,
-                data_dict={"summary_message": summary_message, "long_message": msg, "status": self.status_code},
-                resource=resource,
-            )
-        )
-        self.detail = msg
-        sentry_sdk.capture_exception(self)
+    summary_label = "Server error"
+    default_detail = "Server error"
+    report_to_sentry = True
 
 
-class OtherException(APIException):
-    detail = None
-    status_code = None
-
-    def __init__(self, msg="Bad request", status=status.HTTP_400_BAD_REQUEST, resource=None):
-        summary_message = "%i Other exception" % status
-        errors_logger.info(
-            apiv2.apiv2_utils.log_message_helper(
-                summary_message,
-                data_dict={"summary_message": summary_message, "long_message": msg, "status": status},
-                resource=resource,
-            )
-        )
-        self.detail = msg
-        self.status_code = status
-
-
-class Throttled(APIException):
-    detail = None
+class Throttled(LoggedAPIException):
     status_code = status.HTTP_429_TOO_MANY_REQUESTS
-
-    def __init__(self, msg="Request was throttled", request=None):
-        summary_message = "%i Throttled" % self.status_code
-        errors_logger.info(
-            apiv2.apiv2_utils.log_message_helper(
-                summary_message,
-                data_dict={"summary_message": summary_message, "long_message": msg, "status": self.status_code},
-                request=request,
-            )
-        )
-        self.detail = msg
-        if request is not None:
-            count_request_limit_event(request, RequestLimitReason.API_THROTTLE, enforced=True)
+    summary_label = "Throttled"
+    default_detail = "Request was throttled"

--- a/apiv2/handlers.py
+++ b/apiv2/handlers.py
@@ -1,0 +1,56 @@
+#
+# Freesound is (c) MUSIC TECHNOLOGY GROUP, UNIVERSITAT POMPEU FABRA
+#
+# Freesound is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Freesound is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     See AUTHORS file.
+#
+
+
+import logging
+
+import sentry_sdk
+from rest_framework.views import exception_handler as drf_exception_handler
+
+from apiv2.apiv2_utils import log_message_helper
+from apiv2.exceptions import LoggedAPIException, Throttled
+from utils.ratelimit import RequestLimitReason, count_request_limit_event
+
+errors_logger = logging.getLogger("api_errors")
+
+
+def api_exception_handler(exc, context):
+    # If the exception is one of our specific API handlers, send a
+    # message to the log handler, sentry, and prometheus, if configured
+    response = drf_exception_handler(exc, context)
+    if isinstance(exc, LoggedAPIException):
+        summary = f"{exc.status_code} {exc.summary_label}"
+        errors_logger.info(
+            log_message_helper(
+                summary,
+                data_dict={
+                    "summary_message": summary,
+                    "long_message": exc.detail,
+                    "status": exc.status_code,
+                },
+                resource=exc.log_resource,
+                request=exc.log_request,
+            )
+        )
+        if exc.report_to_sentry:
+            sentry_sdk.capture_exception(exc)
+        if isinstance(exc, Throttled) and exc.log_request is not None:
+            count_request_limit_event(exc.log_request, RequestLimitReason.API_THROTTLE, enforced=True)
+    return response

--- a/apiv2/tests.py
+++ b/apiv2/tests.py
@@ -17,12 +17,17 @@
 # Authors:
 #     See AUTHORS file.
 #
+import json
+from unittest import mock
+
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
+from django.http import Http404
 from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
+from rest_framework.exceptions import ValidationError
 
 from apiv2.models import ApiV2Client
 from apiv2.serializers import DEFAULT_FIELDS_IN_SOUND_LIST, SoundListSerializer, SoundSerializer
@@ -31,8 +36,14 @@ from sounds.models import Sound
 from utils.ratelimit import request_limit_events_total
 from utils.test_helpers import counter_samples, create_user_and_sounds
 
-from .exceptions import BadRequestException, Throttled
+from .exceptions import (
+    BadRequestException,
+    NotFoundException,
+    ServerErrorException,
+    Throttled,
+)
 from .forms import SoundTextSearchFormAPI
+from .handlers import api_exception_handler
 
 
 class TestAPiViews(TestCase):
@@ -714,6 +725,79 @@ class APIAuthenticationTestCase(TestCase):
         self.assertEqual(resp.status_code, 401)
 
 
+class TestAPIExceptionHandlerIntegration(SimpleTestCase):
+    def test_exception_handler_is_wired_into_drf(self):
+        # End-to-end check that a real request that raises a LoggedAPIException is routed through
+        # our configured EXCEPTION_HANDLER.
+        url = reverse("apiv2-download_from_token", args=["bogus"])
+
+        with self.assertLogs("api_errors", level="INFO") as logs:
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), {"detail": "Invalid token."})
+        self.assertEqual(len(logs.records), 1)
+
+
+class TestAPIExceptionHandler(SimpleTestCase):
+    def assert_single_log(self, logs, status_code, summary_label, detail):
+        # Every LoggedAPIException emits exactly one api_errors line in a specific format
+        self.assertEqual(len(logs.records), 1)
+        summary, data, info = logs.records[0].getMessage().split(" #!# ")
+        self.assertEqual(summary, f"{status_code} {summary_label}")
+        self.assertEqual(
+            json.loads(data),
+            {
+                "summary_message": f"{status_code} {summary_label}",
+                "long_message": detail,
+                "status": status_code,
+            },
+        )
+        self.assertIsNone(json.loads(info))
+
+    def test_plain_4xx_logs_once_and_is_not_reported_to_sentry(self):
+        with mock.patch("apiv2.handlers.sentry_sdk.capture_exception") as capture_exception:
+            with self.assertLogs("api_errors", level="INFO") as logs:
+                response = api_exception_handler(NotFoundException(), context={})
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data, {"detail": "Not found"})
+        self.assert_single_log(logs, 404, "Not found", "Not found")
+        capture_exception.assert_not_called()
+
+    def test_server_error_is_reported_to_sentry(self):
+        with mock.patch("apiv2.handlers.sentry_sdk.capture_exception") as capture_exception:
+            with self.assertLogs("api_errors", level="INFO") as logs:
+                exception = ServerErrorException()
+                response = api_exception_handler(exception, context={})
+
+        self.assertEqual(response.status_code, 500)
+        self.assert_single_log(logs, 500, "Server error", "Server error")
+        capture_exception.assert_called_once_with(exception)
+
+    def test_non_custom_exceptions_delegate_without_telemetry(self):
+        cases = (
+            # A DRF exception (APIException subclass) that isn't one of ours.
+            (ValidationError({"field": ["Invalid"]}), 400, {"field": ["Invalid"]}),
+            # Not a DRF exception - a Django exception that DRF adapts into a response.
+            (Http404("Missing"), 404, {"detail": "Missing"}),
+        )
+
+        for exception, status_code, detail in cases:
+            with self.subTest(exception=type(exception).__name__):
+                with (
+                    mock.patch("apiv2.handlers.sentry_sdk.capture_exception") as capture_exception,
+                    mock.patch("apiv2.handlers.count_request_limit_event") as count_request_limit_event,
+                    self.assertNoLogs("api_errors", level="INFO"),
+                ):
+                    response = api_exception_handler(exception, context={})
+
+                self.assertEqual(response.status_code, status_code)
+                self.assertEqual(response.data, detail)
+                capture_exception.assert_not_called()
+                count_request_limit_event.assert_not_called()
+
+
 class TestThrottledException(SimpleTestCase):
     @staticmethod
     def _samples():
@@ -729,14 +813,18 @@ class TestThrottledException(SimpleTestCase):
         request = self._make_request(AnonymousUser())
         before = self._samples().get(("api_throttle", "true", "anonymous"), 0)
 
-        Throttled(request=request)
+        with self.assertLogs("api_errors", level="INFO"):
+            response = api_exception_handler(Throttled(request=request), context={})
 
+        assert response.status_code == 429
         assert self._samples()[("api_throttle", "true", "anonymous")] == before + 1
 
     def test_throttled_counts_event_for_authenticated_request(self):
         request = self._make_request(User(username="throttled_user"))
         before = self._samples().get(("api_throttle", "true", "authenticated"), 0)
 
-        Throttled(request=request)
+        with self.assertLogs("api_errors", level="INFO"):
+            response = api_exception_handler(Throttled(request=request), context={})
 
+        assert response.status_code == 429
         assert self._samples()[("api_throttle", "true", "authenticated")] == before + 1

--- a/apiv2/views.py
+++ b/apiv2/views.py
@@ -51,7 +51,6 @@ from apiv2.exceptions import (
     ConflictException,
     InvalidUrlException,
     NotFoundException,
-    OtherException,
     ServerErrorException,
     UnauthorizedException,
 )
@@ -761,11 +760,11 @@ class UploadSound(WriteRequiredGenericAPIView):
                         try:
                             sound = utils.sound_upload.create_sound(self.user, sound_fields, apiv2_client=apiv2_client)
                         except utils.sound_upload.NoAudioException:
-                            raise OtherException(
+                            raise BadRequestException(
                                 "Something went wrong with accessing the file %s." % sound_fields["name"]
                             )
                         except utils.sound_upload.AlreadyExistsException:
-                            raise OtherException(
+                            raise BadRequestException(
                                 "Sound could not be created because the uploaded file is already part of freesound.",
                                 resource=self,
                             )

--- a/freesound/settings.py
+++ b/freesound/settings.py
@@ -830,6 +830,7 @@ APIV2 = {
 }
 
 REST_FRAMEWORK = {
+    "EXCEPTION_HANDLER": "apiv2.handlers.api_exception_handler",
     "DEFAULT_PAGINATION_CLASS": "apiv2.pagination.CustomPagination",
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_RENDERER_CLASSES": (

--- a/utils/ratelimit.py
+++ b/utils/ratelimit.py
@@ -129,7 +129,7 @@ def rate_per_ip(group, request):
 class RequestLimitReason(enum.Enum):
     """Cause of a request-limit event, used as the `reason` label on request_limit_events_total."""
 
-    # An APIv2 request exceeded its throttling rate (apiv2/exceptions.py)
+    # An APIv2 request exceeded its throttling rate (apiv2/handlers.py)
     API_THROTTLE = "api_throttle"
     # An authenticated user exceeded the daily download limit (utils/download_limit.py)
     DAILY_DOWNLOAD_LIMIT = "daily_download_limit"


### PR DESCRIPTION
our API exceptions had side effects when you initialized them, sending logging events and metrics.

Instead, make the exceptions themselves pure, and only log events in a custom DRF error handler

**Issue(s)**
<!-- URL to issue(s) related to this PR -->

**Description**
<!-- Description of the contents of this PR -->

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
