### PR TITLE
Optimise PackManager.bulk_query_id using SQL aggregation 

### DIFF
--- a/sounds/models.py
+++ b/sounds/models.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import datetime
 import glob
+import itertools
 import json
 import logging
 import math
@@ -41,8 +42,20 @@ from django.contrib.postgres.fields import ArrayField
 from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
-from django.db.models import Avg, Count, Exists, F, OuterRef, Prefetch, Q, Sum
-from django.db.models.functions import Greatest, JSONObject
+from django.db.models import (
+    Avg,
+    Count,
+    Exists,
+    F,
+    IntegerField,
+    JSONField,
+    OuterRef,
+    Q,
+    Subquery,
+    Sum,
+    Window,
+)
+from django.db.models.functions import Coalesce, Greatest, JSONObject, RowNumber
 from django.db.models.signals import post_delete, post_save, pre_delete
 from django.dispatch import receiver
 from django.template.loader import render_to_string
@@ -2020,87 +2033,178 @@ post_delete.connect(post_delete_sound, sender=Sound)
 
 
 class PackManager(models.Manager):
-    def bulk_query_id(self, pack_ids, sound_ids_for_pack_id=dict(), exclude_deleted=True):
+    def bulk_query_id(self, pack_ids, sound_ids_for_pack_id=None, exclude_deleted=True):
         """
-        Returns a list of Pack with some added data properties that are used in display_pack. In this way,
-        a single call to bulk_query_id can be used to retrieve information from all needed packs at once and
-        with a 5 total queries instead of several queries per pack.
-        Note that this method does not return the results sorted as in pack_ids, to do that you should use
-        the ordered_ids method below.
+        Returns a list of Pack with some added data properties used by display_pack:
+        ``selected_sounds_data``, ``num_sounds_unpublished_precomputed``,
+        ``licenses_data_precomputed``, ``pack_tags``, ``user_profile_locations``,
+        ``has_geotags_precomputed``, ``num_ratings_precomputed``,
+        ``avg_rating_precomputed``.
+
+        Aggregates are pushed into SQL via ``Subquery`` / ``ArraySubquery`` /
+        ``Window`` instead of prefetching every sound and iterating in Python.
+        Bounded result sets: top-3 sounds × len(pack_ids), top-10 tags × len(pack_ids),
+        one row per pack for licenses/ratings/geotag/total. Issues up to 4 queries,
+        the last being the optional ``SoundSimilarityVector`` lookup.
+
+        ``sound_ids_for_pack_id`` is all-or-nothing: when supplied, every pack in
+        ``pack_ids`` must have an entry and ``selected_sounds_data`` is restricted to
+        those IDs; otherwise the top 3 sounds are used. Either way the selected sounds
+        are ordered newest-first (``-created, -id``).
+
+        Note: results are not returned sorted as in ``pack_ids`` — use ``ordered_ids``.
         """
+        # Same contract as SoundManager.bulk_query_id: a single id or a list of ids.
+        # Wrap any scalar whole — in particular a str must not be iterated into characters.
         if not isinstance(pack_ids, list):
             pack_ids = [pack_ids]
-        packs = (
-            Pack.objects.prefetch_related(
-                Prefetch("sounds", queryset=Sound.public.select_related("license", "geotag").order_by("-created")),
-                Prefetch("sounds__tags"),
-                Prefetch("sounds__license"),
-            )
+        if not pack_ids:
+            return []
+        sound_ids_for_pack_id = sound_ids_for_pack_id or {}
+        if sound_ids_for_pack_id:
+            missing = set(pack_ids) - set(sound_ids_for_pack_id.keys())
+            if missing:
+                raise ValueError(f"sound_ids_for_pack_id missing entries for packs: {sorted(missing)}")
+
+        num_sounds_selected_per_pack = 3
+        num_tags_selected_per_pack = 10
+
+        # --- Query 1: Pack queryset with annotated per-pack aggregates ---
+        public_sounds = Sound.public.filter(pack_id=OuterRef("pk"))
+        total_sounds = Sound.objects.filter(pack_id=OuterRef("pk")).values("pack_id").annotate(c=Count("*")).values("c")
+        ratings_agg = (
+            public_sounds.filter(num_ratings__gte=settings.MIN_NUMBER_RATINGS)
+            .values("pack_id")
+            .annotate(n=Count("*"), avg=Avg("avg_rating"))
+            .values(data=JSONObject(n="n", avg="avg"))
+        )
+        license_pairs_subq = (
+            public_sounds.values("license_id")
+            .annotate(license_name=F("license__name"))
+            .order_by("license_id")
+            .distinct()
+            .values(pair=JSONObject(id="license_id", name="license_name"))
+        )
+        packs_qs = (
+            Pack.objects.filter(id__in=pack_ids)
             .select_related("user", "user__profile")
-            .annotate(total_sounds_count=Count("sounds"))
-            .filter(id__in=pack_ids)
+            .annotate(
+                total_sounds_count=Coalesce(Subquery(total_sounds, output_field=IntegerField()), 0),
+                ratings_data=Subquery(ratings_agg, output_field=JSONField()),
+                has_geotag=Exists(public_sounds.exclude(geotag=None)),
+                license_pairs=ArraySubquery(license_pairs_subq),
+            )
         )
         if exclude_deleted:
-            packs = packs.exclude(is_deleted=True)
-        num_sounds_selected_per_pack = 3
-        for p in packs:
-            licenses = []
-            selected_sounds_data = []
-            tags = []
-            has_geotags = False
-            sound_ids_pre_selected = sound_ids_for_pack_id.get(p.id, None)
-            ratings = []
-            for s in p.sounds.all():
-                tags += [ti.name for ti in s.tags.all()]
-                licenses.append((s.license.name, s.license.id))
-                if s.num_ratings >= settings.MIN_NUMBER_RATINGS:
-                    ratings.append(s.avg_rating)
-                if not has_geotags and hasattr(s, "geotag"):
-                    has_geotags = True
-                should_add_sound_to_selected_sounds = False
-                if sound_ids_pre_selected is None:
-                    if len(selected_sounds_data) < num_sounds_selected_per_pack:
-                        should_add_sound_to_selected_sounds = True
-                else:
-                    if s.id in sound_ids_pre_selected:
-                        should_add_sound_to_selected_sounds = True
-                if should_add_sound_to_selected_sounds:
-                    selected_sounds_data.append(
-                        {
-                            "id": s.id,
-                            "username": p.user.username,  # Packs have same username as sounds inside pack
-                            "ready_for_similarity": None,  # If using search engine-based similarity, this needs to be retrieved later (see below)
-                            "duration": s.duration,
-                            "preview_mp3": s.locations("preview.LQ.mp3.url"),
-                            "preview_ogg": s.locations("preview.LQ.ogg.url"),
-                            "wave": s.locations("display.wave.L.url"),
-                            "spectral": s.locations("display.spectral.L.url"),
-                            "num_ratings": s.num_ratings,
-                            "avg_rating": s.avg_rating,
-                        }
-                    )
-            p.num_sounds_unpublished_precomputed = p.total_sounds_count - p.num_sounds
-            p.licenses_data_precomputed = ([lid for _, lid in licenses], [lname for lname, _ in licenses])
-            p.pack_tags = [
-                {"name": tag, "count": count, "browse_url": p.browse_pack_tag_url(tag)}
-                for tag, count in Counter(tags).most_common(10)
-            ]  # See pack.get_pack_tags_bw
-            p.selected_sounds_data = selected_sounds_data
-            p.user_profile_locations = p.user.profile.locations()
-            p.has_geotags_precomputed = has_geotags
-            p.num_ratings_precomputed = len(ratings)
-            p.avg_rating_precomputed = sum(ratings) / len(ratings) if len(ratings) else 0.0
+            packs_qs = packs_qs.exclude(is_deleted=True)
+        packs = list(packs_qs)
+        if not packs:
+            return []
+        # Queries 2-4 only need the packs that survived the id/is_deleted filtering above.
+        pack_ids = [p.id for p in packs]
 
-        # To avoid making an individual query for each selected sound, we get the similarity state of all selected sounds per pack in one single extra query
-        selected_sounds_ids = []
+        # --- Query 2: top-N public sounds per pack (Window) or in_bulk fetch ---
+        if sound_ids_for_pack_id:
+            all_preselected_ids = [sid for pid in pack_ids for sid in sound_ids_for_pack_id[pid]]
+            fetched = Sound.public.filter(pack_id__in=pack_ids).in_bulk(all_preselected_ids)
+            # Render newest-first (matching the top-N path and the pre-rewrite behaviour),
+            # not in the supplied order.
+            selected_by_pack = {
+                pid: sorted(
+                    (
+                        fetched[sid]
+                        for sid in sound_ids_for_pack_id[pid]
+                        if sid in fetched and fetched[sid].pack_id == pid
+                    ),
+                    key=lambda s: (s.created, s.id),
+                    reverse=True,
+                )
+                for pid in pack_ids
+            }
+        else:
+            top_sounds = list(
+                Sound.public.annotate(
+                    rn=Window(
+                        expression=RowNumber(),
+                        partition_by=[F("pack_id")],
+                        order_by=[F("created").desc(), F("id").desc()],
+                    )
+                )
+                .filter(pack_id__in=pack_ids)
+                .filter(rn__lte=num_sounds_selected_per_pack)
+                .order_by("pack_id", "-created", "-id")
+            )
+            selected_by_pack = {
+                pid: list(group) for pid, group in itertools.groupby(top_sounds, key=lambda s: s.pack_id)
+            }
+
+        # --- Query 3: top-10 tags per pack ---
+        tag_rows = list(
+            SoundTag.objects.filter(sound__pack_id__in=pack_ids, sound__in=Sound.public.all())
+            .values("sound__pack_id", "tag__name")
+            .annotate(cnt=Count("*"))
+            .annotate(
+                rn=Window(
+                    expression=RowNumber(),
+                    partition_by=[F("sound__pack_id")],
+                    order_by=[F("cnt").desc(), F("tag__name").asc()],
+                )
+            )
+            .filter(rn__lte=num_tags_selected_per_pack)
+            .order_by("sound__pack_id", "-cnt", "tag__name")
+        )
+        tags_by_pack = {
+            pid: list(group) for pid, group in itertools.groupby(tag_rows, key=lambda r: r["sound__pack_id"])
+        }
+
+        # --- Query 4: SoundSimilarityVector check for selected sounds ---
+        selected_sound_ids = [s.id for sounds in selected_by_pack.values() for s in sounds]
+        ready_ids = set(
+            SoundSimilarityVector.objects.filter(sound_id__in=selected_sound_ids).values_list("sound_id", flat=True)
+        )
+
+        # --- Assembly: attach precomputed attrs to each Pack ---
         for p in packs:
-            selected_sounds_ids += [s["id"] for s in p.selected_sounds_data]
-        sound_ids_ready_for_similarity = SoundSimilarityVector.objects.filter(
-            sound_id__in=selected_sounds_ids
-        ).values_list("sound_id", flat=True)
-        for p in packs:
-            for s in p.selected_sounds_data:
-                s["ready_for_similarity"] = s["id"] in sound_ids_ready_for_similarity
+            p.num_sounds_unpublished_precomputed = p.total_sounds_count - p.num_sounds
+
+            pairs = p.license_pairs or []
+            license_ids = [pair["id"] for pair in pairs]
+            license_names = [pair["name"] for pair in pairs]
+            p.licenses_data_precomputed = (license_ids, license_names)
+
+            p.pack_tags = [
+                {
+                    "name": t["tag__name"],
+                    "count": t["cnt"],
+                    "browse_url": p.browse_pack_tag_url(t["tag__name"]),
+                }
+                for t in tags_by_pack.get(p.id, [])
+            ]
+
+            p.has_geotags_precomputed = bool(p.has_geotag)
+
+            ratings = p.ratings_data or {"n": 0, "avg": 0.0}
+            p.num_ratings_precomputed = ratings["n"] or 0
+            p.avg_rating_precomputed = float(ratings["avg"] or 0.0)
+
+            p.user_profile_locations = p.user.profile.locations()
+
+            top_for_pack = selected_by_pack.get(p.id, [])
+            p.selected_sounds_data = [
+                {
+                    "id": s.id,
+                    "username": p.user.username,  # Packs have same username as sounds inside pack
+                    "ready_for_similarity": s.id in ready_ids,
+                    "duration": s.duration,
+                    "preview_mp3": s.locations("preview.LQ.mp3.url"),
+                    "preview_ogg": s.locations("preview.LQ.ogg.url"),
+                    "wave": s.locations("display.wave.L.url"),
+                    "spectral": s.locations("display.spectral.L.url"),
+                    "num_ratings": s.num_ratings,
+                    "avg_rating": s.avg_rating,
+                }
+                for s in top_for_pack
+            ]
 
         return packs
 

--- a/sounds/models.py
+++ b/sounds/models.py
@@ -41,7 +41,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
-from django.db.models import Avg, Exists, F, OuterRef, Prefetch, Q, Sum
+from django.db.models import Avg, Count, Exists, F, OuterRef, Prefetch, Q, Sum
 from django.db.models.functions import Greatest, JSONObject
 from django.db.models.signals import post_delete, post_save, pre_delete
 from django.dispatch import receiver
@@ -2037,6 +2037,7 @@ class PackManager(models.Manager):
                 Prefetch("sounds__license"),
             )
             .select_related("user", "user__profile")
+            .annotate(total_sounds_count=Count("sounds"))
             .filter(id__in=pack_ids)
         )
         if exclude_deleted:
@@ -2078,7 +2079,7 @@ class PackManager(models.Manager):
                             "avg_rating": s.avg_rating,
                         }
                     )
-            p.num_sounds_unpublished_precomputed = p.sounds.count() - p.num_sounds
+            p.num_sounds_unpublished_precomputed = p.total_sounds_count - p.num_sounds
             p.licenses_data_precomputed = ([lid for _, lid in licenses], [lname for lname, _ in licenses])
             p.pack_tags = [
                 {"name": tag, "count": count, "browse_url": p.browse_pack_tag_url(tag)}

--- a/sounds/tests/test_manager.py
+++ b/sounds/tests/test_manager.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from geotags.models import GeoTag
-from sounds.models import Pack, Sound
+from sounds.models import License, Pack, Sound
 from tickets.models import Ticket
 from utils.test_helpers import (
     create_consolidated_audio_descriptors_and_similarity_vectors_for_sound,
@@ -226,3 +226,27 @@ class PackManagerQueryMethods(TestCase):
             for i, pack in enumerate(Pack.objects.ordered_ids(pack_ids=pack_ids_with_duplicates)):
                 self.assertEqual(type(pack), Pack)
                 self.assertEqual(pack_ids_with_duplicates[i], pack.id)
+
+    def test_bulk_query_id_num_sounds_unpublished(self):
+        # some published and some unpublished sounds result in num_sounds_unpublished_precomputed
+        # being set properly
+        _, packs, _ = create_user_and_sounds(
+            num_sounds=2, num_packs=1, user=self.user, count_offset=100, processing_state="OK", moderation_state="OK"
+        )
+        pack = packs[0]
+        Sound.objects.create(
+            user=self.user,
+            original_filename="unpublished sound",
+            license=License.objects.last(),
+            bst_category="ss-n",
+            description="",
+            pack=pack,
+            md5="fakemd5_unpublished",
+            type="wav",
+            processing_state="PE",
+            moderation_state="PE",
+        )
+        pack.process()
+        self.assertEqual(pack.num_sounds, 2)
+        p = Pack.objects.bulk_query_id([pack.id])[0]
+        self.assertEqual(p.num_sounds_unpublished_precomputed, 1)

--- a/sounds/tests/test_manager.py
+++ b/sounds/tests/test_manager.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from geotags.models import GeoTag
-from sounds.models import License, Pack, Sound
+from sounds.models import License, Pack, Sound, SoundSimilarityVector
 from tickets.models import Ticket
 from utils.test_helpers import (
     create_consolidated_audio_descriptors_and_similarity_vectors_for_sound,
@@ -219,9 +219,52 @@ class PackManagerQueryMethods(TestCase):
         self.pack_ids = [p.id for p in packs]
         self.user = user
 
+    @staticmethod
+    def _make_sound(
+        user,
+        pack,
+        original_filename,
+        *,
+        license=None,
+        num_ratings=0,
+        avg_rating=0.0,
+        tags=None,
+        processing_state="OK",
+        moderation_state="OK",
+    ):
+        """Create a Sound in a pack (public by default) with tweakable fields."""
+        sound = Sound.objects.create(
+            user=user,
+            original_filename=original_filename,
+            license=license or License.objects.last(),
+            bst_category="ss-n",
+            description="",
+            pack=pack,
+            md5=f"fake{original_filename}",
+            type="wav",
+            num_ratings=num_ratings,
+            avg_rating=avg_rating,
+            processing_state=processing_state,
+            moderation_state=moderation_state,
+        )
+        if tags is not None:
+            sound.set_tags(tags)
+        return sound
+
     def test_ordered_ids(self):
-        # Test that ordered_ids returns a sorted list of Pack objects with the requested IDs, including duplicates
-        with self.assertNumQueries(2):
+        # Test that ordered_ids returns a sorted list of Pack objects with the requested IDs, including duplicates.
+        # After the bulk_query_id rewrite the query count is 3:
+        #   1. Pack queryset with annotated subqueries (totals/ratings/has_geotag/license_pairs)
+        #   2. Window query for top-N sounds per pack
+        #   3. SoundTag aggregate for top-10 tags per pack
+        # The SoundSimilarityVector check (Query 4 in the implementation) is skipped because
+        # Django optimizes filter(...__in=[]) to no SQL when no sounds were selected.
+        # This holds only while none of the fixture sounds are public: the public-filtered
+        # Window/Tag queries return zero rows and no sound is selected. Assert that
+        # precondition explicitly so a fixture change fails here rather than as an opaque
+        # query-count mismatch.
+        self.assertEqual(Sound.public.filter(pack_id__in=self.pack_ids).count(), 0)
+        with self.assertNumQueries(3):
             pack_ids_with_duplicates = self.pack_ids + self.pack_ids
             for i, pack in enumerate(Pack.objects.ordered_ids(pack_ids=pack_ids_with_duplicates)):
                 self.assertEqual(type(pack), Pack)
@@ -234,19 +277,225 @@ class PackManagerQueryMethods(TestCase):
             num_sounds=2, num_packs=1, user=self.user, count_offset=100, processing_state="OK", moderation_state="OK"
         )
         pack = packs[0]
-        Sound.objects.create(
-            user=self.user,
-            original_filename="unpublished sound",
-            license=License.objects.last(),
-            bst_category="ss-n",
-            description="",
-            pack=pack,
-            md5="fakemd5_unpublished",
-            type="wav",
-            processing_state="PE",
-            moderation_state="PE",
-        )
+        self._make_sound(self.user, pack, "unpublished sound", processing_state="PE", moderation_state="PE")
         pack.process()
         self.assertEqual(pack.num_sounds, 2)
         p = Pack.objects.bulk_query_id([pack.id])[0]
         self.assertEqual(p.num_sounds_unpublished_precomputed, 1)
+
+    def test_bulk_query_id_synthetic_parity(self):
+        # Build a pack with: 5 public sounds (varying licenses + tags + ratings + one geotag),
+        # plus 1 unpublished sound. Verify every precomputed attr matches expectations.
+        pack = Pack.objects.create(user=self.user, name="parity pack")
+        licenses = list(License.objects.all()[:2])
+        self.assertGreaterEqual(len(licenses), 2, "need at least 2 licenses fixture-loaded")
+
+        public_sounds = []
+        for i in range(5):
+            s = self._make_sound(
+                self.user,
+                pack,
+                f"parity-public-{i}",
+                license=licenses[i % 2],
+                num_ratings=(settings.MIN_NUMBER_RATINGS + i) if i < 3 else 0,
+                avg_rating=(6.0 + i) if i < 3 else 0.0,
+                tags=["alpha", "beta"] if i < 2 else ["alpha"],
+            )
+            public_sounds.append(s)
+
+        # 1 unpublished sound
+        self._make_sound(
+            self.user, pack, "parity-unpublished", license=licenses[0], processing_state="PE", moderation_state="PE"
+        )
+        # Geotag on one public sound
+        GeoTag.objects.create(sound=public_sounds[0], lat=1.0, lon=1.0, zoom=1)
+
+        # Pack.num_sounds tracks public count; set explicitly (Pack.process() would normally maintain this).
+        pack.num_sounds = 5
+        pack.save()
+
+        result = Pack.objects.bulk_query_id([pack.id])
+        self.assertEqual(len(result), 1)
+        p = result[0]
+
+        # Three newest public sounds in -created order (id is the tiebreaker).
+        expected_top_ids = [s.id for s in sorted(public_sounds, key=lambda s: (s.created, s.id), reverse=True)[:3]]
+        self.assertEqual([d["id"] for d in p.selected_sounds_data], expected_top_ids)
+
+        # Each selected sound dict has all expected keys.
+        expected_keys = {
+            "id",
+            "username",
+            "ready_for_similarity",
+            "duration",
+            "preview_mp3",
+            "preview_ogg",
+            "wave",
+            "spectral",
+            "num_ratings",
+            "avg_rating",
+        }
+        for d in p.selected_sounds_data:
+            self.assertEqual(set(d.keys()), expected_keys)
+            self.assertIsInstance(d["ready_for_similarity"], bool)
+            self.assertFalse(d["ready_for_similarity"])  # no SoundSimilarityVector rows created
+
+        # ready_for_similarity flips to True for the sound that has a vector and stays False
+        # for the others. public_sounds[4] is the newest sound, so it is always in the top-3.
+        SoundSimilarityVector.objects.create(
+            sound=public_sounds[4],
+            similarity_space_name=settings.SIMILARITY_SPACES_NAMES[0],
+            vector=[0.0] * settings.SIMILARITY_SPACES[settings.SIMILARITY_SPACES_NAMES[0]]["vector_size"],
+        )
+        result2 = Pack.objects.bulk_query_id([pack.id])
+        ready_flags = {d["id"]: d["ready_for_similarity"] for d in result2[0].selected_sounds_data}
+        self.assertTrue(ready_flags[public_sounds[4].id])
+        self.assertFalse(ready_flags[public_sounds[3].id])
+        self.assertFalse(ready_flags[public_sounds[2].id])
+
+        # num_sounds_unpublished_precomputed = total - public.
+        self.assertEqual(p.num_sounds_unpublished_precomputed, 1)
+
+        # licenses_data_precomputed: paired by index, length matches distinct license count.
+        license_ids, license_names = p.licenses_data_precomputed
+        self.assertEqual(len(license_ids), len(license_names))
+        self.assertEqual(set(license_ids), {lic.id for lic in licenses})
+        for lid, lname in zip(license_ids, license_names):
+            self.assertEqual(License.objects.get(id=lid).name, lname)
+
+        # pack_tags: ≤10 entries, sorted by count desc then name asc.
+        self.assertLessEqual(len(p.pack_tags), 10)
+        counts = [t["count"] for t in p.pack_tags]
+        self.assertEqual(counts, sorted(counts, reverse=True))
+        # alpha appears in all 5 public sounds, beta in 2 (i<2). Order: alpha then beta.
+        self.assertEqual(p.pack_tags[0]["name"], "alpha")
+        self.assertEqual(p.pack_tags[0]["count"], 5)
+        self.assertEqual(p.pack_tags[1]["name"], "beta")
+        self.assertEqual(p.pack_tags[1]["count"], 2)
+
+        self.assertTrue(p.has_geotags_precomputed)
+
+        # ratings: 3 sounds at/above threshold (i=0,1,2), avg of (6.0, 7.0, 8.0) = 7.0.
+        self.assertEqual(p.num_ratings_precomputed, 3)
+        self.assertAlmostEqual(p.avg_rating_precomputed, 7.0)
+
+    def test_bulk_query_id_sound_ids_for_pack_id_happy_path(self):
+        pack = Pack.objects.create(user=self.user, name="preselect happy")
+        sounds = [self._make_sound(self.user, pack, f"pre-{i}") for i in range(4)]
+        # sounds are created oldest-first, so sounds[3] is newest. The supplied order is
+        # deliberately not newest-first: selected_sounds_data must still come out newest-first.
+        preselected = [sounds[0].id, sounds[2].id]
+
+        result = Pack.objects.bulk_query_id([pack.id], sound_ids_for_pack_id={pack.id: preselected})
+        self.assertEqual([d["id"] for d in result[0].selected_sounds_data], [sounds[2].id, sounds[0].id])
+
+    def test_bulk_query_id_sound_ids_for_pack_id_missing_raises(self):
+        pack_a = Pack.objects.create(user=self.user, name="A")
+        pack_b = Pack.objects.create(user=self.user, name="B")
+        sound = self._make_sound(self.user, pack_a, "preselect-a")
+        # Missing entry for pack_b → ValueError.
+        with self.assertRaises(ValueError):
+            Pack.objects.bulk_query_id(
+                [pack_a.id, pack_b.id],
+                sound_ids_for_pack_id={pack_a.id: [sound.id]},
+            )
+
+    def test_bulk_query_id_sound_ids_cross_pack_dropped(self):
+        pack_a = Pack.objects.create(user=self.user, name="X")
+        pack_b = Pack.objects.create(user=self.user, name="Y")
+        sound_b = self._make_sound(self.user, pack_b, "y-sound")
+
+        result = Pack.objects.bulk_query_id(
+            [pack_a.id, pack_b.id],
+            # Both packs list sound_b's id. Only pack_b should keep it; pack_a drops it.
+            sound_ids_for_pack_id={pack_a.id: [sound_b.id], pack_b.id: [sound_b.id]},
+        )
+        by_id = {p.id: p for p in result}
+        self.assertEqual(by_id[pack_a.id].selected_sounds_data, [])
+        self.assertEqual([d["id"] for d in by_id[pack_b.id].selected_sounds_data], [sound_b.id])
+
+    def test_bulk_query_id_empty_ratings_subquery(self):
+        # All public sounds below MIN_NUMBER_RATINGS → ratings_data subquery returns no rows.
+        pack = Pack.objects.create(user=self.user, name="no-rated")
+        for i in range(2):
+            self._make_sound(
+                self.user, pack, f"unrated-{i}", num_ratings=max(0, settings.MIN_NUMBER_RATINGS - 1), avg_rating=5.0
+            )
+        p = Pack.objects.bulk_query_id([pack.id])[0]
+        self.assertEqual(p.num_ratings_precomputed, 0)
+        self.assertEqual(p.avg_rating_precomputed, 0.0)
+
+    def test_bulk_query_id_window_tiebreaker(self):
+        # Two sounds with identical `created` → tiebreak by descending id.
+        pack = Pack.objects.create(user=self.user, name="ties")
+        s_old = self._make_sound(self.user, pack, "old")
+        s_mid_a = self._make_sound(self.user, pack, "mid-a")
+        s_mid_b = self._make_sound(self.user, pack, "mid-b")
+        s_new = self._make_sound(self.user, pack, "new")
+        # Make mid-a and mid-b share the same `created` value.
+        Sound.objects.filter(id=s_mid_a.id).update(created=s_mid_b.created)
+        s_mid_a.refresh_from_db()
+
+        p = Pack.objects.bulk_query_id([pack.id])[0]
+        top_ids = [d["id"] for d in p.selected_sounds_data]
+        # `created` ranking: s_new (latest) > {s_mid_a, s_mid_b} (tie) > s_old.
+        # Tiebreaker -id puts higher id first among ties.
+        higher_mid, lower_mid = sorted([s_mid_a.id, s_mid_b.id], reverse=True)
+        self.assertEqual(top_ids, [s_new.id, higher_mid, lower_mid])
+
+    def test_bulk_query_id_has_geotag_only_unpublished(self):
+        # A pack whose only geotagged sounds are unpublished must report has_geotags_precomputed=False.
+        pack = Pack.objects.create(user=self.user, name="geotag-unpublished-only")
+        unpub = self._make_sound(self.user, pack, "unpub-geo", processing_state="PE", moderation_state="PE")
+        GeoTag.objects.create(sound=unpub, lat=1.0, lon=1.0, zoom=1)
+        # And one public sound without a geotag, so the pack has at least one public row.
+        self._make_sound(self.user, pack, "pub-no-geo")
+
+        p = Pack.objects.bulk_query_id([pack.id])[0]
+        self.assertFalse(p.has_geotags_precomputed)
+
+    def test_bulk_query_id_pack_tags_bounded_to_top_10(self):
+        # The tag query limits to the 10 most-used tags per pack in SQL; ties broken by name.
+        pack = Pack.objects.create(user=self.user, name="tag-bound")
+        tag_names = [f"tag{i:02d}" for i in range(12)]
+        self._make_sound(self.user, pack, "tags-a", tags=tag_names)
+        self._make_sound(self.user, pack, "tags-b", tags=["tag11"])
+
+        p = Pack.objects.bulk_query_id([pack.id])[0]
+        self.assertEqual(len(p.pack_tags), 10)
+        # tag11 appears on both sounds so it ranks first; the rest tie at 1 and sort by name.
+        self.assertEqual(p.pack_tags[0]["name"], "tag11")
+        self.assertEqual(p.pack_tags[0]["count"], 2)
+        self.assertEqual([t["name"] for t in p.pack_tags[1:]], tag_names[:9])
+
+    def test_bulk_query_id_empty_pack(self):
+        pack = Pack.objects.create(user=self.user, name="empty")
+        p = Pack.objects.bulk_query_id([pack.id])[0]
+        self.assertEqual(p.selected_sounds_data, [])
+        self.assertEqual(p.num_sounds_unpublished_precomputed, 0)
+        self.assertEqual(p.licenses_data_precomputed, ([], []))
+        self.assertEqual(p.pack_tags, [])
+        self.assertFalse(p.has_geotags_precomputed)
+        self.assertEqual(p.num_ratings_precomputed, 0)
+        self.assertEqual(p.avg_rating_precomputed, 0.0)
+
+    def test_bulk_query_id_empty_pack_ids_returns_empty_list(self):
+        # Function-entry early return; must not run any queries.
+        with self.assertNumQueries(0):
+            self.assertEqual(Pack.objects.bulk_query_id([]), [])
+
+    def test_bulk_query_id_accepts_bare_int(self):
+        # search/views.py + sounds/views.py call bulk_query_id(pack_id) with a bare int.
+        pack = Pack.objects.create(user=self.user, name="bare-int")
+        result = Pack.objects.bulk_query_id(pack.id)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, pack.id)
+
+    def test_bulk_query_id_accepts_bare_str(self):
+        # A str id must be wrapped whole like any other scalar, not iterated into
+        # its digit characters (which would silently query the wrong packs).
+        # Explicit multi-digit id: char-splitting a single-digit id would be indistinguishable.
+        pack = Pack.objects.create(id=1234, user=self.user, name="bare-str")
+        result = Pack.objects.bulk_query_id(str(pack.id))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, pack.id)

--- a/templates/sounds/pack.html
+++ b/templates/sounds/pack.html
@@ -82,7 +82,7 @@
                             data-async-section-content-url="{% url 'pack-stats-section' pack.user.username pack.id %}?ajax=1">
                             <img width="12px" height="12px" src="{% static 'bw-frontend/public/bw_indicator.gif' %}">
                         </section>
-                        {% if pack.num_sounds_unpublished %}
+                        {% if request.user == pack.user and pack.num_sounds_unpublished > 0 %}
                             <div class="v-spacing-top-6 text-red">
                                 {% bw_icon "notification" %}This pack has {{ pack.num_sounds_unpublished}} unpublished sounds
                             </div>


### PR DESCRIPTION
**Issue(s)**
https://github.com/MTG/freesound/issues/1387

**Description**
The old implementation prefetched every public sound of every pack
(with license, geotag and tags) and aggregated per-pack data in Python,
so its cost scaled with the total number of sounds in the packs.
Rewrite it to compute the same data in sql.

Runtime for a user with large packs goes down from ~130 ms to ~36 ms

**Deployment steps**:
<!-- Use this section to indicate if there are any actions that should be 
carried out after this PR is merged and deployed. For example, use this 
section to indicate that a "cronjob should be set up to run command X every Y".
If no deployment steps are required you can indicate "None" or remove this section. -->
