### PR TITLE
Split Solr errors into specific exceptions

### DIFF
--- a/apiv2/apiv2_utils.py
+++ b/apiv2/apiv2_utils.py
@@ -54,7 +54,12 @@ from apiv2.exceptions import (
 from apiv2.forms import API_SORT_OPTIONS_MAP
 from utils.encryption import create_hash
 from utils.logging_filters import get_client_ip
-from utils.search import SearchEngineException, SearchEngineTimeoutException, get_search_engine
+from utils.search import (
+    SearchEngineException,
+    SearchEngineInternalErrorException,
+    SearchEngineTimeoutException,
+    get_search_engine,
+)
 from utils.search.search_sounds import parse_weights_parameter
 
 from .examples import examples
@@ -362,6 +367,16 @@ def api_search(search_form, target_file=None, resource=None):
             )
         )
         raise ServerErrorException(msg="Search is overloaded, please try again later.", resource=resource)
+    except SearchEngineInternalErrorException as e:
+        # A genuine fault on the search server (HTTP 5xx) or an unreachable server, not something
+        # the API client got wrong. Keep the Solr detail in a breadcrumb (.info, not .error, which
+        # would create a second Sentry event via LoggingIntegration) but never echo it to the
+        # client. ServerErrorException.__init__ captures the single Sentry event.
+        search_logger.info(f"Search server internal error: {e}")
+        raise ServerErrorException(
+            msg="There was a problem with the search server, please try again later.",
+            resource=resource,
+        )
     except SearchEngineException as e:
         if search_form.cleaned_data["filter"] is not None:
             raise BadRequestException(

--- a/apiv2/tests.py
+++ b/apiv2/tests.py
@@ -17,6 +17,8 @@
 # Authors:
 #     See AUTHORS file.
 #
+from unittest import mock
+
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.contenttypes.models import ContentType
@@ -29,6 +31,7 @@ from apiv2.serializers import DEFAULT_FIELDS_IN_SOUND_LIST, SoundListSerializer,
 from bookmarks.models import Bookmark, BookmarkCategory
 from sounds.models import Sound
 from utils.ratelimit import request_limit_events_total
+from utils.search import SearchEngineUnavailableException
 from utils.test_helpers import counter_samples, create_user_and_sounds
 
 from .exceptions import BadRequestException, Throttled
@@ -145,6 +148,47 @@ class TestAPI(TestCase):
             "/apiv2/search/text/?query=ambient&filter=tag:(rain%20OR%CAfe)", secure=True, **headers
         )
         self.assertEqual(resp.status_code, 200)
+
+
+class TestApiSearchServerError(TestCase):
+    """When the search backend reports a server-side fault (5xx or unreachable), the API must
+    return a 500 with a generic message and must not leak the raw Solr reason to the client."""
+
+    fixtures = ["licenses"]
+
+    SOLR_REASON = "Failed to connect to server at http://solr:8983/solr/freesound"
+    EXPECTED_MESSAGE = "There was a problem with the search server, please try again later."
+
+    def setUp(self):
+        user, _, _ = create_user_and_sounds(num_sounds=1)
+        self.client_key = ApiV2Client.objects.create(
+            user=user, status="OK", redirect_uri="https://freesound.com", url="https://freesound.com", name="test"
+        ).key
+
+    def _search(self):
+        headers = {"HTTP_AUTHORIZATION": f"Token {self.client_key}"}
+        return self.client.get(reverse("apiv2-sound-text-search") + "?query=test", secure=True, **headers)
+
+    @mock.patch("apiv2.exceptions.sentry_sdk.capture_exception")
+    @mock.patch("apiv2.apiv2_utils.search_logger")
+    @mock.patch("apiv2.apiv2_utils.get_search_engine")
+    def test_server_error_returns_generic_500_without_leaking_solr_reason(
+        self, get_search_engine, search_logger, capture_exception
+    ):
+        get_search_engine.return_value.search_sounds.side_effect = SearchEngineUnavailableException(self.SOLR_REASON)
+
+        resp = self._search()
+
+        self.assertEqual(resp.status_code, 500)
+        self.assertEqual(resp.json()["detail"], self.EXPECTED_MESSAGE)
+        self.assertNotIn(self.SOLR_REASON, resp.content.decode())
+
+        # Exactly one Sentry event (ServerErrorException self-captures on construction).
+        self.assertEqual(capture_exception.call_count, 1)
+        # Diagnostic detail goes to a breadcrumb via .info; .error would create a *second*
+        # event through Sentry's LoggingIntegration.
+        self.assertFalse(search_logger.error.called)
+        self.assertTrue(search_logger.info.called)
 
 
 class TestSoundCombinedSearchFormAPI(SimpleTestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pyjwt==2.6.0",
     "pyparsing==2.4.7",
     "pysndfile~=1.5.3",
-    "pysolr==3.10.0",
+    "pysolr @ git+https://github.com/django-haystack/pysolr.git@6b8b1f973fbb00fd01ca520440d27cda6abcce55",
     "prometheus-client==0.25.0",
     "pytest~=8.0.2",
     "pytest-django~=4.8.0", # community detection in clustering

--- a/search/tests/test_views.py
+++ b/search/tests/test_views.py
@@ -30,7 +30,7 @@ from django.urls import reverse
 from sounds.models import Sound
 from utils.pagination import PreSlicedCountProvidedPaginator
 from utils.ratelimit import request_limit_events_total
-from utils.search import SearchResults
+from utils.search import SearchEngineInternalErrorException, SearchResults
 from utils.test_helpers import counter_samples, create_user_and_sounds
 
 
@@ -260,6 +260,51 @@ class SearchOutOfRangeTests(TestCase):
         self.assertNotContains(resp, "No more results")
         # 0 results shows no paginator
         self.assertNotContains(resp, "bw-pagination_container")
+
+
+class SearchServerErrorTests(TestCase):
+    """A server-side search fault (5xx / unreachable) must show a "problem with the search server"
+    message, not the "is your query correct?" message that blames the user's query."""
+
+    fixtures = ["licenses", "users", "sounds_with_tags"]
+
+    SERVER_MESSAGE = "There was a problem with the search server, please try again later."
+    QUERY_BLAME_MESSAGE = "is your query correct?"
+
+    @mock.patch("search.views.sentry_sdk.capture_exception")
+    @mock.patch("search.views.search_logger")
+    @mock.patch("search.views.perform_search_engine_query")
+    def test_sounds_search_server_error_shows_server_message(
+        self, perform_search_engine_query, search_logger, capture_exception
+    ):
+        exc = SearchEngineInternalErrorException("Solr 500")
+        perform_search_engine_query.side_effect = exc
+        cache.clear()
+
+        resp = self.client.get(reverse("sounds-search") + "?q=test")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context["error_text"], self.SERVER_MESSAGE)
+        self.assertNotContains(resp, self.QUERY_BLAME_MESSAGE)
+        self.assertFalse(search_logger.error.called)
+        self.assertTrue(search_logger.info.called)
+        capture_exception.assert_called_once_with(exc)
+
+    @mock.patch("search.views.sentry_sdk.capture_exception")
+    @mock.patch("search.views.search_logger")
+    @mock.patch("search.views.get_search_engine")
+    def test_forum_search_server_error_shows_server_message(self, get_search_engine, search_logger, capture_exception):
+        exc = SearchEngineInternalErrorException("Solr 500")
+        get_search_engine.return_value.search_forum_posts.side_effect = exc
+
+        resp = self.client.get(reverse("forums-search") + "?q=test")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context["error_text"], self.SERVER_MESSAGE)
+        self.assertNotContains(resp, self.QUERY_BLAME_MESSAGE)
+        self.assertFalse(search_logger.error.called)
+        self.assertTrue(search_logger.info.called)
+        capture_exception.assert_called_once_with(exc)
 
 
 class SearchResultClustering(TestCase):

--- a/search/views.py
+++ b/search/views.py
@@ -46,6 +46,7 @@ from utils.pagination import PreSlicedCountProvidedPaginator, read_page
 from utils.ratelimit import RequestLimitReason, count_request_limit_event, key_for_ratelimiting, rate_per_ip
 from utils.search import (
     SearchEngineException,
+    SearchEngineInternalErrorException,
     SearchEngineTimeoutException,
     get_search_engine,
     search_query_processor,
@@ -275,6 +276,11 @@ def search_view_helper(request):
             )
         )
         return {"error_text": "Search is overloaded, please try again later."}
+    except SearchEngineInternalErrorException as e:
+        # A server-side fault (HTTP 5xx) or an unreachable search server, not the client's query.
+        search_logger.info(f"Search server error: {e}")
+        sentry_sdk.capture_exception(e)
+        return {"error_text": "There was a problem with the search server, please try again later."}
     except SearchEngineException as e:
         search_logger.info(f"Search error: query: {str(query_params)} error {e}")
         sentry_sdk.capture_exception(e)
@@ -433,6 +439,12 @@ def search_forum(request):
             )
             error = True
             error_text = "Search is overloaded, please try again later."
+        except SearchEngineInternalErrorException as e:
+            # A server-side fault (HTTP 5xx) or an unreachable search server, not the client's query.
+            search_logger.info(f"Search server error: {e}")
+            sentry_sdk.capture_exception(e)
+            error = True
+            error_text = "There was a problem with the search server, please try again later."
         except SearchEngineException as e:
             search_logger.info(f"Search error: query: {search_query} error {e}")
             sentry_sdk.capture_exception(e)

--- a/utils/search/__init__.py
+++ b/utils/search/__init__.py
@@ -153,11 +153,43 @@ class SearchResults:
 
 
 class SearchEngineException(Exception):
-    pass
+    """Base class for all search engine errors. Also used for anything we couldn't
+    classify more specifically (including validation errors raised by the query processor)."""
 
 
 class SearchEngineTimeoutException(SearchEngineException):
-    pass
+    """The request to the search engine timed out (client-side), or the search engine
+    returned partial results because it exceeded its own time limit."""
+
+
+class SearchEngineBadRequestException(SearchEngineException):
+    """The search engine rejected the request as malformed (an HTTP 4xx). Typically the
+    result of bad user input rather than a fault on our side."""
+
+
+class SearchEngineSyntaxErrorException(SearchEngineBadRequestException):
+    """The search engine could not parse the query or filter."""
+
+
+class SearchEngineUndefinedFieldException(SearchEngineBadRequestException):
+    """The query referenced a field name that does not exist in the schema."""
+
+
+class SearchEngineInvalidValueException(SearchEngineBadRequestException):
+    """A field value could not be parsed by the search engine (e.g. a non-numeric value
+    for a numeric field)."""
+
+
+class SearchEngineInternalErrorException(SearchEngineException):
+    """The search engine reported an internal fault (an HTTP 5xx). Typically indicates a
+    bug on our side (e.g. a malformed block-join query) rather than bad user input."""
+
+
+class SearchEngineUnavailableException(SearchEngineInternalErrorException):
+    """We could not reach or parse a response from the search engine (connection refused,
+    unreachable host, or a broken HTTP response). A subclass of the internal-error family so
+    every "not the client's fault" handler catches it, but a distinct type so "Solr is down"
+    (infra/on-call) groups separately from "Solr returned a 5xx to a query we built" (code bug)."""
 
 
 class SearchEngineBase:

--- a/utils/search/backends/solr555pysolr.py
+++ b/utils/search/backends/solr555pysolr.py
@@ -24,13 +24,26 @@ import random
 import re
 from collections import defaultdict
 from datetime import date, datetime
+from http.client import HTTPException
 
 import pysolr
+import requests
 from django.conf import settings
 
 from forum.models import Post
 from sounds.models import Sound, SoundSimilarityVector
-from utils.search import SearchEngineBase, SearchEngineException, SearchEngineTimeoutException, SearchResults
+from utils.search import (
+    SearchEngineBadRequestException,
+    SearchEngineBase,
+    SearchEngineException,
+    SearchEngineInternalErrorException,
+    SearchEngineInvalidValueException,
+    SearchEngineSyntaxErrorException,
+    SearchEngineTimeoutException,
+    SearchEngineUnavailableException,
+    SearchEngineUndefinedFieldException,
+    SearchResults,
+)
 from utils.search.backends.solr_common import SolrQuery, SolrResponseInterpreter
 from utils.text import remove_control_chars
 
@@ -187,11 +200,45 @@ class FreesoundSoundJsonEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, value)
 
 
+# pysolr embeds the HTTP status and Solr's reason string in its SolrError message, e.g.
+#   "Solr responded with an error (HTTP 400): [Reason: undefined field foobar]"
+_SOLR_ERROR_HTTP_CODE_RE = re.compile(r"\(HTTP (\d{3})\)")
+
+
 def _raise_search_engine_exception(error: BaseException) -> None:
-    # pysolr swallows exceptions and returns a generic SolrError with some specific text in the message
-    # super annoying but this is the only way to check the type of error.
-    if "timed out" in str(error).lower():
-        raise SearchEngineTimeoutException(error)
+    # pysolr swallows the underlying error and re-raises an opaque SolrError, so classify it
+    # into a typed exception (see utils.search) so each error family is a distinct Sentry issue.
+    message = str(error)
+    code_match = _SOLR_ERROR_HTTP_CODE_RE.search(message)
+    status_code = int(code_match.group(1)) if code_match else None
+    reason = message.lower()
+
+    # Solr responded with a status — trust it over any chained cause. The specific 4xx
+    # families are checked before the generic "cannot parse" wrapper, which Solr prepends to
+    # invalid-number / undefined-field errors.
+    if status_code is not None and 400 <= status_code < 500:
+        if "undefined field" in reason:
+            raise SearchEngineUndefinedFieldException(error)
+        if "invalid number" in reason:
+            raise SearchEngineInvalidValueException(error)
+        if "cannot parse" in reason or "syntaxerror" in reason:
+            raise SearchEngineSyntaxErrorException(error)
+        raise SearchEngineBadRequestException(error)
+
+    if status_code is not None and 500 <= status_code < 600:
+        raise SearchEngineInternalErrorException(error)
+
+    # No HTTP status: Solr never answered. Distinguish transport failures by the exception
+    # pysolr chained via `raise SolrError(...) from err`. Timeout is checked before the broader
+    # (RequestException, HTTPException) because Timeout is a subclass of RequestException and
+    # must win. The explicit `status_code is None` guard encodes that cause-classification is
+    # only the no-status fallback.
+    if status_code is None:
+        if isinstance(error.__cause__, requests.exceptions.Timeout):
+            raise SearchEngineTimeoutException(error)
+        if isinstance(error.__cause__, (requests.exceptions.RequestException, HTTPException)):
+            raise SearchEngineUnavailableException(error)
+
     raise SearchEngineException(error)
 
 

--- a/utils/search/backends/tests/test_solr555pysolr.py
+++ b/utils/search/backends/tests/test_solr555pysolr.py
@@ -1,6 +1,22 @@
+import http.client
+
+import pysolr
+import pytest
+import requests
 from django.test import TestCase
 
+from utils.search import (
+    SearchEngineBadRequestException,
+    SearchEngineException,
+    SearchEngineInternalErrorException,
+    SearchEngineInvalidValueException,
+    SearchEngineSyntaxErrorException,
+    SearchEngineTimeoutException,
+    SearchEngineUnavailableException,
+    SearchEngineUndefinedFieldException,
+)
 from utils.search.backends import solr555pysolr
+from utils.search.backends.solr555pysolr import _raise_search_engine_exception
 
 
 class Solr555PySolrTest(TestCase):
@@ -20,3 +36,110 @@ class Solr555PySolrTest(TestCase):
         filter_query = "username:alastairp -license:(a OR b)"
         updated = solr555pysolr.Solr555PySolrSearchEngine().search_filter_make_intersection(filter_query)
         self.assertEqual(updated, "+username:alastairp -license:(a OR b)")
+
+
+def _solr_error(message, cause=None):
+    """Build a pysolr.SolrError the way pysolr raises it: a message string, optionally
+    chained from an underlying exception (as `raise SolrError(...) from err` would set)."""
+    error = pysolr.SolrError(message)
+    error.__cause__ = cause
+    return error
+
+
+class TestRaiseSearchEngineException:
+    """_raise_search_engine_exception classifies pysolr's opaque SolrError into a typed
+    exception, so each error family becomes a distinct Sentry issue."""
+
+    def test_client_timeout_from_chained_cause(self):
+        # pysolr chains the original requests timeout via `raise SolrError(...) from err`
+        error = _solr_error("Connection to server timed out", cause=requests.exceptions.ReadTimeout())
+        with pytest.raises(SearchEngineTimeoutException):
+            _raise_search_engine_exception(error)
+
+    def test_solr_side_timeout_is_not_a_timeout_exception(self):
+        # A Solr-internal timeout arrives as an HTTP response with no chained cause. We
+        # deliberately no longer string-match "timed out": it surfaces as a generic 5xx.
+        error = _solr_error("Solr responded with an error (HTTP 500): [Reason: search timed out]")
+        with pytest.raises(SearchEngineInternalErrorException):
+            _raise_search_engine_exception(error)
+
+    def test_undefined_field(self):
+        error = _solr_error("Solr responded with an error (HTTP 400): [Reason: undefined field foobar]")
+        with pytest.raises(SearchEngineUndefinedFieldException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineUndefinedFieldException
+
+    def test_syntax_error_cannot_parse(self):
+        error = _solr_error("Solr responded with an error (HTTP 400): [Reason: Cannot parse 'foo:': ...]")
+        with pytest.raises(SearchEngineSyntaxErrorException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineSyntaxErrorException
+
+    def test_syntax_error_named_syntaxerror(self):
+        error = _solr_error(
+            "Solr responded with an error (HTTP 400): [Reason: org.apache.solr.search.SyntaxError: ...]"
+        )
+        with pytest.raises(SearchEngineSyntaxErrorException):
+            _raise_search_engine_exception(error)
+
+    def test_invalid_value(self):
+        error = _solr_error(
+            "Solr responded with an error (HTTP 400): [Reason: Invalid Number: 5,052 for field duration]"
+        )
+        with pytest.raises(SearchEngineInvalidValueException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineInvalidValueException
+
+    def test_unclassified_4xx_is_bad_request(self):
+        error = _solr_error("Solr responded with an error (HTTP 400): [Reason: something we don't recognise]")
+        with pytest.raises(SearchEngineBadRequestException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineBadRequestException
+
+    def test_unclassified_5xx_is_internal_error(self):
+        error = _solr_error("Solr responded with an error (HTTP 503): [Reason: Parent query must not match any docs]")
+        with pytest.raises(SearchEngineInternalErrorException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineInternalErrorException
+
+    def test_connection_error_is_unavailable(self):
+        # No HTTP status (Solr never answered); pysolr chains the connection failure.
+        error = _solr_error(
+            "Failed to connect to server at 'http://solr:8983/...'",
+            cause=requests.exceptions.ConnectionError(),
+        )
+        with pytest.raises(SearchEngineUnavailableException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineUnavailableException
+
+    def test_httpexception_is_unavailable(self):
+        # pysolr also chains http.client.HTTPException for broken HTTP responses.
+        error = _solr_error("Broken response from server", cause=http.client.HTTPException())
+        with pytest.raises(SearchEngineUnavailableException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineUnavailableException
+
+    def test_invalid_value_wrapped_in_cannot_parse(self):
+        # Solr prepends "Cannot parse '…':" to the specific invalid-number reason; the specific
+        # family must win over the generic "cannot parse" (syntax) branch.
+        error = _solr_error(
+            "Solr responded with an error (HTTP 400): [Reason: Cannot parse 'duration:[5,052 TO *]': "
+            "Invalid Number: 5,052]"
+        )
+        with pytest.raises(SearchEngineInvalidValueException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineInvalidValueException
+
+    def test_undefined_field_wrapped_in_cannot_parse(self):
+        error = _solr_error(
+            "Solr responded with an error (HTTP 400): [Reason: Cannot parse 'foobar:x': undefined field foobar]"
+        )
+        with pytest.raises(SearchEngineUndefinedFieldException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineUndefinedFieldException
+
+    def test_unparseable_message_falls_back_to_base(self):
+        error = _solr_error("something went wrong with no HTTP code")
+        with pytest.raises(SearchEngineException) as excinfo:
+            _raise_search_engine_exception(error)
+        assert excinfo.type is SearchEngineException

--- a/uv.lock
+++ b/uv.lock
@@ -803,7 +803,7 @@ requires-dist = [
     { name = "pyjwt", specifier = "==2.6.0" },
     { name = "pyparsing", specifier = "==2.4.7" },
     { name = "pysndfile", specifier = "~=1.5.3" },
-    { name = "pysolr", specifier = "==3.10.0" },
+    { name = "pysolr", git = "https://github.com/django-haystack/pysolr.git?rev=6b8b1f973fbb00fd01ca520440d27cda6abcce55" },
     { name = "pytest", specifier = "~=8.0.2" },
     { name = "pytest-django", specifier = "~=4.8.0" },
     { name = "python-louvain", specifier = "==0.16" },
@@ -1389,13 +1389,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/da/d7/a7520f9bcc0b8b9d1
 
 [[package]]
 name = "pysolr"
-version = "3.10.0"
-source = { registry = "https://pypi.org/simple" }
+version = "3.11.0"
+source = { git = "https://github.com/django-haystack/pysolr.git?rev=6b8b1f973fbb00fd01ca520440d27cda6abcce55#6b8b1f973fbb00fd01ca520440d27cda6abcce55" }
 dependencies = [
     { name = "requests" },
-    { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/f5/59f3375b12172651c02615ed54b9ca8e5ca7cbf6d89a8506a5daec4ed813/pysolr-3.10.0.tar.gz", hash = "sha256:127b4a2dd169234acb1586643a6cd1e3e94b917921e69bf569d7b2a2aa0ef409", size = 59110, upload-time = "2024-09-18T22:49:01.395Z" }
 
 [[package]]
 name = "pytest"
@@ -1555,15 +1553,6 @@ wheels = [
 [package.optional-dependencies]
 django = [
     { name = "django" },
-]
-
-[[package]]
-name = "setuptools"
-version = "80.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description**
Previously all errors from solr turned into a single exception. this meant that any error was grouped into the same issue in sentry, even if the causes were different. Split each type of error into a separate exception so that we can track different classes of errors.
Upgrade pysolr to allow us to specifically identify a timeout based on causing exception rather than inspecting the string of the exception text.

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
